### PR TITLE
Add transparent overlay chart preset

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/PngOutputScaleTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/PngOutputScaleTests.cs
@@ -45,6 +45,26 @@ internal static partial class SmokeTests {
         }
     }
 
+    private static void OverlayPresetEmitsTransparentChromeFreePng() {
+        var chart = Chart.Create()
+            .WithSize(220, 90)
+            .WithOverlay()
+            .AddSmoothArea("CPU", Points(28, 34, 31, 45, 72, 66), ChartColor.FromRgb(20, 184, 166));
+
+        Assert(chart.Options.TransparentBackground, "Overlay charts should keep the PNG canvas transparent.");
+        Assert(!chart.Options.ShowCard && !chart.Options.ShowPlotBackground, "Overlay charts should not render report card or plot panel surfaces.");
+        Assert(!chart.Options.ShowAxes && !chart.Options.ShowGrid && !chart.Options.ShowLegend, "Overlay charts should suppress report axes, grid, and legend by default.");
+
+        var rgba = ReadPngRgba(chart.ToPng(), out var width, out var height);
+        Assert(width == 220 && height == 90, "Overlay PNG output should preserve requested dimensions.");
+        Assert(CountAlphaInRect(rgba, width, 0, 0, 12, 12) == 0, "Overlay PNG corners should stay fully transparent.");
+        Assert(CountAlphaInRect(rgba, width, 40, 24, 140, 42) > 0, "Overlay PNG should still draw visible chart marks.");
+
+        var svg = chart.ToSvg();
+        Assert(!svg.Contains("data-cfx-role=\"chart-card\"", StringComparison.Ordinal), "Overlay SVG should not render the report card surface.");
+        Assert(!svg.Contains("data-cfx-role=\"plot-background\"", StringComparison.Ordinal), "Overlay SVG should not render the plot background surface.");
+    }
+
     private static Chart BareLineChart() {
         var chart = Chart.Create()
             .WithSize(180, 120)

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -47,6 +47,7 @@ internal static partial class SmokeTests {
         ("PNG supersampling scale is configurable", PngSupersamplingScaleIsConfigurable),
         ("PNG output scale emits high-density assets", PngOutputScaleEmitsHighDensityAssets),
         ("PNG print scale survives dense chart stress", PngPrintScaleSurvivesDenseChartStress),
+        ("Overlay preset emits transparent chrome-free PNG", OverlayPresetEmitsTransparentChromeFreePng),
         ("PNG smooth series use curved raster paths", PngSmoothSeriesUseCurvedRasterPaths),
         ("PNG renderer renders report chrome", PngRendersReportChrome),
         ("PNG outline fonts use em-sized text", PngOutlineFontsUseEmSizedText),

--- a/ChartForgeX/Core/Chart.Overlay.cs
+++ b/ChartForgeX/Core/Chart.Overlay.cs
@@ -1,0 +1,25 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Core;
+
+public sealed partial class Chart {
+    /// <summary>
+    /// Configures the chart for transparent overlay rendering on an existing image or surface.
+    /// </summary>
+    /// <param name="showHeader">True to keep the chart title and subtitle visible; otherwise false.</param>
+    /// <returns>The current chart.</returns>
+    public Chart WithOverlay(bool showHeader = false) {
+        Options.TransparentBackground = true;
+        Options.ShowHeader = showHeader;
+        Options.ShowLegend = false;
+        Options.ShowGrid = false;
+        Options.ShowAxes = false;
+        Options.ShowXAxis = false;
+        Options.ShowYAxis = false;
+        Options.ShowAxisLines = false;
+        Options.ShowCard = false;
+        Options.ShowPlotBackground = false;
+        Options.Padding = showHeader ? new ChartPadding(8, 30, 8, 8) : new ChartPadding(8, 8, 8, 8);
+        return this;
+    }
+}

--- a/ChartForgeX/Core/Chart.cs
+++ b/ChartForgeX/Core/Chart.cs
@@ -426,6 +426,7 @@ public sealed partial class Chart {
         Options.ShowAxes = !enabled;
         Options.ShowXAxis = !enabled;
         Options.ShowYAxis = !enabled;
+        Options.ShowAxisLines = !enabled;
         Options.ShowCard = !enabled;
         Options.ShowPlotBackground = !enabled;
         if (enabled) Options.Padding = new ChartPadding(8, 8, 8, 8);

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The GitHub Actions workflow is configured for private repositories and requires 
 - Optional interactive renderers live in adapter packages without changing static renderer behavior.
 - Themes are first-class, especially polished dark/light report modes.
 
+Use `WithOverlay()` when a chart is meant to sit on top of another image, wallpaper, or report canvas. The preset keeps PNG/SVG backgrounds transparent and suppresses report chrome such as cards, plot panels, axes, grid, and legends while leaving the data marks visible.
+
 ## Current package layout
 
 ```text


### PR DESCRIPTION
## Summary
- add `WithOverlay()` for transparent chart overlays on existing images, wallpapers, and report canvases
- suppress card, plot background, axes, grid, legend, and axis lines while preserving visible chart marks
- add PNG/SVG smoke coverage for transparent overlay output

## Validation
- `dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Release --no-restore`
- `git diff --check`
