### PR TITLE
Migrate chart structure SVG renderers to markup writer

### DIFF
--- a/ChartForgeX/Svg/SvgChartRenderer.Heatmap.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Heatmap.cs
@@ -28,7 +28,7 @@ public sealed partial class SvgChartRenderer {
         var cellHeight = Math.Max(1, (plot.Height - gap * (rows.Length - 1)) / rows.Length);
         var radius = Math.Min(8, Math.Min(cellWidth, cellHeight) * 0.16);
 
-        sb.AppendLine("<g data-cfx-role=\"heatmap\">");
+        var body = new StringBuilder();
         for (var rowIndex = 0; rowIndex < rows.Length; rowIndex++) {
             var series = rows[rowIndex];
             var y = plot.Top + rowIndex * (cellHeight + gap);
@@ -37,7 +37,7 @@ public sealed partial class SvgChartRenderer {
                 var rowLabelFontSize = TextFontSizeForSvgWidth(series.Name, rowLabelWidth, t.TickLabelFontSize);
                 var rowLabel = TrimSvgLabelToWidth(series.Name, rowLabelFontSize, rowLabelWidth);
                 if (rowLabel.Length > 0) {
-                    sb.AppendLine($"<text data-cfx-role=\"heatmap-row-label\" x=\"{F(plot.Left - 12)}\" y=\"{F(y + cellHeight / 2)}\" text-anchor=\"end\" dominant-baseline=\"middle\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(rowLabelFontSize)}\" font-weight=\"650\">{Escape(rowLabel)}</text>");
+                    WriteHeatmapRowLabel(body, chart, plot.Left - 12, y + cellHeight / 2, rowLabelFontSize, rowLabel);
                 }
             }
             for (var columnIndex = 0; columnIndex < columns.Length; columnIndex++) {
@@ -49,22 +49,22 @@ public sealed partial class SvgChartRenderer {
                 var color = HeatmapColor(chart, series.Color, value, min, max);
                 var summary = series.Name + ", " + FormatX(chart, column) + ": " + FormatValue(chart, value);
                 if (chart.Options.HeatmapScale == ChartHeatmapScale.Semantic) summary += ", " + status;
-                sb.AppendLine($"<rect class=\"cfx-interactive-region\" tabindex=\"0\" focusable=\"true\" data-cfx-role=\"heatmap-cell\" data-cfx-row=\"{rowIndex}\" data-cfx-column=\"{columnIndex}\" data-cfx-status=\"{status}\" role=\"img\" aria-label=\"{Escape(summary)}\" x=\"{F(x)}\" y=\"{F(y)}\" width=\"{F(cellWidth)}\" height=\"{F(cellHeight)}\" rx=\"{F(radius)}\" fill=\"{color.ToCss()}\" stroke=\"{t.CardBackground.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.HeatmapCellBorderOpacity)}\" stroke-width=\"{F(ChartVisualPrimitives.HeatmapCellBorderStrokeWidth)}\"><title>{Escape(summary)}</title></rect>");
+                WriteHeatmapCell(body, chart, rowIndex, columnIndex, status, summary, x, y, cellWidth, cellHeight, radius, color);
                 if (ShouldDrawDataLabels(chart, series) && cellWidth >= 34 && cellHeight >= 20) {
                     var label = FormatValue(chart, value);
                     var pointIndex = HeatmapPointIndex(series, column);
                     var placement = DataLabelPlacement(chart, series);
                     if (placement == ChartDataLabelPlacement.Auto || placement == ChartDataLabelPlacement.Inside || placement == ChartDataLabelPlacement.Center) {
-                        DrawSvgTextCenteredX(sb, chart, "data-label", label, x + cellWidth / 2, y + cellHeight / 2, HeatmapTextColor(color), t.DataLabelFontSize, cellWidth - 6, "750", style: DataLabelStyle(chart, series, pointIndex));
+                        DrawSvgTextCenteredX(body, chart, "data-label", label, x + cellWidth / 2, y + cellHeight / 2, HeatmapTextColor(color), t.DataLabelFontSize, cellWidth - 6, "750", style: DataLabelStyle(chart, series, pointIndex));
                     } else if (placement == ChartDataLabelPlacement.Left || placement == ChartDataLabelPlacement.Right || placement == ChartDataLabelPlacement.Outside) {
                         var labelX = placement == ChartDataLabelPlacement.Left ? x - 8 : x + cellWidth + 8;
                         var anchor = placement == ChartDataLabelPlacement.Left ? "end" : "start";
                         var connectorStartX = placement == ChartDataLabelPlacement.Left ? x : x + cellWidth;
                         var connectorEndX = placement == ChartDataLabelPlacement.Left ? x - 5 : x + cellWidth + 5;
-                        DrawHeatmapLabelConnector(sb, chart, rowIndex, columnIndex, connectorStartX, y + cellHeight / 2, connectorEndX);
-                        DrawHorizontalValueLabel(sb, chart, label, labelX, y + cellHeight / 2, anchor, basePlot, series, pointIndex);
+                        DrawHeatmapLabelConnector(body, chart, rowIndex, columnIndex, connectorStartX, y + cellHeight / 2, connectorEndX);
+                        DrawHorizontalValueLabel(body, chart, label, labelX, y + cellHeight / 2, anchor, basePlot, series, pointIndex);
                     } else {
-                        DrawDataLabel(sb, chart, label, x + cellWidth / 2, placement == ChartDataLabelPlacement.Above ? y - 8 : y + cellHeight + 12, plot, series: series, pointIndex: pointIndex);
+                        DrawDataLabel(body, chart, label, x + cellWidth / 2, placement == ChartDataLabelPlacement.Above ? y - 8 : y + cellHeight + 12, plot, series: series, pointIndex: pointIndex);
                     }
                 }
             }
@@ -80,19 +80,99 @@ public sealed partial class SvgChartRenderer {
                 if (label.Length == 0) continue;
                 var anchor = EdgeAwareAnchor(label, x, plot, labelFontSize);
                 var labelX = EdgeAwareTextX(label, x, plot, labelFontSize);
-                sb.AppendLine($"<text data-cfx-role=\"heatmap-column-label\" x=\"{F(labelX)}\" y=\"{F(plot.Bottom + 22)}\" text-anchor=\"{anchor}\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(labelFontSize)}\" font-weight=\"650\">{Escape(label)}</text>");
+                WriteHeatmapColumnLabel(body, chart, labelX, plot.Bottom + 22, anchor, labelFontSize, label);
             }
 
-            DrawSvgXAxisTitle(sb, chart, plot, plot.Bottom + 48, "heatmap-x-axis-title");
+            DrawSvgXAxisTitle(body, chart, plot, plot.Bottom + 48, "heatmap-x-axis-title");
             if (!string.IsNullOrWhiteSpace(chart.YAxisTitle)) {
                 var widestRowLabel = rows.Max(series => EstimateTextWidth(series.Name, t.TickLabelFontSize));
                 var axisX = Math.Max(24, plot.Left - widestRowLabel - 48);
-                DrawSvgYAxisTitle(sb, chart, plot, axisX, "heatmap-y-axis-title");
+                DrawSvgYAxisTitle(body, chart, plot, axisX, "heatmap-y-axis-title");
             }
         }
 
-        if (chart.Options.ShowHeatmapScale) DrawHeatmapScale(sb, chart, plot, min, max, rows[0].Color);
-        sb.AppendLine("</g>");
+        if (chart.Options.ShowHeatmapScale) DrawHeatmapScale(body, chart, plot, min, max, rows[0].Color);
+
+        var writer = new SvgMarkupWriter(body.Length + 128);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "heatmap")
+            .Raw(Environment.NewLine)
+            .Raw(body.ToString())
+            .EndElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteHeatmapRowLabel(StringBuilder sb, Chart chart, double x, double y, double fontSize, string label) {
+        var t = chart.Options.Theme;
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "heatmap-row-label")
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("text-anchor", "end")
+            .Attribute("dominant-baseline", "middle")
+            .Attribute("fill", t.MutedText.ToCss())
+            .Attribute("font-family", SvgFontFamilyAttributeValue(t.FontFamily))
+            .Attribute("font-size", fontSize)
+            .Attribute("font-weight", "650")
+            .Text(label)
+            .EndElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteHeatmapCell(StringBuilder sb, Chart chart, int rowIndex, int columnIndex, string status, string summary, double x, double y, double width, double height, double radius, ChartColor color) {
+        var t = chart.Options.Theme;
+        var writer = new SvgMarkupWriter(768);
+        writer
+            .StartElement("rect")
+            .Attribute("class", "cfx-interactive-region")
+            .Attribute("tabindex", "0")
+            .Attribute("focusable", "true")
+            .Attribute("data-cfx-role", "heatmap-cell")
+            .Attribute("data-cfx-row", rowIndex)
+            .Attribute("data-cfx-column", columnIndex)
+            .Attribute("data-cfx-status", status)
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("width", width)
+            .Attribute("height", height)
+            .Attribute("rx", radius)
+            .Attribute("fill", color.ToCss())
+            .Attribute("stroke", t.CardBackground.ToCss())
+            .Attribute("stroke-opacity", ChartVisualPrimitives.HeatmapCellBorderOpacity)
+            .Attribute("stroke-width", ChartVisualPrimitives.HeatmapCellBorderStrokeWidth)
+            .EndStartElement()
+            .StartElement("title")
+            .Text(summary)
+            .EndElement()
+            .EndElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteHeatmapColumnLabel(StringBuilder sb, Chart chart, double x, double y, string anchor, double fontSize, string label) {
+        var t = chart.Options.Theme;
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "heatmap-column-label")
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("text-anchor", anchor)
+            .Attribute("fill", t.MutedText.ToCss())
+            .Attribute("font-family", SvgFontFamilyAttributeValue(t.FontFamily))
+            .Attribute("font-size", fontSize)
+            .Attribute("font-weight", "650")
+            .Text(label)
+            .EndElement()
+            .Line();
+        sb.Append(writer.Build());
     }
 
     private static ChartRect ApplyHeatmapLabelReserve(Chart chart, ChartRect plot, IReadOnlyList<ChartSeries> rows, IReadOnlyList<double> columns) {
@@ -147,7 +227,7 @@ public sealed partial class SvgChartRenderer {
             var ratio = i / (double)(steps - 1);
             var value = min + (max - min) * ratio;
             var color = HeatmapColor(chart, highColor, value, min, max);
-            sb.AppendLine($"<rect data-cfx-role=\"heatmap-scale-step\" data-cfx-status=\"{HeatmapStatus(HeatmapRatio(value, min, max))}\" x=\"{F(x + i * width / steps)}\" y=\"{F(y)}\" width=\"{F(width / steps + ChartVisualPrimitives.HeatmapScaleStepOverlap)}\" height=\"{F(height)}\" rx=\"{F(ChartVisualPrimitives.HeatmapScaleRadius)}\" fill=\"{color.ToCss()}\"/>");
+            WriteHeatmapScaleStep(sb, x + i * width / steps, y, width / steps + ChartVisualPrimitives.HeatmapScaleStepOverlap, height, HeatmapStatus(HeatmapRatio(value, min, max)), color);
         }
 
         var labelMaxWidth = Math.Max(18, width * 0.46);
@@ -158,15 +238,66 @@ public sealed partial class SvgChartRenderer {
         var maxFontSize = TextFontSizeForSvgWidth(maxLabel, labelMaxWidth, t.TickLabelFontSize);
         maxLabel = TrimSvgLabelToWidth(maxLabel, maxFontSize, labelMaxWidth);
         if (minLabel.Length > 0) {
-            sb.AppendLine($"<text data-cfx-role=\"heatmap-scale-label\" x=\"{F(x)}\" y=\"{F(y + ChartVisualPrimitives.HeatmapScaleLabelOffsetY)}\" text-anchor=\"start\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(minFontSize)}\">{Escape(minLabel)}</text>");
+            WriteHeatmapScaleLabel(sb, chart, x, y + ChartVisualPrimitives.HeatmapScaleLabelOffsetY, "start", minFontSize, minLabel);
         }
         if (maxLabel.Length > 0) {
-            sb.AppendLine($"<text data-cfx-role=\"heatmap-scale-label\" x=\"{F(x + width)}\" y=\"{F(y + ChartVisualPrimitives.HeatmapScaleLabelOffsetY)}\" text-anchor=\"end\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(maxFontSize)}\">{Escape(maxLabel)}</text>");
+            WriteHeatmapScaleLabel(sb, chart, x + width, y + ChartVisualPrimitives.HeatmapScaleLabelOffsetY, "end", maxFontSize, maxLabel);
         }
     }
 
+    private static void WriteHeatmapScaleStep(StringBuilder sb, double x, double y, double width, double height, string status, ChartColor color) {
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "heatmap-scale-step")
+            .Attribute("data-cfx-status", status)
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("width", width)
+            .Attribute("height", height)
+            .Attribute("rx", ChartVisualPrimitives.HeatmapScaleRadius)
+            .Attribute("fill", color.ToCss())
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteHeatmapScaleLabel(StringBuilder sb, Chart chart, double x, double y, string anchor, double fontSize, string label) {
+        var t = chart.Options.Theme;
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "heatmap-scale-label")
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("text-anchor", anchor)
+            .Attribute("fill", t.MutedText.ToCss())
+            .Attribute("font-family", SvgFontFamilyAttributeValue(t.FontFamily))
+            .Attribute("font-size", fontSize)
+            .Text(label)
+            .EndElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
     private static void DrawHeatmapLabelConnector(StringBuilder sb, Chart chart, int rowIndex, int columnIndex, double startX, double y, double endX) {
-        sb.AppendLine($"<line data-cfx-role=\"data-label-connector\" data-cfx-row=\"{rowIndex}\" data-cfx-column=\"{columnIndex}\" x1=\"{F(startX)}\" y1=\"{F(y)}\" x2=\"{F(endX)}\" y2=\"{F(y)}\" stroke=\"{DataLabelConnectorColor(chart).ToCss()}\" stroke-width=\"{F(chart.Options.DataLabelConnectorStrokeWidth)}\" stroke-opacity=\"{F(chart.Options.DataLabelConnectorOpacity)}\" stroke-linecap=\"round\"/>");
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("line")
+            .Attribute("data-cfx-role", "data-label-connector")
+            .Attribute("data-cfx-row", rowIndex)
+            .Attribute("data-cfx-column", columnIndex)
+            .Attribute("x1", startX)
+            .Attribute("y1", y)
+            .Attribute("x2", endX)
+            .Attribute("y2", y)
+            .Attribute("stroke", DataLabelConnectorColor(chart).ToCss())
+            .Attribute("stroke-width", chart.Options.DataLabelConnectorStrokeWidth)
+            .Attribute("stroke-opacity", chart.Options.DataLabelConnectorOpacity)
+            .Attribute("stroke-linecap", "round")
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
     }
 
     private static ChartColor HeatmapColor(Chart chart, ChartColor? highColor, double value, double min, double max) {

--- a/ChartForgeX/Svg/SvgChartRenderer.Radar.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Radar.cs
@@ -27,17 +27,18 @@ public sealed partial class SvgChartRenderer {
         var cy = plot.Top + plot.Height / 2 + 6;
         var radius = Math.Max(32, Math.Min(plot.Width, plot.Height) / 2 - 42);
 
-        sb.AppendLine("<g data-cfx-role=\"radar-chart\">");
+        WriteRadarChartStart(sb);
         DrawRadarGrid(sb, chart, plot, categories, ticks, max, cx, cy, radius);
         for (var seriesOrder = 0; seriesOrder < seriesItems.Length; seriesOrder++) {
             var item = seriesItems[seriesOrder];
             var color = item.series.Color ?? chart.Options.Theme.Palette[item.index % chart.Options.Theme.Palette.Length];
             var points = RadarPoints(item.series, categories, max, cx, cy, radius);
             var summary = BuildRadarSummary(chart, item.series, categories);
-            sb.AppendLine($"<path data-cfx-role=\"radar-area\" data-cfx-series=\"{item.index}\" role=\"img\" aria-label=\"{Escape(summary)}\" d=\"{RadarPath(points)}\" fill=\"{color.ToCss()}\" opacity=\"{F(ChartVisualPrimitives.RadarAreaOpacity)}\"/>");
-            sb.AppendLine($"<path data-cfx-role=\"radar-outline\" data-cfx-series=\"{item.index}\" d=\"{RadarPath(points)}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.RadarOutlineStrokeWidth)}\" stroke-linejoin=\"round\"/>");
+            var path = RadarPath(points);
+            WriteRadarArea(sb, item.index, summary, path, color.ToCss());
+            WriteRadarOutline(sb, item.index, path, color.ToCss());
             for (var i = 0; i < points.Count; i++) {
-                sb.AppendLine($"<circle data-cfx-role=\"radar-point\" data-cfx-series=\"{item.index}\" data-cfx-point=\"{i}\" cx=\"{F(points[i].X)}\" cy=\"{F(points[i].Y)}\" r=\"{F(ChartVisualPrimitives.RadarPointRadius)}\" fill=\"{color.ToCss()}\" stroke=\"{t.CardBackground.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.RadarPointStrokeWidth)}\"/>");
+                WriteRadarPoint(sb, item.index, i, points[i], color.ToCss(), t.CardBackground.ToCss());
                 if (ShouldDrawDataLabels(chart, item.series)) {
                     var labelPoint = RadarDataLabelPoint(chart, item.series, points[i], i, categories.Length, seriesOrder, seriesItems.Length);
                     DrawDataLabel(sb, chart, FormatValue(chart, RadarValue(item.series, categories[i])), labelPoint.X, labelPoint.Y, plot, series: item.series, pointIndex: RadarPointIndex(item.series, categories[i]));
@@ -46,7 +47,7 @@ public sealed partial class SvgChartRenderer {
         }
 
         DrawLegend(sb, chart, chart.Options.Size.Width, chart.Options.Size.Height);
-        sb.AppendLine("</g>");
+        WriteRadarChartEnd(sb);
     }
 
     private static void DrawRadarGrid(StringBuilder sb, Chart chart, ChartRect plot, IReadOnlyList<double> categories, IReadOnlyList<double> ticks, double max, double cx, double cy, double radius) {
@@ -54,7 +55,7 @@ public sealed partial class SvgChartRenderer {
         foreach (var tick in ticks) {
             if (tick <= 0) continue;
             var ring = RadarRing(categories.Count, cx, cy, radius * tick / max);
-            if (chart.Options.ShowGrid) sb.AppendLine($"<path data-cfx-role=\"radar-ring\" d=\"{RadarPath(ring)}\" fill=\"none\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" opacity=\"{F(ChartVisualPrimitives.RadarRingOpacity)}\"/>");
+            if (chart.Options.ShowGrid) WriteRadarRing(sb, RadarPath(ring), t.Grid.ToCss());
             var isOuterTick = Math.Abs(tick - max) <= Math.Max(0.000001, max * 0.000001);
             if (chart.Options.ShowAxes && !isOuterTick) {
                 var label = FormatValue(chart, tick);
@@ -66,7 +67,7 @@ public sealed partial class SvgChartRenderer {
             var angle = RadarAngle(i, categories.Count);
             var endX = cx + Math.Cos(angle) * radius;
             var endY = cy + Math.Sin(angle) * radius;
-            if (chart.Options.ShowGrid) sb.AppendLine($"<line data-cfx-role=\"radar-spoke\" x1=\"{F(cx)}\" y1=\"{F(cy)}\" x2=\"{F(endX)}\" y2=\"{F(endY)}\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" opacity=\"{F(ChartVisualPrimitives.RadarSpokeOpacity)}\"/>");
+            if (chart.Options.ShowGrid) WriteRadarSpoke(sb, cx, cy, endX, endY, t.Grid.ToCss());
             if (chart.Options.ShowAxes) DrawRadarAxisLabel(sb, chart, plot, categories[i], cx + Math.Cos(angle) * (radius + 24), cy + Math.Sin(angle) * (radius + 24), angle);
         }
     }
@@ -83,7 +84,122 @@ public sealed partial class SvgChartRenderer {
         var safeY = Clamp(y, labelBounds.Top + fontSize, labelBounds.Bottom - fontSize);
         var anchor = EdgeAwareAnchor(label, safeX, labelBounds, fontSize);
         if (anchor == "middle") anchor = Math.Cos(angle) > 0.32 ? "start" : Math.Cos(angle) < -0.32 ? "end" : "middle";
-        sb.AppendLine($"<text data-cfx-role=\"radar-axis-label\" x=\"{F(safeX)}\" y=\"{F(safeY)}\" text-anchor=\"{anchor}\" dominant-baseline=\"middle\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(fontSize)}\" font-weight=\"650\">{Escape(label)}</text>");
+        WriteRadarAxisLabel(sb, label, safeX, safeY, anchor, t.MutedText.ToCss(), SvgFontFamilyAttributeValue(t.FontFamily), fontSize);
+    }
+
+    private static void WriteRadarChartStart(StringBuilder sb) {
+        var writer = new SvgMarkupWriter(128);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "radar-chart")
+            .EndStartElement()
+            .Line();
+        sb.Append(writer.ToString());
+    }
+
+    private static void WriteRadarChartEnd(StringBuilder sb) {
+        sb.AppendLine("</g>");
+    }
+
+    private static void WriteRadarArea(StringBuilder sb, int seriesIndex, string summary, string path, string fill) {
+        var writer = new SvgMarkupWriter(512);
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", "radar-area")
+            .Attribute("data-cfx-series", seriesIndex)
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .Attribute("d", path)
+            .Attribute("fill", fill)
+            .Attribute("opacity", ChartVisualPrimitives.RadarAreaOpacity)
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteRadarOutline(StringBuilder sb, int seriesIndex, string path, string stroke) {
+        var writer = new SvgMarkupWriter(512);
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", "radar-outline")
+            .Attribute("data-cfx-series", seriesIndex)
+            .Attribute("d", path)
+            .Attribute("fill", "none")
+            .Attribute("stroke", stroke)
+            .Attribute("stroke-width", ChartVisualPrimitives.RadarOutlineStrokeWidth)
+            .Attribute("stroke-linejoin", "round")
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteRadarPoint(StringBuilder sb, int seriesIndex, int pointIndex, ChartPoint point, string fill, string stroke) {
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("circle")
+            .Attribute("data-cfx-role", "radar-point")
+            .Attribute("data-cfx-series", seriesIndex)
+            .Attribute("data-cfx-point", pointIndex)
+            .Attribute("cx", point.X)
+            .Attribute("cy", point.Y)
+            .Attribute("r", ChartVisualPrimitives.RadarPointRadius)
+            .Attribute("fill", fill)
+            .Attribute("stroke", stroke)
+            .Attribute("stroke-width", ChartVisualPrimitives.RadarPointStrokeWidth)
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteRadarRing(StringBuilder sb, string path, string stroke) {
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", "radar-ring")
+            .Attribute("d", path)
+            .Attribute("fill", "none")
+            .Attribute("stroke", stroke)
+            .Attribute("stroke-width", ChartVisualPrimitives.GridStrokeWidth)
+            .Attribute("opacity", ChartVisualPrimitives.RadarRingOpacity)
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteRadarSpoke(StringBuilder sb, double cx, double cy, double endX, double endY, string stroke) {
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("line")
+            .Attribute("data-cfx-role", "radar-spoke")
+            .Attribute("x1", cx)
+            .Attribute("y1", cy)
+            .Attribute("x2", endX)
+            .Attribute("y2", endY)
+            .Attribute("stroke", stroke)
+            .Attribute("stroke-width", ChartVisualPrimitives.GridStrokeWidth)
+            .Attribute("opacity", ChartVisualPrimitives.RadarSpokeOpacity)
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
+    }
+
+    private static void WriteRadarAxisLabel(StringBuilder sb, string label, double x, double y, string anchor, string fill, string fontFamily, double fontSize) {
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "radar-axis-label")
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("text-anchor", anchor)
+            .Attribute("dominant-baseline", "middle")
+            .Attribute("fill", fill)
+            .Attribute("font-family", fontFamily)
+            .Attribute("font-size", fontSize)
+            .Attribute("font-weight", "650")
+            .Text(label)
+            .EndElement()
+            .Line();
+        sb.Append(writer.Build());
     }
 
     private static double SvgRadarLabelWidth(Chart chart, double angle) {

--- a/ChartForgeX/Svg/SvgChartRenderer.Timeline.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Timeline.cs
@@ -25,18 +25,47 @@ public sealed partial class SvgChartRenderer {
         var tickLabelWidth = Math.Max(18, plot.Width / Math.Max(1, ticks.Count - 1) - 6);
         var rowLabelWidth = Math.Max(8, plot.Left - 24);
 
-        sb.AppendLine("<g data-cfx-role=\"timeline\">");
-        DrawTimelineItemGradients(sb, id, items);
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "timeline")
+            .EndStartElement()
+            .Line();
+        DrawTimelineItemGradients(writer, id, items);
         foreach (var tick in ticks) {
             var x = ProjectTimelineX(tick, min, max, plot);
-            if (chart.Options.ShowGrid) sb.AppendLine($"<line x1=\"{F(x)}\" y1=\"{F(plot.Top)}\" x2=\"{F(x)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" opacity=\"{F(ChartVisualPrimitives.TimelineGridOpacity)}\"/>");
+            if (chart.Options.ShowGrid) {
+                writer
+                    .StartElement("line")
+                    .Attribute("x1", x)
+                    .Attribute("y1", plot.Top)
+                    .Attribute("x2", x)
+                    .Attribute("y2", plot.Bottom)
+                    .Attribute("stroke", t.Grid.ToCss())
+                    .Attribute("stroke-width", ChartVisualPrimitives.GridStrokeWidth)
+                    .Attribute("opacity", ChartVisualPrimitives.TimelineGridOpacity)
+                    .EndEmptyElement()
+                    .Line();
+            }
+
             if (chart.Options.ShowAxes) {
                 var rawLabel = FormatTimelineTick(chart, tick);
                 var labelFontSize = TextFontSizeForSvgWidth(rawLabel, tickLabelWidth, t.TickLabelFontSize);
                 var label = TrimSvgLabelToWidth(rawLabel, labelFontSize, tickLabelWidth);
                 var anchor = EdgeAwareAnchor(label, x, plot, labelFontSize);
                 var labelX = EdgeAwareTextX(label, x, plot, labelFontSize);
-                sb.AppendLine($"<text data-cfx-role=\"timeline-tick-label\" x=\"{F(labelX)}\" y=\"{F(plot.Bottom + 22)}\" text-anchor=\"{anchor}\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(labelFontSize)}\">{Escape(label)}</text>");
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "timeline-tick-label")
+                    .Attribute("x", labelX)
+                    .Attribute("y", plot.Bottom + 22)
+                    .Attribute("text-anchor", anchor)
+                    .Attribute("fill", t.MutedText.ToCss())
+                    .Attribute("font-family", TimelineFontFamily(t.FontFamily))
+                    .Attribute("font-size", labelFontSize)
+                    .Text(label)
+                    .EndElement()
+                    .Line();
             }
         }
 
@@ -49,37 +78,90 @@ public sealed partial class SvgChartRenderer {
             var width = Math.Max(2, Math.Abs(x2 - x1));
             var duration = FormatTimelineDuration(chart, item.Start, item.End);
             var summary = BuildTimelineSummary(chart, item, duration);
-            if (chart.Options.ShowGrid) sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(y + rowHeight / 2)}\" x2=\"{F(plot.Right)}\" y2=\"{F(y + rowHeight / 2)}\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" opacity=\"{F(ChartVisualPrimitives.TimelineRowGridOpacity)}\"/>");
+            if (chart.Options.ShowGrid) {
+                writer
+                    .StartElement("line")
+                    .Attribute("x1", plot.Left)
+                    .Attribute("y1", y + rowHeight / 2)
+                    .Attribute("x2", plot.Right)
+                    .Attribute("y2", y + rowHeight / 2)
+                    .Attribute("stroke", t.Grid.ToCss())
+                    .Attribute("stroke-width", ChartVisualPrimitives.GridStrokeWidth)
+                    .Attribute("opacity", ChartVisualPrimitives.TimelineRowGridOpacity)
+                    .EndEmptyElement()
+                    .Line();
+            }
+
             if (chart.Options.ShowAxes) {
                 var rowLabelFontSize = TextFontSizeForSvgWidth(item.Name, rowLabelWidth, t.TickLabelFontSize);
                 var rowLabel = TrimSvgLabelToWidth(item.Name, rowLabelFontSize, rowLabelWidth);
-                sb.AppendLine($"<text data-cfx-role=\"timeline-row-label\" x=\"{F(plot.Left - 14)}\" y=\"{F(y + rowHeight / 2)}\" text-anchor=\"end\" dominant-baseline=\"middle\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(rowLabelFontSize)}\" font-weight=\"650\">{Escape(rowLabel)}</text>");
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "timeline-row-label")
+                    .Attribute("x", plot.Left - 14)
+                    .Attribute("y", y + rowHeight / 2)
+                    .Attribute("text-anchor", "end")
+                    .Attribute("dominant-baseline", "middle")
+                    .Attribute("fill", t.MutedText.ToCss())
+                    .Attribute("font-family", TimelineFontFamily(t.FontFamily))
+                    .Attribute("font-size", rowLabelFontSize)
+                    .Attribute("font-weight", "650")
+                    .Text(rowLabel)
+                    .EndElement()
+                    .Line();
             }
-            DrawTimelineRangeBar(sb, chart, item, id, i, left, y, width, rowHeight, duration, summary);
+            DrawTimelineRangeBar(writer, chart, item, id, i, left, y, width, rowHeight, duration, summary);
             if (item.ShowDataLabels && width >= 72) {
-                DrawSvgTextCenteredX(sb, chart, "data-label", duration, left + width / 2, y + rowHeight / 2, HeatmapTextColor(item.Color), t.DataLabelFontSize, width - 6, "750");
+                DrawSvgTextCenteredX(writer, chart, "data-label", duration, left + width / 2, y + rowHeight / 2, HeatmapTextColor(item.Color), t.DataLabelFontSize, width - 6, "750");
             }
         }
 
         if (chart.Options.ShowAxes) {
-            sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(plot.Bottom)}\" x2=\"{F(plot.Right)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.AxisStrokeWidth)}\"/>");
-            DrawSvgXAxisTitle(sb, chart, plot, plot.Bottom + 49, "timeline-x-axis-title");
+            writer
+                .StartElement("line")
+                .Attribute("x1", plot.Left)
+                .Attribute("y1", plot.Bottom)
+                .Attribute("x2", plot.Right)
+                .Attribute("y2", plot.Bottom)
+                .Attribute("stroke", t.Axis.ToCss())
+                .Attribute("stroke-width", ChartVisualPrimitives.AxisStrokeWidth)
+                .EndEmptyElement()
+                .Line();
+            DrawTimelineSvgXAxisTitle(writer, chart, plot, plot.Bottom + 49, "timeline-x-axis-title");
             if (!string.IsNullOrWhiteSpace(chart.YAxisTitle)) {
                 var widestLabel = items.Max(item => EstimateTextWidth(item.Name, t.TickLabelFontSize));
                 var axisX = Math.Max(24, plot.Left - widestLabel - 46);
-                DrawSvgYAxisTitle(sb, chart, plot, axisX, "timeline-y-axis-title");
+                DrawTimelineSvgYAxisTitle(writer, chart, plot, axisX, "timeline-y-axis-title");
             }
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
-    private static void DrawTimelineItemGradients(StringBuilder sb, string id, IReadOnlyList<TimelineItem> items) {
-        sb.AppendLine("<defs>");
+    private static void DrawTimelineItemGradients(SvgMarkupWriter writer, string id, IReadOnlyList<TimelineItem> items) {
+        writer.StartElement("defs").EndStartElement().Line();
         foreach (var item in items) {
-            sb.AppendLine($"<linearGradient id=\"{id}-timelineFill{item.SeriesIndex}\" x1=\"0\" x2=\"0\" y1=\"0\" y2=\"1\"><stop offset=\"0%\" stop-color=\"{TimelineItemGradientTop(item.Color).ToHex()}\"/><stop offset=\"100%\" stop-color=\"{TimelineItemGradientBottom(item.Color).ToHex()}\"/></linearGradient>");
+            writer
+                .StartElement("linearGradient")
+                .Attribute("id", id + "-timelineFill" + item.SeriesIndex.ToString(CultureInfo.InvariantCulture))
+                .Attribute("x1", "0")
+                .Attribute("x2", "0")
+                .Attribute("y1", "0")
+                .Attribute("y2", "1")
+                .EndStartElement()
+                .StartElement("stop")
+                .Attribute("offset", "0%")
+                .Attribute("stop-color", TimelineItemGradientTop(item.Color).ToHex())
+                .EndEmptyElement()
+                .StartElement("stop")
+                .Attribute("offset", "100%")
+                .Attribute("stop-color", TimelineItemGradientBottom(item.Color).ToHex())
+                .EndEmptyElement()
+                .EndElement()
+                .Line();
         }
-        sb.AppendLine("</defs>");
+        writer.EndElement().Line();
     }
 
     private static List<TimelineItem> BuildTimelineItems(Chart chart) {
@@ -96,18 +178,123 @@ public sealed partial class SvgChartRenderer {
         return items;
     }
 
-    private static void DrawTimelineRangeBar(StringBuilder sb, Chart chart, TimelineItem item, string id, int row, double left, double y, double width, double rowHeight, string duration, string summary) {
+    private static void DrawTimelineRangeBar(SvgMarkupWriter writer, Chart chart, TimelineItem item, string id, int row, double left, double y, double width, double rowHeight, string duration, string summary) {
         var radius = Math.Min(ChartVisualPrimitives.TimelineItemCornerRadiusMax, rowHeight / 2);
         var highlightInset = Math.Min(radius, width / 3);
         var highlightEnd = left + width - highlightInset;
         var borderStroke = ChartVisualPrimitives.TimelineItemBorderStrokeWidth;
         var borderInset = borderStroke / 2.0;
-        sb.AppendLine($"<rect data-cfx-role=\"timeline-item\" data-cfx-row=\"{row}\" data-cfx-start=\"{F(item.Start)}\" data-cfx-end=\"{F(item.End)}\" data-cfx-duration=\"{Escape(duration)}\" role=\"img\" aria-label=\"{Escape(summary)}\" x=\"{F(left)}\" y=\"{F(y)}\" width=\"{F(width)}\" height=\"{F(rowHeight)}\" rx=\"{F(radius)}\" fill=\"url(#{id}-timelineFill{item.SeriesIndex})\"/>");
-        sb.AppendLine($"<rect data-cfx-role=\"timeline-item-border\" x=\"{F(left + borderInset)}\" y=\"{F(y + borderInset)}\" width=\"{F(Math.Max(0, width - borderStroke))}\" height=\"{F(Math.Max(0, rowHeight - borderStroke))}\" rx=\"{F(Math.Max(0, radius - borderInset))}\" fill=\"none\" stroke=\"{chart.Options.Theme.CardBackground.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.TimelineItemBorderOpacity)}\" stroke-width=\"{F(borderStroke)}\"/>");
+        writer
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "timeline-item")
+            .Attribute("data-cfx-row", row)
+            .Attribute("data-cfx-start", item.Start)
+            .Attribute("data-cfx-end", item.End)
+            .Attribute("data-cfx-duration", duration)
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .Attribute("x", left)
+            .Attribute("y", y)
+            .Attribute("width", width)
+            .Attribute("height", rowHeight)
+            .Attribute("rx", radius)
+            .Attribute("fill", "url(#" + id + "-timelineFill" + item.SeriesIndex.ToString(CultureInfo.InvariantCulture) + ")")
+            .EndEmptyElement()
+            .Line();
+        writer
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "timeline-item-border")
+            .Attribute("x", left + borderInset)
+            .Attribute("y", y + borderInset)
+            .Attribute("width", Math.Max(0, width - borderStroke))
+            .Attribute("height", Math.Max(0, rowHeight - borderStroke))
+            .Attribute("rx", Math.Max(0, radius - borderInset))
+            .Attribute("fill", "none")
+            .Attribute("stroke", chart.Options.Theme.CardBackground.ToCss())
+            .Attribute("stroke-opacity", ChartVisualPrimitives.TimelineItemBorderOpacity)
+            .Attribute("stroke-width", borderStroke)
+            .EndEmptyElement()
+            .Line();
         if (highlightEnd > left + highlightInset) {
-            sb.AppendLine($"<line data-cfx-role=\"timeline-item-highlight\" x1=\"{F(left + highlightInset)}\" y1=\"{F(y + ChartVisualPrimitives.TimelineItemHighlightOffsetY)}\" x2=\"{F(highlightEnd)}\" y2=\"{F(y + ChartVisualPrimitives.TimelineItemHighlightOffsetY)}\" stroke=\"#fff\" stroke-opacity=\"{F(ChartVisualPrimitives.TimelineItemHighlightOpacity)}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" stroke-linecap=\"round\"/>");
+            writer
+                .StartElement("line")
+                .Attribute("data-cfx-role", "timeline-item-highlight")
+                .Attribute("x1", left + highlightInset)
+                .Attribute("y1", y + ChartVisualPrimitives.TimelineItemHighlightOffsetY)
+                .Attribute("x2", highlightEnd)
+                .Attribute("y2", y + ChartVisualPrimitives.TimelineItemHighlightOffsetY)
+                .Attribute("stroke", "#fff")
+                .Attribute("stroke-opacity", ChartVisualPrimitives.TimelineItemHighlightOpacity)
+                .Attribute("stroke-width", ChartVisualPrimitives.GridStrokeWidth)
+                .Attribute("stroke-linecap", "round")
+                .EndEmptyElement()
+                .Line();
         }
     }
+
+    private static void DrawTimelineSvgXAxisTitle(SvgMarkupWriter writer, Chart chart, ChartRect plot, double y, string role) {
+        if (string.IsNullOrWhiteSpace(chart.XAxisTitle)) return;
+        DrawTimelineSvgTextCenteredX(writer, chart, role, chart.XAxisTitle, plot.Left + plot.Width / 2, y, chart.Options.Theme.MutedText, chart.Options.Theme.AxisTitleFontSize, plot.Width - 4, "600", middleBaseline: false, style: chart.Options.AxisTitleStyle);
+    }
+
+    private static void DrawTimelineSvgYAxisTitle(SvgMarkupWriter writer, Chart chart, ChartRect plot, double axisX, string role) {
+        if (string.IsNullOrWhiteSpace(chart.YAxisTitle)) return;
+        var t = chart.Options.Theme;
+        var maxWidth = Math.Max(40, plot.Height * 0.72);
+        var style = chart.Options.AxisTitleStyle;
+        var fontSize = TextFontSizeForSvgWidth(chart.YAxisTitle, maxWidth, StyleFontSize(style, t.AxisTitleFontSize));
+        var text = TrimSvgLabelToWidth(chart.YAxisTitle, fontSize, maxWidth);
+        if (text.Length == 0) return;
+
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", role)
+            .Attribute("transform", "translate(" + F(axisX) + " " + F(plot.Top + plot.Height / 2) + ") rotate(-90)")
+            .Attribute("text-anchor", "middle")
+            .Attribute("fill", StyleColor(style, t.MutedText).ToCss())
+            .Attribute("font-family", TimelineFontFamily(StyleFontFamily(chart, style)))
+            .Attribute("font-size", fontSize)
+            .Attribute("font-weight", StyleWeight(style, "600"));
+        WriteTimelineSvgTextStyleAttributes(writer, style);
+        writer
+            .Text(text)
+            .EndElement()
+            .Line();
+    }
+
+    private static void DrawTimelineSvgTextCenteredX(SvgMarkupWriter writer, Chart chart, string role, string text, double centerX, double y, ChartColor fill, double fontSize, double maxWidth, string fontWeight, bool middleBaseline, ChartTextStyle? style) {
+        var preferredFontSize = StyleFontSize(style, fontSize);
+        var fittedFontSize = TextFontSizeForSvgWidth(text, Math.Max(8, maxWidth), preferredFontSize);
+        var fittedText = TrimSvgLabelToWidth(text, fittedFontSize, Math.Max(8, maxWidth));
+        if (fittedText.Length == 0) return;
+
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", role)
+            .Attribute("x", centerX)
+            .Attribute("y", y)
+            .Attribute("text-anchor", "middle");
+        if (middleBaseline) writer.Attribute("dominant-baseline", "middle");
+        writer
+            .Attribute("fill", StyleColor(style, fill).ToCss())
+            .Attribute("font-family", TimelineFontFamily(StyleFontFamily(chart, style)))
+            .Attribute("font-size", fittedFontSize)
+            .Attribute("font-weight", StyleWeight(style, fontWeight));
+        WriteTimelineSvgTextStyleAttributes(writer, style);
+        writer
+            .Text(fittedText)
+            .EndElement()
+            .Line();
+    }
+
+    private static void WriteTimelineSvgTextStyleAttributes(SvgMarkupWriter writer, ChartTextStyle? style) {
+        if (style == null) return;
+        if (style.Italic) writer.Attribute("font-style", "italic");
+        if (style.Underline) writer.Attribute("text-decoration", "underline");
+    }
+
+    private static string TimelineFontFamily(string value) =>
+        string.IsNullOrWhiteSpace(value) ? "system-ui, sans-serif" : value;
 
     private static ChartRect ApplyTimelineReserve(Chart chart, ChartRect plot, IReadOnlyList<TimelineItem> items) {
         var t = chart.Options.Theme;

--- a/ChartForgeX/Svg/SvgChartRenderer.Tree.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Tree.cs
@@ -15,9 +15,14 @@ public sealed partial class SvgChartRenderer {
         if (model.Nodes.Count == 0 || model.Links.Count == 0) return;
         var t = chart.Options.Theme;
         var showLabels = chart.Series.First(series => series.Kind == ChartSeriesKind.Tree).ShowDataLabels != false;
-        sb.AppendLine("<g data-cfx-role=\"tree-chart\">");
-        DrawTreeNodeGradients(sb, chart, id);
-        foreach (var link in model.Links) DrawTreeLink(sb, chart, model, link);
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "tree-chart")
+            .EndStartElement()
+            .Line();
+        DrawTreeNodeGradients(writer, chart, id);
+        foreach (var link in model.Links) DrawTreeLink(writer, chart, model, link);
         foreach (var node in model.Nodes) {
             var fillIndex = node.Depth % Math.Max(1, t.Palette.Length);
             var summary = node.Label + ": level " + node.Depth.ToString(CultureInfo.InvariantCulture);
@@ -25,24 +30,71 @@ public sealed partial class SvgChartRenderer {
             var labelColor = HeatmapTextColor(t.Palette[fillIndex]);
             var borderStroke = ChartVisualPrimitives.TreeNodeBorderStrokeWidth;
             var borderInset = borderStroke / 2.0;
-            sb.AppendLine($"<rect data-cfx-role=\"tree-node\" data-cfx-node=\"{node.Index}\" data-cfx-depth=\"{node.Depth}\" data-cfx-label=\"{Escape(node.Label)}\" role=\"img\" aria-label=\"{Escape(summary)}\" x=\"{F(node.X)}\" y=\"{F(node.Y)}\" width=\"{F(model.NodeWidth)}\" height=\"{F(model.NodeHeight)}\" rx=\"{F(radius)}\" fill=\"url(#{id}-treeFill{fillIndex})\"/>");
-            sb.AppendLine($"<rect data-cfx-role=\"tree-node-border\" x=\"{F(node.X + borderInset)}\" y=\"{F(node.Y + borderInset)}\" width=\"{F(Math.Max(0, model.NodeWidth - borderStroke))}\" height=\"{F(Math.Max(0, model.NodeHeight - borderStroke))}\" rx=\"{F(Math.Max(0, radius - borderInset))}\" fill=\"none\" stroke=\"{TreeLabelHalo(labelColor).ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.TreeNodeBorderOpacity)}\" stroke-width=\"{F(borderStroke)}\" vector-effect=\"non-scaling-stroke\"/>");
-            if (showLabels) DrawTreeNodeLabel(sb, chart, node, model, labelColor);
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-role", "tree-node")
+                .Attribute("data-cfx-node", node.Index)
+                .Attribute("data-cfx-depth", node.Depth)
+                .Attribute("data-cfx-label", node.Label)
+                .Attribute("role", "img")
+                .Attribute("aria-label", summary)
+                .Attribute("x", node.X)
+                .Attribute("y", node.Y)
+                .Attribute("width", model.NodeWidth)
+                .Attribute("height", model.NodeHeight)
+                .Attribute("rx", radius)
+                .Attribute("fill", $"url(#{id}-treeFill{fillIndex})")
+                .EndEmptyElement()
+                .Line();
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-role", "tree-node-border")
+                .Attribute("x", node.X + borderInset)
+                .Attribute("y", node.Y + borderInset)
+                .Attribute("width", Math.Max(0, model.NodeWidth - borderStroke))
+                .Attribute("height", Math.Max(0, model.NodeHeight - borderStroke))
+                .Attribute("rx", Math.Max(0, radius - borderInset))
+                .Attribute("fill", "none")
+                .Attribute("stroke", TreeLabelHalo(labelColor).ToCss())
+                .Attribute("stroke-opacity", ChartVisualPrimitives.TreeNodeBorderOpacity)
+                .Attribute("stroke-width", borderStroke)
+                .Attribute("vector-effect", "non-scaling-stroke")
+                .EndEmptyElement()
+                .Line();
+            if (showLabels) DrawTreeNodeLabel(writer, chart, node, model, labelColor);
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
-    private static void DrawTreeNodeGradients(StringBuilder sb, Chart chart, string id) {
-        sb.AppendLine("<defs>");
+    private static void DrawTreeNodeGradients(SvgMarkupWriter writer, Chart chart, string id) {
+        writer.StartElement("defs").EndStartElement().Line();
         for (var i = 0; i < chart.Options.Theme.Palette.Length; i++) {
             var color = chart.Options.Theme.Palette[i];
-            sb.AppendLine($"<linearGradient id=\"{id}-treeFill{i}\" x1=\"0\" x2=\"0\" y1=\"0\" y2=\"1\"><stop offset=\"0%\" stop-color=\"{TreeNodeGradientTop(color).ToHex()}\"/><stop offset=\"100%\" stop-color=\"{TreeNodeGradientBottom(color).ToHex()}\"/></linearGradient>");
+            writer
+                .StartElement("linearGradient")
+                .Attribute("id", $"{id}-treeFill{i}")
+                .Attribute("x1", 0)
+                .Attribute("x2", 0)
+                .Attribute("y1", 0)
+                .Attribute("y2", 1)
+                .EndStartElement()
+                .StartElement("stop")
+                .Attribute("offset", "0%")
+                .Attribute("stop-color", TreeNodeGradientTop(color).ToHex())
+                .EndEmptyElement()
+                .StartElement("stop")
+                .Attribute("offset", "100%")
+                .Attribute("stop-color", TreeNodeGradientBottom(color).ToHex())
+                .EndEmptyElement()
+                .EndElement()
+                .Line();
         }
-        sb.AppendLine("</defs>");
+        writer.EndElement().Line();
     }
 
-    private static void DrawTreeLink(StringBuilder sb, Chart chart, TreeModel model, TreeLink link) {
+    private static void DrawTreeLink(SvgMarkupWriter writer, Chart chart, TreeModel model, TreeLink link) {
         var parent = model.Nodes[link.Parent];
         var child = model.Nodes[link.Child];
         var color = chart.Options.Theme.Palette[parent.Depth % chart.Options.Theme.Palette.Length];
@@ -53,7 +105,22 @@ public sealed partial class SvgChartRenderer {
         var gap = Math.Max(ChartVisualPrimitives.TreeLinkMinGap, (x1 - x0) / 2);
         var width = Math.Max(ChartVisualPrimitives.TreeLinkMinStrokeWidth, Math.Min(ChartVisualPrimitives.TreeLinkMaxStrokeWidth, ChartVisualPrimitives.TreeLinkMinStrokeWidth + link.Value / Math.Max(0.000001, model.MaxLinkValue) * ChartVisualPrimitives.TreeLinkStrokeWidthRange));
         var path = "M " + F(x0) + " " + F(y0) + " C " + F(x0 + gap) + " " + F(y0) + " " + F(x1 - gap) + " " + F(y1) + " " + F(x1) + " " + F(y1);
-        sb.AppendLine($"<path data-cfx-role=\"tree-link\" data-cfx-parent=\"{link.Parent}\" data-cfx-child=\"{link.Child}\" data-cfx-value=\"{F(link.Value)}\" data-cfx-parent-label=\"{Escape(parent.Label)}\" data-cfx-child-label=\"{Escape(child.Label)}\" d=\"{path}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.TreeLinkStrokeOpacity)}\" stroke-width=\"{F(width)}\" stroke-linecap=\"round\"/>");
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", "tree-link")
+            .Attribute("data-cfx-parent", link.Parent)
+            .Attribute("data-cfx-child", link.Child)
+            .Attribute("data-cfx-value", link.Value)
+            .Attribute("data-cfx-parent-label", parent.Label)
+            .Attribute("data-cfx-child-label", child.Label)
+            .Attribute("d", path)
+            .Attribute("fill", "none")
+            .Attribute("stroke", color.ToCss())
+            .Attribute("stroke-opacity", ChartVisualPrimitives.TreeLinkStrokeOpacity)
+            .Attribute("stroke-width", width)
+            .Attribute("stroke-linecap", "round")
+            .EndEmptyElement()
+            .Line();
     }
 
     private static TreeModel BuildTreeModel(Chart chart, ChartRect plot) {
@@ -129,15 +196,40 @@ public sealed partial class SvgChartRenderer {
 
     private static double TreeNodeLabelFontSize(double baseSize) => Math.Max(ChartVisualPrimitives.TreeNodeLabelMinFontSize, baseSize);
 
-    private static void DrawTreeNodeLabel(StringBuilder sb, Chart chart, TreeNode node, TreeModel model, ChartColor labelColor) {
+    private static void DrawTreeNodeLabel(SvgMarkupWriter writer, Chart chart, TreeNode node, TreeModel model, ChartColor labelColor) {
         var fontSize = TreeNodeLabelFontSize(chart.Options.Theme.TickLabelFontSize);
         var maxWidth = model.NodeWidth - ChartVisualPrimitives.TreeNodeLabelHorizontalPadding * 2;
         var lines = TreeNodeLabelLines(node.Label, fontSize, maxWidth);
         var lineHeight = fontSize * ChartVisualPrimitives.TreeNodeLabelLineHeightFactor;
         var firstY = node.Y + model.NodeHeight / 2 - (lines.Length - 1) * lineHeight / 2;
         for (var i = 0; i < lines.Length; i++) {
-            DrawSvgTextCenteredX(sb, chart, "tree-node-label", lines[i], node.X + model.NodeWidth / 2, firstY + i * lineHeight, labelColor, fontSize, maxWidth, "800", TreeLabelHalo(labelColor), ChartVisualPrimitives.TreeLabelStrokeWidth);
+            DrawTreeNodeLabelLine(writer, chart, lines[i], node.X + model.NodeWidth / 2, firstY + i * lineHeight, labelColor, fontSize, maxWidth);
         }
+    }
+
+    private static void DrawTreeNodeLabelLine(SvgMarkupWriter writer, Chart chart, string text, double centerX, double y, ChartColor labelColor, double fontSize, double maxWidth) {
+        var fittedFontSize = TextFontSizeForSvgWidth(text, Math.Max(8, maxWidth), fontSize);
+        var fittedText = TrimSvgLabelToWidth(text, fittedFontSize, Math.Max(8, maxWidth));
+        if (fittedText.Length == 0) return;
+
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "tree-node-label")
+            .Attribute("x", centerX)
+            .Attribute("y", y)
+            .Attribute("text-anchor", "middle")
+            .Attribute("dominant-baseline", "middle")
+            .Attribute("fill", labelColor.ToCss())
+            .Attribute("stroke", TreeLabelHalo(labelColor).ToCss())
+            .Attribute("stroke-width", ChartVisualPrimitives.TreeLabelStrokeWidth)
+            .Attribute("paint-order", "stroke fill")
+            .Attribute("stroke-linejoin", "round")
+            .Attribute("font-family", SvgFontFamily(chart.Options.Theme.FontFamily))
+            .Attribute("font-size", fittedFontSize)
+            .Attribute("font-weight", "800")
+            .Text(fittedText)
+            .EndElement()
+            .Line();
     }
 
     private static string[] TreeNodeLabelLines(string label, double fontSize, double maxWidth) {

--- a/ChartForgeX/Svg/SvgChartRenderer.Treemap.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Treemap.cs
@@ -22,10 +22,14 @@ public sealed partial class SvgChartRenderer {
         var tiles = ChartTreemapLayout.Compute(series, TreemapPlot(chart, basePlot));
         if (tiles.Count == 0) return;
 
-        var t = chart.Options.Theme;
         var showLabels = series.ShowDataLabels != false;
-        sb.AppendLine("<g data-cfx-role=\"treemap\">");
-        DrawTreemapTileGradients(sb, chart, id, series, seriesIndex);
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "treemap")
+            .EndStartElement()
+            .Line();
+        DrawTreemapTileGradients(writer, chart, id, series, seriesIndex);
         for (var i = 0; i < tiles.Count; i++) {
             var tile = tiles[i];
             var rect = tile.Rect;
@@ -35,41 +39,104 @@ public sealed partial class SvgChartRenderer {
             var value = FormatValue(chart, tile.Point.Y);
             var summary = label + ": " + value;
             var radius = Math.Min(ChartVisualPrimitives.TreemapTileCornerRadiusMax, Math.Min(rect.Width, rect.Height) * ChartVisualPrimitives.TreemapTileCornerRadiusFactor);
-            DrawTreemapTile(sb, chart, id, series, seriesIndex, tile.PointIndex, rect, color, radius, summary, label, tile.Point.Y);
-            if (showLabels) DrawTreemapTileLabels(sb, chart, rect, label, value, color);
+            DrawTreemapTile(writer, chart, id, series, seriesIndex, tile.PointIndex, rect, radius, summary, label, tile.Point.Y);
+            if (showLabels) DrawTreemapTileLabels(writer, chart, rect, label, value, color);
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
-    private static void DrawTreemapTileGradients(StringBuilder sb, Chart chart, string id, ChartSeries series, int seriesIndex) {
-        sb.AppendLine("<defs>");
+    private static void DrawTreemapTileGradients(SvgMarkupWriter writer, Chart chart, string id, ChartSeries series, int seriesIndex) {
+        writer.StartElement("defs").EndStartElement().Line();
         if (series.Color.HasValue) {
             var color = series.Color.Value;
-            sb.AppendLine($"<linearGradient id=\"{id}-treemapFillSeries{seriesIndex}\" x1=\"0\" x2=\"0\" y1=\"0\" y2=\"1\"><stop offset=\"0%\" stop-color=\"{TreemapTileGradientTop(color).ToHex()}\"/><stop offset=\"100%\" stop-color=\"{TreemapTileGradientBottom(color).ToHex()}\"/></linearGradient>");
+            WriteTreemapTileGradient(writer, id + "-treemapFillSeries" + seriesIndex, color);
         }
 
         for (var i = 0; i < series.PointColors.Count; i++) {
             if (!series.PointColors[i].HasValue) continue;
             var color = series.PointColors[i]!.Value;
-            sb.AppendLine($"<linearGradient id=\"{id}-treemapFillSeries{seriesIndex}Point{i}\" x1=\"0\" x2=\"0\" y1=\"0\" y2=\"1\"><stop offset=\"0%\" stop-color=\"{TreemapTileGradientTop(color).ToHex()}\"/><stop offset=\"100%\" stop-color=\"{TreemapTileGradientBottom(color).ToHex()}\"/></linearGradient>");
+            WriteTreemapTileGradient(writer, id + "-treemapFillSeries" + seriesIndex + "Point" + i, color);
         }
 
         for (var i = 0; i < chart.Options.Theme.Palette.Length; i++) {
             var color = chart.Options.Theme.Palette[i];
-            sb.AppendLine($"<linearGradient id=\"{id}-treemapFill{i}\" x1=\"0\" x2=\"0\" y1=\"0\" y2=\"1\"><stop offset=\"0%\" stop-color=\"{TreemapTileGradientTop(color).ToHex()}\"/><stop offset=\"100%\" stop-color=\"{TreemapTileGradientBottom(color).ToHex()}\"/></linearGradient>");
+            WriteTreemapTileGradient(writer, id + "-treemapFill" + i, color);
         }
-        sb.AppendLine("</defs>");
+        writer.EndElement().Line();
     }
 
-    private static void DrawTreemapTile(StringBuilder sb, Chart chart, string id, ChartSeries series, int seriesIndex, int pointIndex, ChartRect rect, ChartColor color, double radius, string summary, string label, double value) {
+    private static void WriteTreemapTileGradient(SvgMarkupWriter writer, string gradientId, ChartColor color) {
+        writer
+            .StartElement("linearGradient")
+            .Attribute("id", gradientId)
+            .Attribute("x1", "0")
+            .Attribute("x2", "0")
+            .Attribute("y1", "0")
+            .Attribute("y2", "1")
+            .EndStartElement()
+            .StartElement("stop")
+            .Attribute("offset", "0%")
+            .Attribute("stop-color", TreemapTileGradientTop(color).ToHex())
+            .EndEmptyElement()
+            .StartElement("stop")
+            .Attribute("offset", "100%")
+            .Attribute("stop-color", TreemapTileGradientBottom(color).ToHex())
+            .EndEmptyElement()
+            .EndElement()
+            .Line();
+    }
+
+    private static void DrawTreemapTile(SvgMarkupWriter writer, Chart chart, string id, ChartSeries series, int seriesIndex, int pointIndex, ChartRect rect, double radius, string summary, string label, double value) {
         var fill = TreemapTileFill(chart, series, seriesIndex, pointIndex, id);
         var highlightInset = Math.Min(radius, rect.Width / 4);
         var highlightEnd = rect.X + rect.Width - highlightInset;
-        sb.AppendLine($"<rect data-cfx-role=\"treemap-tile\" data-cfx-point=\"{pointIndex}\" data-cfx-label=\"{Escape(label)}\" data-cfx-value=\"{F(value)}\" role=\"img\" aria-label=\"{Escape(summary)}\" x=\"{F(rect.X)}\" y=\"{F(rect.Y)}\" width=\"{F(rect.Width)}\" height=\"{F(rect.Height)}\" rx=\"{F(radius)}\" fill=\"{fill}\"/>");
-        sb.AppendLine($"<rect data-cfx-role=\"treemap-tile-border\" data-cfx-point=\"{pointIndex}\" x=\"{F(rect.X + 0.5)}\" y=\"{F(rect.Y + 0.5)}\" width=\"{F(Math.Max(0, rect.Width - 1))}\" height=\"{F(Math.Max(0, rect.Height - 1))}\" rx=\"{F(Math.Max(0, radius - 0.5))}\" fill=\"none\" stroke=\"{chart.Options.Theme.CardBackground.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.TreemapTileBorderOpacity)}\" stroke-width=\"{F(ChartVisualPrimitives.TreemapTileBorderStrokeWidth)}\"/>");
+        writer
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "treemap-tile")
+            .Attribute("data-cfx-point", pointIndex)
+            .Attribute("data-cfx-label", label)
+            .Attribute("data-cfx-value", value)
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .Attribute("x", rect.X)
+            .Attribute("y", rect.Y)
+            .Attribute("width", rect.Width)
+            .Attribute("height", rect.Height)
+            .Attribute("rx", radius)
+            .Attribute("fill", fill)
+            .EndEmptyElement()
+            .Line()
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "treemap-tile-border")
+            .Attribute("data-cfx-point", pointIndex)
+            .Attribute("x", rect.X + 0.5)
+            .Attribute("y", rect.Y + 0.5)
+            .Attribute("width", Math.Max(0, rect.Width - 1))
+            .Attribute("height", Math.Max(0, rect.Height - 1))
+            .Attribute("rx", Math.Max(0, radius - 0.5))
+            .Attribute("fill", "none")
+            .Attribute("stroke", chart.Options.Theme.CardBackground.ToCss())
+            .Attribute("stroke-opacity", ChartVisualPrimitives.TreemapTileBorderOpacity)
+            .Attribute("stroke-width", ChartVisualPrimitives.TreemapTileBorderStrokeWidth)
+            .EndEmptyElement()
+            .Line();
         if (highlightEnd > rect.X + highlightInset && rect.Height > 12) {
-            sb.AppendLine($"<line data-cfx-role=\"treemap-tile-highlight\" data-cfx-point=\"{pointIndex}\" x1=\"{F(rect.X + highlightInset)}\" y1=\"{F(rect.Y + 1.35)}\" x2=\"{F(highlightEnd)}\" y2=\"{F(rect.Y + 1.35)}\" stroke=\"#fff\" stroke-opacity=\"{F(ChartVisualPrimitives.TreemapTileHighlightOpacity)}\" stroke-width=\"{F(ChartVisualPrimitives.TreemapTileHighlightStrokeWidth)}\" stroke-linecap=\"round\"/>");
+            writer
+                .StartElement("line")
+                .Attribute("data-cfx-role", "treemap-tile-highlight")
+                .Attribute("data-cfx-point", pointIndex)
+                .Attribute("x1", rect.X + highlightInset)
+                .Attribute("y1", rect.Y + 1.35)
+                .Attribute("x2", highlightEnd)
+                .Attribute("y2", rect.Y + 1.35)
+                .Attribute("stroke", "#fff")
+                .Attribute("stroke-opacity", ChartVisualPrimitives.TreemapTileHighlightOpacity)
+                .Attribute("stroke-width", ChartVisualPrimitives.TreemapTileHighlightStrokeWidth)
+                .Attribute("stroke-linecap", "round")
+                .EndEmptyElement()
+                .Line();
         }
     }
 
@@ -77,7 +144,7 @@ public sealed partial class SvgChartRenderer {
         return new ChartRect(basePlot.X + 10, basePlot.Y + 12, Math.Max(1, basePlot.Width - 20), Math.Max(1, basePlot.Height - 24));
     }
 
-    private static void DrawTreemapTileLabels(StringBuilder sb, Chart chart, ChartRect rect, string label, string value, ChartColor color) {
+    private static void DrawTreemapTileLabels(SvgMarkupWriter writer, Chart chart, ChartRect rect, string label, string value, ChartColor color) {
         if (rect.Width < 48 || rect.Height < 30) return;
         var t = chart.Options.Theme;
         var textColor = HeatmapTextColor(color);
@@ -87,7 +154,18 @@ public sealed partial class SvgChartRenderer {
         var labelFontSize = TextFontSizeForSvgWidth(label, maxWidth, Math.Min(t.LegendFontSize, Math.Max(8, rect.Height * 0.20)));
         var fittedLabel = TrimSvgLabelToWidth(label, labelFontSize, maxWidth);
         if (fittedLabel.Length > 0) {
-            sb.AppendLine($"<text data-cfx-role=\"treemap-label\" x=\"{F(rect.X + insetX)}\" y=\"{F(rect.Y + insetY + labelFontSize)}\" fill=\"{textColor.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(labelFontSize)}\" font-weight=\"800\">{Escape(fittedLabel)}</text>");
+            writer
+                .StartElement("text")
+                .Attribute("data-cfx-role", "treemap-label")
+                .Attribute("x", rect.X + insetX)
+                .Attribute("y", rect.Y + insetY + labelFontSize)
+                .Attribute("fill", textColor.ToCss())
+                .Attribute("font-family", TreemapSvgFontFamily(t.FontFamily))
+                .Attribute("font-size", labelFontSize)
+                .Attribute("font-weight", "800")
+                .Text(fittedLabel)
+                .EndElement()
+                .Line();
         }
 
         if (rect.Height < 52) return;
@@ -96,10 +174,24 @@ public sealed partial class SvgChartRenderer {
         if (fittedValue.Length > 0) {
             var valueY = rect.Y + insetY + labelFontSize + ChartVisualPrimitives.TreemapTileValueGap + valueFontSize;
             if (valueY <= rect.Bottom - insetY * 0.45) {
-                sb.AppendLine($"<text data-cfx-role=\"treemap-value\" x=\"{F(rect.X + insetX)}\" y=\"{F(valueY)}\" fill=\"{textColor.ToCss()}\" fill-opacity=\"{F(ChartVisualPrimitives.TreemapValueOpacity)}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(valueFontSize)}\" font-weight=\"700\">{Escape(fittedValue)}</text>");
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "treemap-value")
+                    .Attribute("x", rect.X + insetX)
+                    .Attribute("y", valueY)
+                    .Attribute("fill", textColor.ToCss())
+                    .Attribute("fill-opacity", ChartVisualPrimitives.TreemapValueOpacity)
+                    .Attribute("font-family", TreemapSvgFontFamily(t.FontFamily))
+                    .Attribute("font-size", valueFontSize)
+                    .Attribute("font-weight", "700")
+                    .Text(fittedValue)
+                    .EndElement()
+                    .Line();
             }
         }
     }
+
+    private static string TreemapSvgFontFamily(string value) => string.IsNullOrWhiteSpace(value) ? "system-ui, sans-serif" : value;
 
     private static bool IsTreemapChart(Chart chart) => chart.Series.Any(series => series.Kind == ChartSeriesKind.Treemap);
 


### PR DESCRIPTION
## Summary
- migrate Heatmap, Radar, Timeline, Tree, and Treemap SVG output toward SvgMarkupWriter
- preserve chart metadata, accessible summaries, labels, gradients, legends, and existing shared helper behavior
- continue the parallel batched SVG renderer migration after the prior five-renderer batch

## Validation
- dotnet build ChartForgeX.sln -c Debug -m:1 -nr:false
- dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Debug --no-build
- dotnet build ChartForgeX.Examples\ChartForgeX.Examples.csproj -c Release -m:1 -nr:false
- dotnet ChartForgeX.Examples\bin\Release\net8.0\ChartForgeX.Examples.dll
- .\Build.ps1 -Configuration Release
- git diff --check