### PR TITLE
Migrate additional SVG renderers to markup writer

### DIFF
--- a/ChartForgeX/Svg/SvgChartRenderer.PolarArea.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.PolarArea.cs
@@ -28,9 +28,14 @@ public sealed partial class SvgChartRenderer {
         var cy = chartPlot.Top + chartPlot.Height / 2;
         var sweep = Math.PI * 2 / series.Points.Count;
 
-        sb.AppendLine("<g data-cfx-role=\"polar-area-chart\">");
-        if (chart.Options.ShowGrid) DrawPolarAreaGrid(sb, chart, cx, cy, radius);
-        DrawPolarAreaZeroSlots(sb, chart, series, cx, cy, radius, sweep);
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "polar-area-chart")
+            .EndStartElement()
+            .Line();
+        if (chart.Options.ShowGrid) DrawPolarAreaGrid(writer, chart, cx, cy, radius);
+        DrawPolarAreaZeroSlots(writer, chart, series, cx, cy, radius, sweep);
         for (var i = 0; i < values.Length; i++) {
             var point = values[i].Point;
             var pointIndex = values[i].PointIndex;
@@ -40,7 +45,21 @@ public sealed partial class SvgChartRenderer {
             var label = SliceLabel(chart, point, pointIndex);
             var percent = point.Y / total;
             var summary = label + ": " + FormatValue(chart, point.Y) + ", " + FormatPercent(percent);
-            sb.AppendLine($"<path data-cfx-role=\"polar-area-segment\" data-cfx-point=\"{pointIndex}\" data-cfx-label=\"{Escape(label)}\" data-cfx-value=\"{F(point.Y)}\" data-cfx-percent=\"{F(percent)}\" role=\"img\" aria-label=\"{Escape(summary)}\" d=\"{BuildSlicePath(cx, cy, segmentRadius, 0, start, end)}\" fill=\"{PieSliceFill(chart, series, pointIndex, id)}\" stroke=\"{t.CardBackground.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.SliceSeparatorStrokeWidth)}\"/>");
+            writer
+                .StartElement("path")
+                .Attribute("data-cfx-role", "polar-area-segment")
+                .Attribute("data-cfx-point", pointIndex)
+                .Attribute("data-cfx-label", label)
+                .Attribute("data-cfx-value", point.Y)
+                .Attribute("data-cfx-percent", percent)
+                .Attribute("role", "img")
+                .Attribute("aria-label", summary)
+                .Attribute("d", BuildSlicePath(cx, cy, segmentRadius, 0, start, end))
+                .Attribute("fill", PieSliceFill(chart, series, pointIndex, id))
+                .Attribute("stroke", t.CardBackground.ToCss())
+                .Attribute("stroke-width", ChartVisualPrimitives.SliceSeparatorStrokeWidth)
+                .EndEmptyElement()
+                .Line();
 
             if (ShouldDrawDataLabels(chart, series) && segmentRadius > ChartVisualPrimitives.PolarAreaLabelMinRadius) {
                 var mid = start + sweep / 2;
@@ -49,12 +68,12 @@ public sealed partial class SvgChartRenderer {
             }
         }
 
+        sb.Append(writer.ToString());
         if (chart.Options.ShowLegend) DrawSliceLegend(sb, chart, series, legendValues, plot, total);
         sb.AppendLine("</g>");
     }
 
-    private static void DrawPolarAreaZeroSlots(StringBuilder sb, Chart chart, ChartSeries series, double cx, double cy, double radius, double sweep) {
-        var t = chart.Options.Theme;
+    private static void DrawPolarAreaZeroSlots(SvgMarkupWriter writer, Chart chart, ChartSeries series, double cx, double cy, double radius, double sweep) {
         for (var pointIndex = 0; pointIndex < series.Points.Count; pointIndex++) {
             var point = series.Points[pointIndex];
             if (point.Y > 0) continue;
@@ -64,15 +83,44 @@ public sealed partial class SvgChartRenderer {
             var summary = label + ": " + FormatValue(chart, point.Y) + ", 0%";
             var color = PieSliceColor(chart, series, pointIndex);
             var inner = radius * ChartVisualPrimitives.PolarAreaZeroSlotInnerRadiusFactor;
-            sb.AppendLine($"<path data-cfx-role=\"polar-area-zero-slot\" data-cfx-point=\"{pointIndex}\" data-cfx-label=\"{Escape(label)}\" data-cfx-value=\"{F(point.Y)}\" data-cfx-percent=\"0\" data-cfx-inner-radius-factor=\"{F(ChartVisualPrimitives.PolarAreaZeroSlotInnerRadiusFactor)}\" role=\"img\" aria-label=\"{Escape(summary)}\" d=\"{BuildSlicePath(cx, cy, radius, inner, start, end)}\" fill=\"{color.ToCss()}\" fill-opacity=\"{F(ChartVisualPrimitives.PolarAreaZeroSlotFillOpacity)}\" stroke=\"{color.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.PolarAreaZeroSlotStrokeOpacity)}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" stroke-dasharray=\"3 4\"/>");
+            writer
+                .StartElement("path")
+                .Attribute("data-cfx-role", "polar-area-zero-slot")
+                .Attribute("data-cfx-point", pointIndex)
+                .Attribute("data-cfx-label", label)
+                .Attribute("data-cfx-value", point.Y)
+                .Attribute("data-cfx-percent", 0)
+                .Attribute("data-cfx-inner-radius-factor", ChartVisualPrimitives.PolarAreaZeroSlotInnerRadiusFactor)
+                .Attribute("role", "img")
+                .Attribute("aria-label", summary)
+                .Attribute("d", BuildSlicePath(cx, cy, radius, inner, start, end))
+                .Attribute("fill", color.ToCss())
+                .Attribute("fill-opacity", ChartVisualPrimitives.PolarAreaZeroSlotFillOpacity)
+                .Attribute("stroke", color.ToCss())
+                .Attribute("stroke-opacity", ChartVisualPrimitives.PolarAreaZeroSlotStrokeOpacity)
+                .Attribute("stroke-width", ChartVisualPrimitives.GridStrokeWidth)
+                .Attribute("stroke-dasharray", "3 4")
+                .EndEmptyElement()
+                .Line();
         }
     }
 
-    private static void DrawPolarAreaGrid(StringBuilder sb, Chart chart, double cx, double cy, double radius) {
+    private static void DrawPolarAreaGrid(SvgMarkupWriter writer, Chart chart, double cx, double cy, double radius) {
         var t = chart.Options.Theme;
         for (var i = 1; i <= ChartVisualPrimitives.PolarAreaGridRings; i++) {
             var r = radius * i / ChartVisualPrimitives.PolarAreaGridRings;
-            sb.AppendLine($"<circle data-cfx-role=\"polar-area-ring\" cx=\"{F(cx)}\" cy=\"{F(cy)}\" r=\"{F(r)}\" fill=\"none\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" opacity=\"{F(ChartVisualPrimitives.PolarAreaGridOpacity)}\"/>");
+            writer
+                .StartElement("circle")
+                .Attribute("data-cfx-role", "polar-area-ring")
+                .Attribute("cx", cx)
+                .Attribute("cy", cy)
+                .Attribute("r", r)
+                .Attribute("fill", "none")
+                .Attribute("stroke", t.Grid.ToCss())
+                .Attribute("stroke-width", ChartVisualPrimitives.GridStrokeWidth)
+                .Attribute("opacity", ChartVisualPrimitives.PolarAreaGridOpacity)
+                .EndEmptyElement()
+                .Line();
         }
     }
 }

--- a/ChartForgeX/Svg/SvgChartRenderer.RangeBand.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.RangeBand.cs
@@ -22,9 +22,11 @@ public sealed partial class SvgChartRenderer {
 
         if (lower.Count == 0) return;
         var path = BuildRangeBandPath(lower, upper);
-        sb.AppendLine($"<path data-cfx-role=\"range-band\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{lower.Count}\" d=\"{path}\" fill=\"{color.ToCss()}\" opacity=\"{F(ChartVisualPrimitives.RangeBandFillOpacity)}\"/>");
-        sb.AppendLine($"<path data-cfx-role=\"range-band-upper\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{upper.Count}\" d=\"{BuildLinePath(upper, false)}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.RangeBandBoundaryStrokeWidth)}\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"{F(ChartVisualPrimitives.RangeBandBoundaryOpacity)}\"/>");
-        sb.AppendLine($"<path data-cfx-role=\"range-band-lower\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{lower.Count}\" d=\"{BuildLinePath(lower, false)}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.RangeBandBoundaryStrokeWidth)}\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"{F(ChartVisualPrimitives.RangeBandBoundaryOpacity)}\"/>");
+        var writer = new SvgMarkupWriter(1024);
+        WriteRangeBandArea(writer, index, lower.Count, path, color.ToCss());
+        WriteRangeBandBoundary(writer, "range-band-upper", index, upper.Count, BuildLinePath(upper, false), color.ToCss());
+        WriteRangeBandBoundary(writer, "range-band-lower", index, lower.Count, BuildLinePath(lower, false), color.ToCss());
+        sb.Append(writer.Build());
         if (ShouldDrawDataLabels(chart, series)) {
             var reservedLabels = new List<ChartLabelBounds>();
             for (var pointIndex = 0; pointIndex + 1 < series.Points.Count; pointIndex += 2) {
@@ -38,6 +40,36 @@ public sealed partial class SvgChartRenderer {
                 DrawRangeIntervalLabel(sb, chart, series, item, plot, reservedLabels, label, x, yLow, yHigh);
             }
         }
+    }
+
+    private static void WriteRangeBandArea(SvgMarkupWriter writer, int seriesIndex, int intervalCount, string path, string color) {
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", "range-band")
+            .Attribute("data-cfx-series", seriesIndex)
+            .Attribute("data-cfx-interval-count", intervalCount)
+            .Attribute("d", path)
+            .Attribute("fill", color)
+            .Attribute("opacity", ChartVisualPrimitives.RangeBandFillOpacity)
+            .EndEmptyElement()
+            .Line();
+    }
+
+    private static void WriteRangeBandBoundary(SvgMarkupWriter writer, string role, int seriesIndex, int intervalCount, string path, string color) {
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", role)
+            .Attribute("data-cfx-series", seriesIndex)
+            .Attribute("data-cfx-interval-count", intervalCount)
+            .Attribute("d", path)
+            .Attribute("fill", "none")
+            .Attribute("stroke", color)
+            .Attribute("stroke-width", ChartVisualPrimitives.RangeBandBoundaryStrokeWidth)
+            .Attribute("stroke-linecap", "round")
+            .Attribute("stroke-linejoin", "round")
+            .Attribute("opacity", ChartVisualPrimitives.RangeBandBoundaryOpacity)
+            .EndEmptyElement()
+            .Line();
     }
 
     private static void DrawRangeIntervalLabel(StringBuilder sb, Chart chart, ChartSeries series, int pointIndex, ChartRect plot, List<ChartLabelBounds> reservedLabels, string label, double x, double yLow, double yHigh) {

--- a/ChartForgeX/Svg/SvgChartRenderer.SecondaryAxis.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.SecondaryAxis.cs
@@ -21,23 +21,92 @@ public sealed partial class SvgChartRenderer {
         var tickStyle = o.TickLabelStyle;
         var tickFontSize = StyleFontSize(tickStyle, t.TickLabelFontSize);
         var tickLabelMaxWidth = Math.Max(24, chart.Options.Size.Width - plot.Right - 18);
+        var writer = new SvgMarkupWriter(2048);
         foreach (var yv in yTicks) {
             var y = map.Y(yv);
             var rawLabel = FormatSecondaryValue(chart, yv);
             var labelFontSize = TextFontSizeForSvgWidth(rawLabel, tickLabelMaxWidth, tickFontSize);
             var label = TrimSvgLabelToWidth(rawLabel, labelFontSize, tickLabelMaxWidth);
             if (label.Length == 0) continue;
-            sb.AppendLine($"<text data-cfx-role=\"secondary-y-axis-tick\" data-cfx-value=\"{F(yv)}\" x=\"{F(plot.Right+12)}\" y=\"{F(y+4)}\" text-anchor=\"start\" fill=\"{StyleColor(tickStyle, t.MutedText).ToCss()}\" font-family=\"{SvgFontFamily(StyleFontFamily(chart, tickStyle))}\" font-size=\"{F(labelFontSize)}\"{SvgTextStyleAttributes(tickStyle)}>{Escape(label)}</text>");
+            WriteSecondaryYAxisTick(writer, chart, tickStyle, yv, plot.Right + 12, y + 4, StyleColor(tickStyle, t.MutedText).ToCss(), labelFontSize, label);
         }
 
-        if (ShowAxisLines(chart)) sb.AppendLine($"<line data-cfx-role=\"secondary-y-axis\" x1=\"{F(plot.Right)}\" y1=\"{F(plot.Top)}\" x2=\"{F(plot.Right)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.AxisStrokeWidth)}\"/>");
-        if (string.IsNullOrWhiteSpace(chart.SecondaryYAxisTitle)) return;
+        if (ShowAxisLines(chart)) WriteSecondaryYAxisLine(writer, plot, t.Axis.ToCss());
+        if (string.IsNullOrWhiteSpace(chart.SecondaryYAxisTitle)) {
+            sb.Append(writer.Build());
+            return;
+        }
+
         var style = chart.Options.AxisTitleStyle;
         var titleMaxWidth = Math.Max(40, plot.Height * 0.72);
         var titleFontSize = TextFontSizeForSvgWidth(chart.SecondaryYAxisTitle, titleMaxWidth, StyleFontSize(style, t.AxisTitleFontSize));
         var title = TrimSvgLabelToWidth(chart.SecondaryYAxisTitle, titleFontSize, titleMaxWidth);
-        if (title.Length == 0) return;
-        sb.AppendLine($"<text data-cfx-role=\"secondary-y-axis-title\" data-cfx-label=\"{Escape(chart.SecondaryYAxisTitle)}\" transform=\"translate({F(Math.Min(chart.Options.Size.Width - 18, plot.Right + 54))} {F(plot.Top + plot.Height / 2.0)}) rotate(90)\" text-anchor=\"middle\" fill=\"{StyleColor(style, t.MutedText).ToCss()}\" font-family=\"{SvgFontFamily(StyleFontFamily(chart, style))}\" font-size=\"{F(titleFontSize)}\" font-weight=\"{StyleWeight(style, "600")}\"{SvgTextStyleAttributes(style)}>{Escape(title)}</text>");
+        if (title.Length != 0) {
+            WriteSecondaryYAxisTitle(
+                writer,
+                chart,
+                style,
+                chart.SecondaryYAxisTitle,
+                title,
+                Math.Min(chart.Options.Size.Width - 18, plot.Right + 54),
+                plot.Top + plot.Height / 2.0,
+                StyleColor(style, t.MutedText).ToCss(),
+                titleFontSize);
+        }
+
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteSecondaryYAxisTick(SvgMarkupWriter writer, Chart chart, ChartTextStyle tickStyle, double value, double x, double y, string color, double fontSize, string label) {
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "secondary-y-axis-tick")
+            .Attribute("data-cfx-value", value)
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("text-anchor", "start")
+            .Attribute("fill", color)
+            .Attribute("font-family", SvgFontFamilyAttributeValue(StyleFontFamily(chart, tickStyle)))
+            .Attribute("font-size", fontSize)
+            .Raw(SvgTextStyleAttributes(tickStyle))
+            .Text(label)
+            .EndElement()
+            .Line();
+    }
+
+    private static void WriteSecondaryYAxisLine(SvgMarkupWriter writer, ChartRect plot, string color) {
+        writer
+            .StartElement("line")
+            .Attribute("data-cfx-role", "secondary-y-axis")
+            .Attribute("x1", plot.Right)
+            .Attribute("y1", plot.Top)
+            .Attribute("x2", plot.Right)
+            .Attribute("y2", plot.Bottom)
+            .Attribute("stroke", color)
+            .Attribute("stroke-width", ChartVisualPrimitives.AxisStrokeWidth)
+            .EndEmptyElement()
+            .Line();
+    }
+
+    private static void WriteSecondaryYAxisTitle(SvgMarkupWriter writer, Chart chart, ChartTextStyle style, string rawTitle, string title, double x, double y, string color, double fontSize) {
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "secondary-y-axis-title")
+            .Attribute("data-cfx-label", rawTitle)
+            .Attribute("transform", "translate(" + F(x) + " " + F(y) + ") rotate(90)")
+            .Attribute("text-anchor", "middle")
+            .Attribute("fill", color)
+            .Attribute("font-family", SvgFontFamilyAttributeValue(StyleFontFamily(chart, style)))
+            .Attribute("font-size", fontSize)
+            .Attribute("font-weight", StyleWeight(style, "600"))
+            .Raw(SvgTextStyleAttributes(style))
+            .Text(title)
+            .EndElement()
+            .Line();
+    }
+
+    private static string SvgFontFamilyAttributeValue(string value) {
+        return string.IsNullOrWhiteSpace(value) ? "system-ui, sans-serif" : value;
     }
 
     private static ChartRect ApplySecondaryYAxisLabelReserve(Chart chart, ChartRect plot, IReadOnlyList<double> yTicks) {

--- a/ChartForgeX/Svg/SvgChartRenderer.Waterfall.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Waterfall.cs
@@ -24,8 +24,8 @@ public sealed partial class SvgChartRenderer {
         var negative = t.Negative;
         var totalColor = t.Warning;
 
-        sb.AppendLine("<g data-cfx-role=\"waterfall-chart\">");
-        DrawWaterfallGrid(sb, chart, plot, bounds, ticks);
+        var body = new StringBuilder();
+        DrawWaterfallGrid(body, chart, plot, bounds, ticks);
         var reservedLabels = new List<ChartLabelBounds>();
         for (var i = 0; i < steps.Count; i++) {
             var step = steps[i];
@@ -39,10 +39,10 @@ public sealed partial class SvgChartRenderer {
             var summary = WaterfallLabel(chart, step) + ": " + (step.IsTotal ? FormatValue(chart, step.End) : FormatSignedValue(chart, step.Delta)) + ", " + status;
             if (i > 0) {
                 var connectorY = WaterfallY(plot, bounds, step.Start);
-                sb.AppendLine($"<line data-cfx-role=\"waterfall-connector\" x1=\"{F(centerX - slot + barWidth / 2)}\" y1=\"{F(connectorY)}\" x2=\"{F(centerX - barWidth / 2)}\" y2=\"{F(connectorY)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.WaterfallConnectorStrokeWidth)}\" stroke-dasharray=\"{F(ChartVisualPrimitives.WaterfallConnectorDash)} {F(ChartVisualPrimitives.WaterfallConnectorGap)}\" opacity=\"{F(ChartVisualPrimitives.WaterfallConnectorOpacity)}\"/>");
+                WriteWaterfallConnector(body, centerX - slot + barWidth / 2, connectorY, centerX - barWidth / 2, connectorY, t.Axis);
             }
 
-            sb.AppendLine($"<rect data-cfx-role=\"waterfall-bar\" data-cfx-point=\"{i}\" data-cfx-label=\"{Escape(WaterfallLabel(chart, step))}\" data-cfx-start=\"{F(step.Start)}\" data-cfx-end=\"{F(step.End)}\" data-cfx-delta=\"{F(step.Delta)}\" data-cfx-status=\"{status}\" role=\"img\" aria-label=\"{Escape(summary)}\" x=\"{F(centerX - barWidth / 2)}\" y=\"{F(top)}\" width=\"{F(barWidth)}\" height=\"{F(height)}\" rx=\"6\" fill=\"{color.ToCss()}\"/>");
+            WriteWaterfallBar(body, chart, step, i, status, summary, color, centerX - barWidth / 2, top, barWidth, height);
             if (ShouldDrawDataLabels(chart, series)) {
                 var label = step.IsTotal ? FormatValue(chart, step.End) : FormatSignedValue(chart, step.Delta);
                 var pointIndex = step.IsTotal ? -1 : i;
@@ -50,7 +50,7 @@ public sealed partial class SvgChartRenderer {
                 if (placement == ChartDataLabelPlacement.Left || placement == ChartDataLabelPlacement.Right || placement == ChartDataLabelPlacement.Outside) {
                     var labelX = placement == ChartDataLabelPlacement.Left ? centerX - barWidth / 2 - 8 : centerX + barWidth / 2 + 8;
                     var anchor = placement == ChartDataLabelPlacement.Left ? "end" : "start";
-                    if (ReserveSvgHorizontalLabel(label, labelX, top + height / 2, anchor, chart, plot, reservedLabels)) DrawHorizontalValueLabel(sb, chart, label, labelX, top + height / 2, anchor, plot, series, pointIndex);
+                    if (ReserveSvgHorizontalLabel(label, labelX, top + height / 2, anchor, chart, plot, reservedLabels)) DrawHorizontalValueLabel(body, chart, label, labelX, top + height / 2, anchor, plot, series, pointIndex);
                 } else {
                     if ((placement == ChartDataLabelPlacement.Inside || placement == ChartDataLabelPlacement.Center) && height < t.DataLabelFontSize + 8) continue;
                     var labelY = placement == ChartDataLabelPlacement.Inside || placement == ChartDataLabelPlacement.Center
@@ -60,31 +60,39 @@ public sealed partial class SvgChartRenderer {
                             : placement == ChartDataLabelPlacement.Below
                                 ? top + height + 13
                                 : step.Delta >= 0 || step.IsTotal ? top - 11 : top + height + 13;
-                    if (ReserveSvgLabel(label, centerX, labelY, chart, plot, reservedLabels)) DrawDataLabel(sb, chart, label, centerX, labelY, plot, series: series, pointIndex: pointIndex);
+                    if (ReserveSvgLabel(label, centerX, labelY, chart, plot, reservedLabels)) DrawDataLabel(body, chart, label, centerX, labelY, plot, series: series, pointIndex: pointIndex);
                 }
             }
 
-            if (chart.Options.ShowAxes) DrawXAxisLabel(sb, chart, plot, WaterfallLabel(chart, step), centerX, plot.Bottom + XAxisLabelOffset(chart), Clamp(chart.Options.XAxisLabelAngle, -80, 80), "waterfall-x-axis-label");
+            if (chart.Options.ShowAxes) DrawXAxisLabel(body, chart, plot, WaterfallLabel(chart, step), centerX, plot.Bottom + XAxisLabelOffset(chart), Clamp(chart.Options.XAxisLabelAngle, -80, 80), "waterfall-x-axis-label");
         }
 
-        DrawLegend(sb, chart, chart.Options.Size.Width, chart.Options.Size.Height);
-        sb.AppendLine("</g>");
+        DrawLegend(body, chart, chart.Options.Size.Width, chart.Options.Size.Height);
+        var writer = new SvgMarkupWriter(body.Length + 128);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "waterfall-chart")
+            .Raw(Environment.NewLine)
+            .Raw(body.ToString())
+            .EndElement()
+            .Line();
+        sb.Append(writer.Build());
     }
 
     private static void DrawWaterfallGrid(StringBuilder sb, Chart chart, ChartRect plot, ChartRange bounds, IReadOnlyList<double> ticks) {
         var t = chart.Options.Theme;
         foreach (var tick in ticks) {
             var y = WaterfallY(plot, bounds, tick);
-            if (chart.Options.ShowGrid) sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(y)}\" x2=\"{F(plot.Right)}\" y2=\"{F(y)}\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\"/>");
-            if (chart.Options.ShowAxes) sb.AppendLine($"<text data-cfx-role=\"waterfall-y-axis-label\" x=\"{F(plot.Left - 12)}\" y=\"{F(y + 4)}\" text-anchor=\"end\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(t.TickLabelFontSize)}\">{Escape(FormatValue(chart, tick))}</text>");
+            if (chart.Options.ShowGrid) WriteWaterfallGridLine(sb, plot.Left, y, plot.Right, y, t.Grid, ChartVisualPrimitives.GridStrokeWidth);
+            if (chart.Options.ShowAxes) WriteWaterfallYAxisLabel(sb, chart, plot.Left - 12, y + 4, FormatValue(chart, tick));
         }
 
         var zeroY = WaterfallY(plot, bounds, 0);
-        if (ShowAxisLines(chart) && zeroY > plot.Top && zeroY < plot.Bottom) sb.AppendLine($"<line data-cfx-role=\"waterfall-zero-axis\" x1=\"{F(plot.Left)}\" y1=\"{F(zeroY)}\" x2=\"{F(plot.Right)}\" y2=\"{F(zeroY)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.ZeroAxisStrokeWidth)}\"/>");
+        if (ShowAxisLines(chart) && zeroY > plot.Top && zeroY < plot.Bottom) WriteWaterfallAxisLine(sb, "waterfall-zero-axis", plot.Left, zeroY, plot.Right, zeroY, t.Axis, ChartVisualPrimitives.ZeroAxisStrokeWidth);
         if (!chart.Options.ShowAxes) return;
         if (ShowAxisLines(chart)) {
-            sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(plot.Bottom)}\" x2=\"{F(plot.Right)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.AxisStrokeWidth)}\"/>");
-            sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(plot.Top)}\" x2=\"{F(plot.Left)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.AxisStrokeWidth)}\"/>");
+            WriteWaterfallAxisLine(sb, null, plot.Left, plot.Bottom, plot.Right, plot.Bottom, t.Axis, ChartVisualPrimitives.AxisStrokeWidth);
+            WriteWaterfallAxisLine(sb, null, plot.Left, plot.Top, plot.Left, plot.Bottom, t.Axis, ChartVisualPrimitives.AxisStrokeWidth);
         }
         DrawSvgXAxisTitle(sb, chart, plot, plot.Bottom + XAxisTitleOffset(chart), "waterfall-x-axis-title");
         if (!string.IsNullOrWhiteSpace(chart.YAxisTitle)) {
@@ -92,6 +100,97 @@ public sealed partial class SvgChartRenderer {
             var axisX = Math.Max(24, plot.Left - widestTick - 48);
             DrawSvgYAxisTitle(sb, chart, plot, axisX, "waterfall-y-axis-title");
         }
+    }
+
+    private static void WriteWaterfallConnector(StringBuilder sb, double x1, double y1, double x2, double y2, ChartColor axisColor) {
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("line")
+            .Attribute("data-cfx-role", "waterfall-connector")
+            .Attribute("x1", x1)
+            .Attribute("y1", y1)
+            .Attribute("x2", x2)
+            .Attribute("y2", y2)
+            .Attribute("stroke", axisColor.ToCss())
+            .Attribute("stroke-width", ChartVisualPrimitives.WaterfallConnectorStrokeWidth)
+            .Attribute("stroke-dasharray", SvgMarkupWriter.FormatNumber(ChartVisualPrimitives.WaterfallConnectorDash) + " " + SvgMarkupWriter.FormatNumber(ChartVisualPrimitives.WaterfallConnectorGap))
+            .Attribute("opacity", ChartVisualPrimitives.WaterfallConnectorOpacity)
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteWaterfallBar(StringBuilder sb, Chart chart, WaterfallStep step, int pointIndex, string status, string summary, ChartColor color, double x, double y, double width, double height) {
+        var writer = new SvgMarkupWriter(512);
+        writer
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "waterfall-bar")
+            .Attribute("data-cfx-point", pointIndex)
+            .Attribute("data-cfx-label", WaterfallLabel(chart, step))
+            .Attribute("data-cfx-start", step.Start)
+            .Attribute("data-cfx-end", step.End)
+            .Attribute("data-cfx-delta", step.Delta)
+            .Attribute("data-cfx-status", status)
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("width", width)
+            .Attribute("height", height)
+            .Attribute("rx", 6)
+            .Attribute("fill", color.ToCss())
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteWaterfallGridLine(StringBuilder sb, double x1, double y1, double x2, double y2, ChartColor color, double strokeWidth) {
+        var writer = new SvgMarkupWriter(256);
+        writer
+            .StartElement("line")
+            .Attribute("x1", x1)
+            .Attribute("y1", y1)
+            .Attribute("x2", x2)
+            .Attribute("y2", y2)
+            .Attribute("stroke", color.ToCss())
+            .Attribute("stroke-width", strokeWidth)
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteWaterfallYAxisLabel(StringBuilder sb, Chart chart, double x, double y, string label) {
+        var t = chart.Options.Theme;
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "waterfall-y-axis-label")
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("text-anchor", "end")
+            .Attribute("fill", t.MutedText.ToCss())
+            .Attribute("font-family", SvgFontFamily(t.FontFamily))
+            .Attribute("font-size", t.TickLabelFontSize)
+            .Text(label)
+            .EndElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteWaterfallAxisLine(StringBuilder sb, string? role, double x1, double y1, double x2, double y2, ChartColor color, double strokeWidth) {
+        var writer = new SvgMarkupWriter(256);
+        writer.StartElement("line");
+        writer.Attribute("data-cfx-role", role);
+        writer
+            .Attribute("x1", x1)
+            .Attribute("y1", y1)
+            .Attribute("x2", x2)
+            .Attribute("y2", y2)
+            .Attribute("stroke", color.ToCss())
+            .Attribute("stroke-width", strokeWidth)
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
     }
 
     private static List<WaterfallStep> BuildWaterfallSteps(ChartSeries series) {

--- a/ChartForgeX/Svg/SvgChartRenderer.WordCloud.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.WordCloud.cs
@@ -15,16 +15,47 @@ public sealed partial class SvgChartRenderer {
         var series = chart.Series.First(item => item.Kind == ChartSeriesKind.WordCloud);
         var t = chart.Options.Theme;
         var maximumTerms = chart.Options.WordCloudMaximumTerms.HasValue ? chart.Options.WordCloudMaximumTerms.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "all";
-        sb.AppendLine($"<g data-cfx-role=\"word-cloud\" data-cfx-density=\"{F(chart.Options.WordCloudDensity)}\" data-cfx-maximum-terms=\"{maximumTerms}\" data-cfx-edge-padding=\"{F(ChartWordCloudLayout.EdgePadding(plot))}\">");
+        var fontFamily = string.IsNullOrWhiteSpace(t.FontFamily) ? "system-ui, sans-serif" : t.FontFamily;
+        var writer = new SvgMarkupWriter(2048);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "word-cloud")
+            .Attribute("data-cfx-density", chart.Options.WordCloudDensity)
+            .Attribute("data-cfx-maximum-terms", maximumTerms)
+            .Attribute("data-cfx-edge-padding", ChartWordCloudLayout.EdgePadding(plot))
+            .EndStartElement()
+            .Line();
         for (var i = 0; i < terms.Count; i++) {
             var term = terms[i];
             var color = WordCloudTermColor(series, t, term.PointIndex, i);
-            var transform = Math.Abs(term.Angle) < 0.001 ? string.Empty : $" transform=\"rotate({F(term.Angle)} {F(term.X)} {F(term.Y)})\"";
             var summary = term.Text + ": " + FormatValue(chart, term.Value);
-            sb.AppendLine($"<text data-cfx-role=\"word-cloud-term\" data-cfx-point=\"{term.PointIndex}\" data-cfx-text=\"{Escape(term.Text)}\" data-cfx-value=\"{F(term.Value)}\" role=\"img\" aria-label=\"{Escape(summary)}\" x=\"{F(term.X)}\" y=\"{F(term.Y)}\" text-anchor=\"middle\" dominant-baseline=\"middle\" fill=\"{color.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(term.FontSize)}\" font-weight=\"800\"{transform}>{Escape(term.Text)}</text>");
+            writer
+                .StartElement("text")
+                .Attribute("data-cfx-role", "word-cloud-term")
+                .Attribute("data-cfx-point", term.PointIndex)
+                .Attribute("data-cfx-text", term.Text)
+                .Attribute("data-cfx-value", term.Value)
+                .Attribute("role", "img")
+                .Attribute("aria-label", summary)
+                .Attribute("x", term.X)
+                .Attribute("y", term.Y)
+                .Attribute("text-anchor", "middle")
+                .Attribute("dominant-baseline", "middle")
+                .Attribute("fill", color.ToCss())
+                .Attribute("font-family", fontFamily)
+                .Attribute("font-size", term.FontSize)
+                .Attribute("font-weight", "800");
+            if (Math.Abs(term.Angle) >= 0.001) {
+                writer.Attribute("transform", $"rotate({F(term.Angle)} {F(term.X)} {F(term.Y)})");
+            }
+            writer
+                .Text(term.Text)
+                .EndElement()
+                .Line();
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
     private static ChartColor WordCloudTermColor(ChartSeries series, ChartTheme theme, int pointIndex, int renderIndex) {


### PR DESCRIPTION
## Summary
- migrate WordCloud, RangeBand, SecondaryAxis, Waterfall, and PolarArea SVG output toward SvgMarkupWriter
- preserve chart metadata, accessible summaries, label behavior, and existing shared helper paths
- batch several proven small renderer migrations after the prior single-renderer PRs

## Validation
- dotnet build ChartForgeX.sln -c Debug -m:1 -nr:false
- dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Debug --no-build
- dotnet build ChartForgeX.Examples\ChartForgeX.Examples.csproj -c Release -m:1 -nr:false
- dotnet ChartForgeX.Examples\bin\Release\net8.0\ChartForgeX.Examples.dll
- .\Build.ps1 -Configuration Release
- git diff --cached --check