### PR TITLE
Migrate box plot SVG summaries to markup writer

### DIFF
--- a/ChartForgeX/Svg/SvgChartRenderer.BoxPlot.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.BoxPlot.cs
@@ -33,14 +33,7 @@ public sealed partial class SvgChartRenderer {
             var color = PointColor(chart, series, index, item);
             var summary = FormatValue(chart, minimum.Y) + "-" + FormatValue(chart, maximum.Y) + ", median " + FormatValue(chart, median.Y);
 
-            sb.AppendLine($"<g data-cfx-role=\"box-plot\" data-cfx-series=\"{index}\" data-cfx-point=\"{item}\" data-cfx-x=\"{F(minimum.X)}\" data-cfx-min=\"{F(minimum.Y)}\" data-cfx-q1=\"{F(q1.Y)}\" data-cfx-median=\"{F(median.Y)}\" data-cfx-q3=\"{F(q3.Y)}\" data-cfx-max=\"{F(maximum.Y)}\" role=\"img\" aria-label=\"{Escape(summary)}\">");
-            sb.AppendLine($"<title>{Escape(summary)}</title>");
-            sb.AppendLine($"<line data-cfx-role=\"box-whisker\" x1=\"{F(x)}\" y1=\"{F(yMax)}\" x2=\"{F(x)}\" y2=\"{F(yMin)}\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.BoxPlotStrokeWidth)}\" stroke-linecap=\"round\" opacity=\"{F(ChartVisualPrimitives.BoxPlotWhiskerOpacity)}\"/>");
-            sb.AppendLine($"<line data-cfx-role=\"box-cap\" x1=\"{F(x - capWidth / 2)}\" y1=\"{F(yMin)}\" x2=\"{F(x + capWidth / 2)}\" y2=\"{F(yMin)}\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.BoxPlotStrokeWidth)}\" stroke-linecap=\"round\"/>");
-            sb.AppendLine($"<line data-cfx-role=\"box-cap\" x1=\"{F(x - capWidth / 2)}\" y1=\"{F(yMax)}\" x2=\"{F(x + capWidth / 2)}\" y2=\"{F(yMax)}\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.BoxPlotStrokeWidth)}\" stroke-linecap=\"round\"/>");
-            sb.AppendLine($"<rect data-cfx-role=\"box-body\" x=\"{F(x - boxWidth / 2)}\" y=\"{F(top)}\" width=\"{F(boxWidth)}\" height=\"{F(height)}\" rx=\"{F(ChartVisualPrimitives.BoxPlotBodyRadius)}\" fill=\"{color.ToCss()}\" opacity=\"{F(ChartVisualPrimitives.BoxPlotBodyFillOpacity)}\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.BoxPlotStrokeWidth)}\"/>");
-            sb.AppendLine($"<line data-cfx-role=\"box-median\" x1=\"{F(x - boxWidth / 2)}\" y1=\"{F(yMedian)}\" x2=\"{F(x + boxWidth / 2)}\" y2=\"{F(yMedian)}\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.BoxPlotMedianStrokeWidth)}\" stroke-linecap=\"round\"/>");
-            sb.AppendLine("</g>");
+            WriteBoxPlotSummary(sb, index, item, minimum.X, minimum.Y, q1.Y, median.Y, q3.Y, maximum.Y, summary, color, x, yMin, yMedian, yMax, top, height, boxWidth, capWidth);
             var label = FormatValue(chart, median.Y);
             if (ShouldDrawDataLabels(chart, series)) {
                 var placement = DataLabelPlacement(chart, series);
@@ -58,5 +51,84 @@ public sealed partial class SvgChartRenderer {
                 }
             }
         }
+    }
+
+    private static void WriteBoxPlotSummary(
+        StringBuilder sb,
+        int seriesIndex,
+        int pointIndex,
+        double valueX,
+        double minimum,
+        double q1,
+        double median,
+        double q3,
+        double maximum,
+        string summary,
+        ChartColor color,
+        double x,
+        double yMin,
+        double yMedian,
+        double yMax,
+        double top,
+        double height,
+        double boxWidth,
+        double capWidth) {
+        var colorCss = color.ToCss();
+        var writer = new SvgMarkupWriter(1024);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "box-plot")
+            .Attribute("data-cfx-series", seriesIndex)
+            .Attribute("data-cfx-point", pointIndex)
+            .Attribute("data-cfx-x", valueX)
+            .Attribute("data-cfx-min", minimum)
+            .Attribute("data-cfx-q1", q1)
+            .Attribute("data-cfx-median", median)
+            .Attribute("data-cfx-q3", q3)
+            .Attribute("data-cfx-max", maximum)
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .EndStartElement()
+            .Line()
+            .StartElement("title")
+            .Text(summary)
+            .EndElement()
+            .Line();
+        WriteBoxPlotLine(writer, "box-whisker", x, yMax, x, yMin, colorCss, ChartVisualPrimitives.BoxPlotStrokeWidth, ChartVisualPrimitives.BoxPlotWhiskerOpacity);
+        WriteBoxPlotLine(writer, "box-cap", x - capWidth / 2, yMin, x + capWidth / 2, yMin, colorCss, ChartVisualPrimitives.BoxPlotStrokeWidth);
+        WriteBoxPlotLine(writer, "box-cap", x - capWidth / 2, yMax, x + capWidth / 2, yMax, colorCss, ChartVisualPrimitives.BoxPlotStrokeWidth);
+        writer
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "box-body")
+            .Attribute("x", x - boxWidth / 2)
+            .Attribute("y", top)
+            .Attribute("width", boxWidth)
+            .Attribute("height", height)
+            .Attribute("rx", ChartVisualPrimitives.BoxPlotBodyRadius)
+            .Attribute("fill", colorCss)
+            .Attribute("opacity", ChartVisualPrimitives.BoxPlotBodyFillOpacity)
+            .Attribute("stroke", colorCss)
+            .Attribute("stroke-width", ChartVisualPrimitives.BoxPlotStrokeWidth)
+            .EndEmptyElement()
+            .Line();
+        WriteBoxPlotLine(writer, "box-median", x - boxWidth / 2, yMedian, x + boxWidth / 2, yMedian, colorCss, ChartVisualPrimitives.BoxPlotMedianStrokeWidth);
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteBoxPlotLine(SvgMarkupWriter writer, string role, double x1, double y1, double x2, double y2, string color, double strokeWidth, double? opacity = null) {
+        writer
+            .StartElement("line")
+            .Attribute("data-cfx-role", role)
+            .Attribute("x1", x1)
+            .Attribute("y1", y1)
+            .Attribute("x2", x2)
+            .Attribute("y2", y2)
+            .Attribute("stroke", color)
+            .Attribute("stroke-width", strokeWidth)
+            .Attribute("stroke-linecap", "round")
+            .OptionalAttribute("opacity", opacity)
+            .EndEmptyElement()
+            .Line();
     }
 }


### PR DESCRIPTION
## Summary
- migrate BoxPlot SVG summary groups and primitive shapes to SvgMarkupWriter
- preserve box plot metadata, title, accessibility summary, and existing label-helper behavior
- keep the change scoped to the SVG renderer so follow-up helper migrations stay reviewable

## Validation
- dotnet build ChartForgeX.sln -c Debug -m:1 -nr:false
- dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Debug --no-build
- dotnet run --project ChartForgeX.Examples\ChartForgeX.Examples.csproj -c Release
- .\Build.ps1 -Configuration Release
- git diff --check