### PR TITLE
Migrate additional SVG chart surfaces to markup writer

### DIFF
--- a/ChartForgeX/Svg/SvgChartGridRenderer.cs
+++ b/ChartForgeX/Svg/SvgChartGridRenderer.cs
@@ -34,27 +34,69 @@ public sealed class SvgChartGridRenderer {
         var theme = grid.Theme ?? grid.Charts[0].Options.Theme;
         var background = theme.Background.A == 0 ? theme.CardBackground.ToCss() : theme.Background.ToCss();
         var id = "cfx-grid-" + StableHash(idScope ?? string.Empty, grid.Title, grid.Charts.Count.ToString(CultureInfo.InvariantCulture));
-        var sb = new StringBuilder();
-        sb.AppendLine("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"" + layout.Width.ToString(CultureInfo.InvariantCulture) + "\" height=\"" + layout.Height.ToString(CultureInfo.InvariantCulture) + "\" viewBox=\"0 0 " + layout.Width.ToString(CultureInfo.InvariantCulture) + " " + layout.Height.ToString(CultureInfo.InvariantCulture) + "\" role=\"img\" aria-labelledby=\"" + id + "-title " + id + "-desc\" preserveAspectRatio=\"xMidYMid meet\" shape-rendering=\"geometricPrecision\" text-rendering=\"geometricPrecision\" style=\"max-width:100%;height:auto;display:block\">");
-        sb.AppendLine("<title id=\"" + id + "-title\">" + Escape(grid.Title.Length == 0 ? "ChartForgeX chart grid" : grid.Title) + "</title>");
-        sb.AppendLine("<desc id=\"" + id + "-desc\">" + Escape("Static chart grid containing " + grid.Charts.Count.ToString(CultureInfo.InvariantCulture) + " charts.") + "</desc>");
-        sb.AppendLine("<rect width=\"100%\" height=\"100%\" fill=\"" + background + "\"/>");
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("svg")
+            .Attribute("xmlns", "http://www.w3.org/2000/svg")
+            .Attribute("width", layout.Width)
+            .Attribute("height", layout.Height)
+            .Attribute("viewBox", "0 0 " + layout.Width.ToString(CultureInfo.InvariantCulture) + " " + layout.Height.ToString(CultureInfo.InvariantCulture))
+            .Attribute("role", "img")
+            .Attribute("aria-labelledby", id + "-title " + id + "-desc")
+            .Attribute("preserveAspectRatio", "xMidYMid meet")
+            .Attribute("shape-rendering", "geometricPrecision")
+            .Attribute("text-rendering", "geometricPrecision")
+            .Attribute("style", "max-width:100%;height:auto;display:block")
+            .EndStartElement()
+            .Line()
+            .StartElement("title")
+            .Attribute("id", id + "-title")
+            .Text(grid.Title.Length == 0 ? "ChartForgeX chart grid" : grid.Title)
+            .EndElement()
+            .Line()
+            .StartElement("desc")
+            .Attribute("id", id + "-desc")
+            .Text("Static chart grid containing " + grid.Charts.Count.ToString(CultureInfo.InvariantCulture) + " charts.")
+            .EndElement()
+            .Line()
+            .StartElement("rect")
+            .Attribute("width", "100%")
+            .Attribute("height", "100%")
+            .Attribute("fill", background)
+            .EndEmptyElement()
+            .Line();
         if (layout.HeaderHeight > 0) {
             var headerWidth = Math.Max(8, layout.Width - grid.Padding * 2);
             var titleFontSize = StyleFontSize(grid.TitleStyle, theme.TitleFontSize);
             var subtitleFontSize = StyleFontSize(grid.SubtitleStyle, theme.SubtitleFontSize);
-            if (grid.Title.Length > 0) sb.AppendLine("<text data-cfx-role=\"grid-title\" x=\"" + grid.Padding.ToString(CultureInfo.InvariantCulture) + "\" y=\"" + (grid.Padding + titleFontSize * 0.62).ToString(CultureInfo.InvariantCulture) + "\" fill=\"" + StyleColor(grid.TitleStyle, theme.Text).ToCss() + "\" font-family=\"" + Escape(StyleFontFamily(grid.TitleStyle, theme.FontFamily)) + "\" font-size=\"" + titleFontSize.ToString(CultureInfo.InvariantCulture) + "\" font-weight=\"" + Escape(StyleWeight(grid.TitleStyle, "800")) + "\"" + SvgTextStyleAttributes(grid.TitleStyle) + ">" + Escape(FitText(grid.Title, titleFontSize, headerWidth)) + "</text>");
-            if (grid.Subtitle.Length > 0) sb.AppendLine("<text data-cfx-role=\"grid-subtitle\" x=\"" + (grid.Padding + 2).ToString(CultureInfo.InvariantCulture) + "\" y=\"" + (grid.Padding + titleFontSize + subtitleFontSize).ToString(CultureInfo.InvariantCulture) + "\" fill=\"" + StyleColor(grid.SubtitleStyle, theme.MutedText).ToCss() + "\" font-family=\"" + Escape(StyleFontFamily(grid.SubtitleStyle, theme.FontFamily)) + "\" font-size=\"" + subtitleFontSize.ToString(CultureInfo.InvariantCulture) + "\" font-weight=\"" + Escape(StyleWeight(grid.SubtitleStyle, "400")) + "\"" + SvgTextStyleAttributes(grid.SubtitleStyle) + ">" + Escape(FitText(grid.Subtitle, subtitleFontSize, headerWidth)) + "</text>");
+            if (grid.Title.Length > 0) WriteGridText(writer, "grid-title", grid.Padding, grid.Padding + titleFontSize * 0.62, StyleColor(grid.TitleStyle, theme.Text).ToCss(), StyleFontFamily(grid.TitleStyle, theme.FontFamily), titleFontSize, StyleWeight(grid.TitleStyle, "800"), grid.TitleStyle, FitText(grid.Title, titleFontSize, headerWidth));
+            if (grid.Subtitle.Length > 0) WriteGridText(writer, "grid-subtitle", grid.Padding + 2, grid.Padding + titleFontSize + subtitleFontSize, StyleColor(grid.SubtitleStyle, theme.MutedText).ToCss(), StyleFontFamily(grid.SubtitleStyle, theme.FontFamily), subtitleFontSize, StyleWeight(grid.SubtitleStyle, "400"), grid.SubtitleStyle, FitText(grid.Subtitle, subtitleFontSize, headerWidth));
         }
 
         for (var i = 0; i < layout.Cells.Count; i++) {
             var cell = layout.Cells[i];
             var childSvg = _chartRenderer.Render(cell.Chart, id + "-cell-" + i.ToString(CultureInfo.InvariantCulture));
-            sb.AppendLine(PositionChildSvg(childSvg, cell.X, cell.Y, cell.Width, cell.Height));
+            writer.Raw(PositionChildSvg(childSvg, cell.X, cell.Y, cell.Width, cell.Height)).Line();
         }
 
-        sb.AppendLine("</svg>");
-        return sb.ToString();
+        writer.EndElement().Line();
+        return writer.Build();
+    }
+
+    private static void WriteGridText(SvgMarkupWriter writer, string role, double x, double y, string fill, string fontFamily, double fontSize, string fontWeight, ChartTextStyle style, string text) {
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", role)
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("fill", fill)
+            .Attribute("font-family", fontFamily)
+            .Attribute("font-size", fontSize)
+            .Attribute("font-weight", fontWeight)
+            .Raw(SvgTextStyleAttributes(style))
+            .Text(text)
+            .EndElement()
+            .Line();
     }
 
     private static string Escape(string value) => value.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");

--- a/ChartForgeX/Svg/SvgChartRenderer.CalendarHeatmap.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CalendarHeatmap.cs
@@ -48,8 +48,23 @@ public sealed partial class SvgChartRenderer {
         var endText = end.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         var containerSummary = series.Name + " calendar heatmap from " + startText + " to " + endText + " with " + filledDays.ToString(CultureInfo.InvariantCulture) + " filled days and " + emptyDays.ToString(CultureInfo.InvariantCulture) + " empty days";
 
-        sb.AppendLine($"<g data-cfx-role=\"calendar-heatmap\" data-cfx-label=\"{Escape(series.Name)}\" data-cfx-start-date=\"{startText}\" data-cfx-end-date=\"{endText}\" data-cfx-day-count=\"{totalDays}\" data-cfx-filled-day-count=\"{filledDays}\" data-cfx-empty-day-count=\"{emptyDays}\" data-cfx-min-value=\"{F(sourceMin)}\" data-cfx-max-value=\"{F(sourceMax)}\" role=\"group\" aria-label=\"{Escape(containerSummary)}\">");
-        DrawCalendarHeatmapSvgAxes(sb, chart, start, maxDate, x0, y0, cell, gap);
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "calendar-heatmap")
+            .Attribute("data-cfx-label", series.Name)
+            .Attribute("data-cfx-start-date", startText)
+            .Attribute("data-cfx-end-date", endText)
+            .Attribute("data-cfx-day-count", totalDays)
+            .Attribute("data-cfx-filled-day-count", filledDays)
+            .Attribute("data-cfx-empty-day-count", emptyDays)
+            .Attribute("data-cfx-min-value", sourceMin)
+            .Attribute("data-cfx-max-value", sourceMax)
+            .Attribute("role", "group")
+            .Attribute("aria-label", containerSummary)
+            .EndStartElement()
+            .Line();
+        DrawCalendarHeatmapSvgAxes(writer, chart, start, maxDate, x0, y0, cell, gap);
         for (var day = start; day <= end; day = day.AddDays(1)) {
             var column = (day - start).Days / 7;
             var row = (int)day.DayOfWeek;
@@ -63,20 +78,62 @@ public sealed partial class SvgChartRenderer {
             var y = y0 + row * (cell + gap);
             var dateText = day.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var summary = hasValue ? series.Name + ", " + dateText + ": " + FormatValue(chart, value) : series.Name + ", " + dateText + ": No data";
-            sb.AppendLine($"<rect class=\"cfx-interactive-region\" tabindex=\"0\" focusable=\"true\" data-cfx-role=\"calendar-heatmap-cell\" data-cfx-date=\"{dateText}\" data-cfx-week-index=\"{column}\" data-cfx-weekday-index=\"{row}\" data-cfx-value=\"{F(value)}\" data-cfx-level=\"{level}\" data-cfx-empty=\"{(!hasValue).ToString().ToLowerInvariant()}\" data-cfx-status=\"{status}\" role=\"img\" aria-label=\"{Escape(summary)}\" x=\"{F(x)}\" y=\"{F(y)}\" width=\"{F(cell)}\" height=\"{F(cell)}\" rx=\"{F(radius)}\" fill=\"{color.ToCss()}\" stroke=\"{t.CardBackground.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.HeatmapCellBorderOpacity)}\" stroke-width=\"{F(ChartVisualPrimitives.HeatmapCellBorderStrokeWidth)}\"><title>{Escape(summary)}</title></rect>");
+            writer
+                .StartElement("rect")
+                .Attribute("class", "cfx-interactive-region")
+                .Attribute("tabindex", "0")
+                .Attribute("focusable", "true")
+                .Attribute("data-cfx-role", "calendar-heatmap-cell")
+                .Attribute("data-cfx-date", dateText)
+                .Attribute("data-cfx-week-index", column)
+                .Attribute("data-cfx-weekday-index", row)
+                .Attribute("data-cfx-value", value)
+                .Attribute("data-cfx-level", level)
+                .Attribute("data-cfx-empty", !hasValue)
+                .Attribute("data-cfx-status", status)
+                .Attribute("role", "img")
+                .Attribute("aria-label", summary)
+                .Attribute("x", x)
+                .Attribute("y", y)
+                .Attribute("width", cell)
+                .Attribute("height", cell)
+                .Attribute("rx", radius)
+                .Attribute("fill", color.ToCss())
+                .Attribute("stroke", t.CardBackground.ToCss())
+                .Attribute("stroke-opacity", ChartVisualPrimitives.HeatmapCellBorderOpacity)
+                .Attribute("stroke-width", ChartVisualPrimitives.HeatmapCellBorderStrokeWidth)
+                .EndStartElement()
+                .StartElement("title")
+                .Text(summary)
+                .EndElement()
+                .EndElement()
+                .Line();
         }
 
-        if (chart.Options.ShowHeatmapScale) DrawCalendarHeatmapSvgScale(sb, chart, series, min, max, x0 + gridWidth, y0 + gridHeight + 20, cell, hasEmptyCells);
-        sb.AppendLine("</g>");
+        if (chart.Options.ShowHeatmapScale) DrawCalendarHeatmapSvgScale(writer, chart, series, min, max, x0 + gridWidth, y0 + gridHeight + 20, cell, hasEmptyCells);
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
-    private static void DrawCalendarHeatmapSvgAxes(StringBuilder sb, Chart chart, DateTime start, DateTime end, double x0, double y0, double cell, double gap) {
+    private static void DrawCalendarHeatmapSvgAxes(SvgMarkupWriter writer, Chart chart, DateTime start, DateTime end, double x0, double y0, double cell, double gap) {
         if (!chart.Options.ShowAxes) return;
         var t = chart.Options.Theme;
         var rows = new[] { (1, "Mon"), (3, "Wed"), (5, "Fri") };
         foreach (var item in rows) {
             var y = y0 + item.Item1 * (cell + gap) + cell / 2;
-            sb.AppendLine($"<text data-cfx-role=\"calendar-heatmap-weekday-label\" x=\"{F(x0 - 8)}\" y=\"{F(y)}\" text-anchor=\"end\" dominant-baseline=\"middle\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(t.TickLabelFontSize)}\">{item.Item2}</text>");
+            writer
+                .StartElement("text")
+                .Attribute("data-cfx-role", "calendar-heatmap-weekday-label")
+                .Attribute("x", x0 - 8)
+                .Attribute("y", y)
+                .Attribute("text-anchor", "end")
+                .Attribute("dominant-baseline", "middle")
+                .Attribute("fill", t.MutedText.ToCss())
+                .Attribute("font-family", SvgFontFamilyAttributeValue(t.FontFamily))
+                .Attribute("font-size", t.TickLabelFontSize)
+                .Text(item.Item2)
+                .EndElement()
+                .Line();
         }
 
         var month = new DateTime(start.Year, start.Month, 1);
@@ -86,7 +143,19 @@ public sealed partial class SvgChartRenderer {
             var column = Math.Max(0, (month - start).Days / 7);
             var x = x0 + column * (cell + gap);
             if (x - lastX >= 28) {
-                sb.AppendLine($"<text data-cfx-role=\"calendar-heatmap-month-label\" x=\"{F(x)}\" y=\"{F(y0 - 8)}\" text-anchor=\"start\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(t.TickLabelFontSize)}\" font-weight=\"650\">{month.ToString("MMM", CultureInfo.InvariantCulture)}</text>");
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "calendar-heatmap-month-label")
+                    .Attribute("x", x)
+                    .Attribute("y", y0 - 8)
+                    .Attribute("text-anchor", "start")
+                    .Attribute("fill", t.MutedText.ToCss())
+                    .Attribute("font-family", SvgFontFamilyAttributeValue(t.FontFamily))
+                    .Attribute("font-size", t.TickLabelFontSize)
+                    .Attribute("font-weight", "650")
+                    .Text(month.ToString("MMM", CultureInfo.InvariantCulture))
+                    .EndElement()
+                    .Line();
                 lastX = x;
             }
 
@@ -94,7 +163,7 @@ public sealed partial class SvgChartRenderer {
         }
     }
 
-    private static void DrawCalendarHeatmapSvgScale(StringBuilder sb, Chart chart, ChartSeries series, double min, double max, double right, double y, double cell, bool showNoData) {
+    private static void DrawCalendarHeatmapSvgScale(SvgMarkupWriter writer, Chart chart, ChartSeries series, double min, double max, double right, double y, double cell, bool showNoData) {
         var t = chart.Options.Theme;
         var size = Math.Max(7, Math.Min(12, cell));
         var gap = Math.Max(2, size * 0.28);
@@ -104,18 +173,70 @@ public sealed partial class SvgChartRenderer {
         var lessLabelX = x - 8;
         if (showNoData) {
             var noData = CalendarHeatmapEmptyColor(chart);
-            sb.AppendLine($"<rect data-cfx-role=\"calendar-heatmap-scale-no-data\" data-cfx-status=\"empty\" x=\"{F(x)}\" y=\"{F(y)}\" width=\"{F(size)}\" height=\"{F(size)}\" rx=\"{F(Math.Min(3, size * 0.22))}\" fill=\"{noData.ToCss()}\"><title>No data</title></rect>");
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-role", "calendar-heatmap-scale-no-data")
+                .Attribute("data-cfx-status", "empty")
+                .Attribute("x", x)
+                .Attribute("y", y)
+                .Attribute("width", size)
+                .Attribute("height", size)
+                .Attribute("rx", Math.Min(3, size * 0.22))
+                .Attribute("fill", noData.ToCss())
+                .EndStartElement()
+                .StartElement("title")
+                .Text("No data")
+                .EndElement()
+                .EndElement()
+                .Line();
             x += size + gap;
         }
 
-        sb.AppendLine($"<text data-cfx-role=\"calendar-heatmap-scale-label\" x=\"{F(lessLabelX)}\" y=\"{F(y + size / 2)}\" text-anchor=\"end\" dominant-baseline=\"middle\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(t.TickLabelFontSize)}\">Less</text>");
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "calendar-heatmap-scale-label")
+            .Attribute("x", lessLabelX)
+            .Attribute("y", y + size / 2)
+            .Attribute("text-anchor", "end")
+            .Attribute("dominant-baseline", "middle")
+            .Attribute("fill", t.MutedText.ToCss())
+            .Attribute("font-family", SvgFontFamilyAttributeValue(t.FontFamily))
+            .Attribute("font-size", t.TickLabelFontSize)
+            .Text("Less")
+            .EndElement()
+            .Line();
         for (var i = 0; i < 5; i++) {
             var value = min + (max - min) * (i / 4.0);
             var ratio = CalendarHeatmapRatio(value, min, max);
             var color = CalendarHeatmapColor(chart, series, null, value, min, max);
-            sb.AppendLine($"<rect data-cfx-role=\"calendar-heatmap-scale-step\" data-cfx-level=\"{i}\" data-cfx-value=\"{F(value)}\" data-cfx-status=\"{HeatmapStatus(ratio)}\" x=\"{F(x + i * (size + gap))}\" y=\"{F(y)}\" width=\"{F(size)}\" height=\"{F(size)}\" rx=\"{F(Math.Min(3, size * 0.22))}\" fill=\"{color.ToCss()}\"/>");
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-role", "calendar-heatmap-scale-step")
+                .Attribute("data-cfx-level", i)
+                .Attribute("data-cfx-value", value)
+                .Attribute("data-cfx-status", HeatmapStatus(ratio))
+                .Attribute("x", x + i * (size + gap))
+                .Attribute("y", y)
+                .Attribute("width", size)
+                .Attribute("height", size)
+                .Attribute("rx", Math.Min(3, size * 0.22))
+                .Attribute("fill", color.ToCss())
+                .EndEmptyElement()
+                .Line();
         }
-        sb.AppendLine($"<text data-cfx-role=\"calendar-heatmap-scale-label\" x=\"{F(x + width + 8)}\" y=\"{F(y + size / 2)}\" text-anchor=\"start\" dominant-baseline=\"middle\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(t.TickLabelFontSize)}\">More</text>");
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "calendar-heatmap-scale-label")
+            .Attribute("x", x + width + 8)
+            .Attribute("y", y + size / 2)
+            .Attribute("text-anchor", "start")
+            .Attribute("dominant-baseline", "middle")
+            .Attribute("fill", t.MutedText.ToCss())
+            .Attribute("font-family", SvgFontFamilyAttributeValue(t.FontFamily))
+            .Attribute("font-size", t.TickLabelFontSize)
+            .Text("More")
+            .EndElement()
+            .Line();
     }
 
     private static ChartColor CalendarHeatmapColor(Chart chart, ChartSeries series, ChartColor? pointColor, double value, double min, double max) {

--- a/ChartForgeX/Svg/SvgChartRenderer.Funnel.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Funnel.cs
@@ -30,8 +30,13 @@ public sealed partial class SvgChartRenderer {
         var gap = Math.Min(10, Math.Max(4, plot.Height / values.Length * 0.08));
         var segmentHeights = FunnelSegmentHeights(values, plot.Height, gap);
         var y = plot.Top;
-        sb.AppendLine("<g data-cfx-role=\"funnel-chart\">");
-        DrawFunnelPointGradients(sb, id, series);
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "funnel-chart")
+            .EndStartElement()
+            .Line();
+        DrawFunnelPointGradients(writer, id, series);
 
         for (var i = 0; i < values.Length; i++) {
             var segmentHeight = segmentHeights[i];
@@ -56,7 +61,24 @@ public sealed partial class SvgChartRenderer {
             var dropOff = i == 0 ? 0 : FunnelDropOff(values[i].Y, values[i - 1].Y);
             var summary = label + ": " + value + ", retained " + FormatPercent(retention);
             if (i > 0) summary += ", drop-off " + FormatPercent(dropOff);
-            sb.AppendLine($"<path data-cfx-role=\"funnel-segment\" data-cfx-point=\"{i}\" data-cfx-label=\"{Escape(label)}\" data-cfx-value=\"{F(values[i].Y)}\" data-cfx-retention=\"{F(retention)}\" data-cfx-dropoff=\"{F(dropOff)}\" role=\"img\" aria-label=\"{Escape(summary)}\" d=\"M {F(topLeft)} {F(segmentY)} L {F(topRight)} {F(segmentY)} L {F(bottomRight)} {F(segmentY + segmentDrawHeight)} L {F(bottomLeft)} {F(segmentY + segmentDrawHeight)} Z\" fill=\"{fill}\" stroke=\"{t.CardBackground.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.FunnelSegmentStrokeWidth)}\" stroke-opacity=\"{F(ChartVisualPrimitives.FunnelSegmentStrokeOpacity)}\" stroke-linejoin=\"round\"/>");
+            writer
+                .StartElement("path")
+                .Attribute("data-cfx-role", "funnel-segment")
+                .Attribute("data-cfx-point", i)
+                .Attribute("data-cfx-label", label)
+                .Attribute("data-cfx-value", values[i].Y)
+                .Attribute("data-cfx-retention", retention)
+                .Attribute("data-cfx-dropoff", dropOff)
+                .Attribute("role", "img")
+                .Attribute("aria-label", summary)
+                .Attribute("d", $"M {F(topLeft)} {F(segmentY)} L {F(topRight)} {F(segmentY)} L {F(bottomRight)} {F(segmentY + segmentDrawHeight)} L {F(bottomLeft)} {F(segmentY + segmentDrawHeight)} Z")
+                .Attribute("fill", fill)
+                .Attribute("stroke", t.CardBackground.ToCss())
+                .Attribute("stroke-width", ChartVisualPrimitives.FunnelSegmentStrokeWidth)
+                .Attribute("stroke-opacity", ChartVisualPrimitives.FunnelSegmentStrokeOpacity)
+                .Attribute("stroke-linejoin", "round")
+                .EndEmptyElement()
+                .Line();
 
             var centerX = plot.Left + plot.Width / 2;
             var centerY = segmentY + segmentDrawHeight / 2;
@@ -64,15 +86,17 @@ public sealed partial class SvgChartRenderer {
             var labelStroke = FunnelTextHalo(labelColor, t.CardBackground);
             var labelWidth = Math.Max(36, Math.Min(topWidth, bottomWidth) - 18);
             if (showLabels) {
+                var labelWriter = new StringBuilder();
                 if (values[i].Y <= 0) {
                     var zeroLabelX = topRight + 12;
                     var zeroLabelWidth = Math.Max(44, Math.Min(metricsX - zeroLabelX - 12, plot.Right - zeroLabelX));
-                    DrawSvgTextLeft(sb, chart, "funnel-label", label, zeroLabelX, centerY - 6, t.Text, t.LegendFontSize, zeroLabelWidth, "800");
-                    DrawSvgTextLeft(sb, chart, "funnel-value", value, zeroLabelX, centerY + 13, t.MutedText, t.DataLabelFontSize, zeroLabelWidth, "750");
+                    DrawSvgTextLeft(labelWriter, chart, "funnel-label", label, zeroLabelX, centerY - 6, t.Text, t.LegendFontSize, zeroLabelWidth, "800");
+                    DrawSvgTextLeft(labelWriter, chart, "funnel-value", value, zeroLabelX, centerY + 13, t.MutedText, t.DataLabelFontSize, zeroLabelWidth, "750");
                 } else {
-                    DrawSvgTextCenteredX(sb, chart, "funnel-label", label, centerX, centerY - 4, labelColor, t.LegendFontSize, labelWidth, "800", labelStroke, 1.8);
-                    DrawSvgTextCenteredX(sb, chart, "funnel-value", value, centerX, centerY + 15, labelColor, t.DataLabelFontSize, labelWidth, "750", labelStroke, 1.8);
+                    DrawSvgTextCenteredX(labelWriter, chart, "funnel-label", label, centerX, centerY - 4, labelColor, t.LegendFontSize, labelWidth, "800", labelStroke, 1.8);
+                    DrawSvgTextCenteredX(labelWriter, chart, "funnel-value", value, centerX, centerY + 15, labelColor, t.DataLabelFontSize, labelWidth, "750", labelStroke, 1.8);
                 }
+                writer.Raw(labelWriter.ToString());
             }
             if (showLabels && i > 0) {
                 var guideX = Math.Min(metricsX - 10, bottomRight + 8);
@@ -80,15 +104,30 @@ public sealed partial class SvgChartRenderer {
                 var retentionLabel = FormatPercent(retention) + " retained";
                 var dropOffLabel = FormatFunnelDropOffLabel(dropOff, values[i - 1].Y);
                 var dropOffColor = values[i - 1].Y <= 0 ? t.MutedText : t.Negative;
-                sb.AppendLine($"<line data-cfx-role=\"funnel-dropoff-line\" x1=\"{F(guideX)}\" y1=\"{F(segmentY + gap * -0.35)}\" x2=\"{F(guideX)}\" y2=\"{F(segmentY + segmentDrawHeight * 0.55)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.FunnelDropoffLineStrokeWidth)}\" stroke-dasharray=\"3 4\" opacity=\"{F(ChartVisualPrimitives.FunnelDropoffLineOpacity)}\"/>");
-                DrawSvgTextLeft(sb, chart, "funnel-retention", retentionLabel, metricsX, centerY - 3, t.MutedText, t.TickLabelFontSize, metricMaxWidth, "700");
-                DrawSvgTextLeft(sb, chart, "funnel-dropoff", dropOffLabel, metricsX, centerY + 14, dropOffColor, t.TickLabelFontSize, metricMaxWidth, "650");
+                writer
+                    .StartElement("line")
+                    .Attribute("data-cfx-role", "funnel-dropoff-line")
+                    .Attribute("x1", guideX)
+                    .Attribute("y1", segmentY + gap * -0.35)
+                    .Attribute("x2", guideX)
+                    .Attribute("y2", segmentY + segmentDrawHeight * 0.55)
+                    .Attribute("stroke", t.Axis.ToCss())
+                    .Attribute("stroke-width", ChartVisualPrimitives.FunnelDropoffLineStrokeWidth)
+                    .Attribute("stroke-dasharray", "3 4")
+                    .Attribute("opacity", ChartVisualPrimitives.FunnelDropoffLineOpacity)
+                    .EndEmptyElement()
+                    .Line();
+                var metricsWriter = new StringBuilder();
+                DrawSvgTextLeft(metricsWriter, chart, "funnel-retention", retentionLabel, metricsX, centerY - 3, t.MutedText, t.TickLabelFontSize, metricMaxWidth, "700");
+                DrawSvgTextLeft(metricsWriter, chart, "funnel-dropoff", dropOffLabel, metricsX, centerY + 14, dropOffColor, t.TickLabelFontSize, metricMaxWidth, "650");
+                writer.Raw(metricsWriter.ToString());
             }
 
             y += segmentHeight + gap;
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
     private static double[] FunnelSegmentHeights(ChartPoint[] values, double plotHeight, double gap) {
@@ -132,20 +171,39 @@ public sealed partial class SvgChartRenderer {
         baseline <= 0 ? "prev stage was 0" :
         dropOff <= 0 ? "0% from prev" : "-" + FormatPercent(dropOff) + " from prev";
 
-    private static void DrawFunnelPointGradients(StringBuilder sb, string id, ChartSeries series) {
+    private static void DrawFunnelPointGradients(SvgMarkupWriter writer, string id, ChartSeries series) {
         var wroteDefs = false;
         for (var i = 0; i < series.PointColors.Count; i++) {
             if (!series.PointColors[i].HasValue) continue;
             if (!wroteDefs) {
-                sb.AppendLine("<defs>");
+                writer.StartElement("defs").EndStartElement().Line();
                 wroteDefs = true;
             }
 
             var color = series.PointColors[i]!.Value;
-            sb.AppendLine($"<linearGradient id=\"{id}-funnelPointFill{i}\" x1=\"0\" x2=\"1\" y1=\"0\" y2=\"1\"><stop offset=\"0%\" stop-color=\"{color.ToHex()}\" stop-opacity=\"1\"/><stop offset=\"100%\" stop-color=\"{color.ToHex()}\" stop-opacity=\"0.78\"/></linearGradient>");
+            writer
+                .StartElement("linearGradient")
+                .Attribute("id", $"{id}-funnelPointFill{i}")
+                .Attribute("x1", "0")
+                .Attribute("x2", "1")
+                .Attribute("y1", "0")
+                .Attribute("y2", "1")
+                .EndStartElement()
+                .StartElement("stop")
+                .Attribute("offset", "0%")
+                .Attribute("stop-color", color.ToHex())
+                .Attribute("stop-opacity", "1")
+                .EndEmptyElement()
+                .StartElement("stop")
+                .Attribute("offset", "100%")
+                .Attribute("stop-color", color.ToHex())
+                .Attribute("stop-opacity", "0.78")
+                .EndEmptyElement()
+                .EndElement()
+                .Line();
         }
 
-        if (wroteDefs) sb.AppendLine("</defs>");
+        if (wroteDefs) writer.EndElement().Line();
     }
 
     private static ChartColor FunnelSegmentColor(Chart chart, ChartSeries series, int pointIndex) =>

--- a/ChartForgeX/Svg/SvgChartRenderer.HorizontalAxes.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.HorizontalAxes.cs
@@ -19,29 +19,45 @@ public sealed partial class SvgChartRenderer {
         for (var i = 0; i < xTicks.Count; i++) {
             var x = map.X(xTicks[i]);
             var label = TrimSvgLabelToWidth(xLabels[i], tickFontSize, xLabelMaxWidth);
-            if (o.ShowGrid) sb.AppendLine($"<line x1=\"{F(x)}\" y1=\"{F(plot.Top)}\" x2=\"{F(x)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" opacity=\"{F(ChartVisualPrimitives.HorizontalBarValueGridOpacity)}\"/>");
+            if (o.ShowGrid) WriteHorizontalAxisLine(sb, null, x, plot.Top, x, plot.Bottom, t.Grid.ToCss(), ChartVisualPrimitives.GridStrokeWidth, ChartVisualPrimitives.HorizontalBarValueGridOpacity);
             if (ShowXAxis(chart) && label.Length > 0) DrawXAxisLabel(sb, chart, plot, label, x, plot.Bottom + 21, 0, maxWidth: xLabelMaxWidth);
         }
 
         foreach (var category in categoryTicks) {
             var y = map.Y(category);
-            if (o.ShowGrid) sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(y)}\" x2=\"{F(plot.Right)}\" y2=\"{F(y)}\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" opacity=\"{F(ChartVisualPrimitives.HorizontalBarCategoryGridOpacity)}\"/>");
+            if (o.ShowGrid) WriteHorizontalAxisLine(sb, null, plot.Left, y, plot.Right, y, t.Grid.ToCss(), ChartVisualPrimitives.GridStrokeWidth, ChartVisualPrimitives.HorizontalBarCategoryGridOpacity);
             if (ShowYAxis(chart)) DrawHorizontalCategoryLabel(sb, chart, plot, FormatX(chart, category), y);
         }
 
         var zeroX = map.X(0);
         if (ShowXAxis(chart) && ShowAxisLines(chart) && zeroX > plot.Left && zeroX < plot.Right) {
-            sb.AppendLine($"<line x1=\"{F(zeroX)}\" y1=\"{F(plot.Top)}\" x2=\"{F(zeroX)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.ZeroAxisStrokeWidth)}\"/>");
+            WriteHorizontalAxisLine(sb, null, zeroX, plot.Top, zeroX, plot.Bottom, t.Axis.ToCss(), ChartVisualPrimitives.ZeroAxisStrokeWidth);
         }
 
         if (ShowXAxis(chart)) {
-            if (ShowAxisLines(chart)) sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(plot.Bottom)}\" x2=\"{F(plot.Right)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.AxisStrokeWidth)}\"/>");
+            if (ShowAxisLines(chart)) WriteHorizontalAxisLine(sb, null, plot.Left, plot.Bottom, plot.Right, plot.Bottom, t.Axis.ToCss(), ChartVisualPrimitives.AxisStrokeWidth);
             DrawSvgXAxisTitle(sb, chart, plot, plot.Bottom + XAxisTitleOffset(chart, xLabels));
         }
         if (ShowYAxis(chart)) {
-            if (ShowAxisLines(chart)) sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(plot.Top)}\" x2=\"{F(plot.Left)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.AxisStrokeWidth)}\"/>");
+            if (ShowAxisLines(chart)) WriteHorizontalAxisLine(sb, null, plot.Left, plot.Top, plot.Left, plot.Bottom, t.Axis.ToCss(), ChartVisualPrimitives.AxisStrokeWidth);
             DrawSvgYAxisTitle(sb, chart, plot, 26);
         }
+    }
+
+    private static void WriteHorizontalAxisLine(StringBuilder sb, string? role, double x1, double y1, double x2, double y2, string stroke, double strokeWidth, double? opacity = null) {
+        var writer = new SvgMarkupWriter(256);
+        writer.StartElement("line");
+        writer.Attribute("data-cfx-role", role);
+        writer
+            .Attribute("x1", x1)
+            .Attribute("y1", y1)
+            .Attribute("x2", x2)
+            .Attribute("y2", y2)
+            .Attribute("stroke", stroke)
+            .Attribute("stroke-width", strokeWidth);
+        if (opacity.HasValue) writer.Attribute("opacity", opacity.Value);
+        writer.EndEmptyElement().Line();
+        sb.Append(writer.Build());
     }
 
     private static ChartRect ApplyHorizontalBarReserve(Chart chart, ChartRect plot, IReadOnlyList<double> categoryTicks) {
@@ -74,8 +90,28 @@ public sealed partial class SvgChartRenderer {
             var lineFontSize = TextFontSizeForSvgWidth(lines[i], maxWidth, fontSize);
             var line = TrimSvgLabelToWidth(lines[i], lineFontSize, maxWidth);
             if (line.Length == 0) continue;
-            sb.AppendLine($"<text data-cfx-role=\"horizontal-category-label\" data-cfx-line=\"{i}\" x=\"{F(plot.Left - 12)}\" y=\"{F(firstBaseline + i * lineHeight)}\" text-anchor=\"end\" fill=\"{StyleColor(style, t.MutedText).ToCss()}\" font-family=\"{SvgFontFamily(StyleFontFamily(chart, style))}\" font-size=\"{F(lineFontSize)}\" font-weight=\"{StyleWeight(style, "600")}\"{SvgTextStyleAttributes(style)}>{Escape(line)}</text>");
+            WriteHorizontalCategoryLabelLine(sb, chart, style, i, plot.Left - 12, firstBaseline + i * lineHeight, StyleColor(style, t.MutedText).ToCss(), lineFontSize, line);
         }
+    }
+
+    private static void WriteHorizontalCategoryLabelLine(StringBuilder sb, Chart chart, ChartTextStyle style, int lineIndex, double x, double y, string fill, double fontSize, string label) {
+        var writer = new SvgMarkupWriter(384);
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "horizontal-category-label")
+            .Attribute("data-cfx-line", lineIndex)
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("text-anchor", "end")
+            .Attribute("fill", fill)
+            .Attribute("font-family", SvgFontFamilyAttributeValue(StyleFontFamily(chart, style)))
+            .Attribute("font-size", fontSize)
+            .Attribute("font-weight", StyleWeight(style, "600"))
+            .Raw(SvgTextStyleAttributes(style))
+            .Text(label)
+            .EndElement()
+            .Line();
+        sb.Append(writer.Build());
     }
 
     private static double SvgHorizontalCategoryWrapWidth(Chart chart) => Math.Max(90, Math.Min(230, chart.Options.Size.Width * 0.28));

--- a/ChartForgeX/Svg/SvgChartRenderer.HorizontalBar.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.HorizontalBar.cs
@@ -23,7 +23,7 @@ public sealed partial class SvgChartRenderer {
             var width = Math.Abs(valueX - baseX);
             var y = map.Y(p.X) + layout.Offset - layout.BarHeight / 2;
             var radius = chart.Options.BarMode == ChartBarMode.Stacked ? Math.Min(3, layout.BarHeight / 2) : Math.Min(7, layout.BarHeight / 2);
-            sb.AppendLine($"<rect data-cfx-role=\"horizontal-bar\" data-cfx-series=\"{index}\" data-cfx-point=\"{pointIndex}\" data-cfx-category=\"{F(p.X)}\" data-cfx-value=\"{F(p.Y)}\" data-cfx-base=\"{F(baseValue)}\" x=\"{F(left)}\" y=\"{F(y)}\" width=\"{F(width)}\" height=\"{F(layout.BarHeight)}\" rx=\"{F(radius)}\" fill=\"{BarFill(chart, s, index, pointIndex, id)}\" opacity=\"{F(ChartVisualPrimitives.BarFillOpacity)}\"/>");
+            WriteHorizontalBar(sb, index, pointIndex, p.X, p.Y, baseValue, left, y, width, layout.BarHeight, radius, BarFill(chart, s, index, pointIndex, id));
             DrawSvgBarHighlight(sb, left, y, width, layout.BarHeight);
             if (ShouldDrawDataLabels(chart, s)) {
                 var label = FormatValue(chart, p.Y);
@@ -45,6 +45,28 @@ public sealed partial class SvgChartRenderer {
                 }
             }
         }
+    }
+
+    private static void WriteHorizontalBar(StringBuilder sb, int seriesIndex, int pointIndex, double category, double value, double baseValue, double x, double y, double width, double height, double radius, string fill) {
+        var writer = new SvgMarkupWriter(512);
+        writer
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "horizontal-bar")
+            .Attribute("data-cfx-series", seriesIndex)
+            .Attribute("data-cfx-point", pointIndex)
+            .Attribute("data-cfx-category", category)
+            .Attribute("data-cfx-value", value)
+            .Attribute("data-cfx-base", baseValue)
+            .Attribute("x", x)
+            .Attribute("y", y)
+            .Attribute("width", width)
+            .Attribute("height", height)
+            .Attribute("rx", radius)
+            .Attribute("fill", fill)
+            .Attribute("opacity", ChartVisualPrimitives.BarFillOpacity)
+            .EndEmptyElement()
+            .Line();
+        sb.Append(writer.Build());
     }
 
     private static HorizontalBarLayoutInfo HorizontalBarLayout(Chart chart, ChartRect plot, int seriesIndex) {

--- a/ChartForgeX/Svg/SvgChartRenderer.Pie.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Pie.cs
@@ -31,6 +31,7 @@ public sealed partial class SvgChartRenderer {
         var start = -Math.PI / 2;
         var sliceRole = series.Kind == ChartSeriesKind.Donut ? "donut-slice" : "pie-slice";
         var outsideLabels = new List<PieLabelCandidate>();
+        var writer = new SvgMarkupWriter(4096);
 
         for (var i = 0; i < values.Length; i++) {
             var point = values[i].Point;
@@ -43,9 +44,23 @@ public sealed partial class SvgChartRenderer {
             var offset = PieSliceOffset(series, pointIndex) * radius;
             var sliceCx = cx + Math.Cos(mid) * offset;
             var sliceCy = cy + Math.Sin(mid) * offset;
-            var donutMetadata = series.Kind == ChartSeriesKind.Donut ? $" data-cfx-inner-radius-ratio=\"{F(chart.Options.DonutInnerRadiusRatio)}\"" : string.Empty;
-            var offsetMetadata = offset > 0 ? $" data-cfx-slice-offset=\"{F(PieSliceOffset(series, pointIndex))}\"" : string.Empty;
-            sb.AppendLine($"<path data-cfx-role=\"{sliceRole}\" data-cfx-point=\"{pointIndex}\" data-cfx-label=\"{Escape(label)}\" data-cfx-value=\"{F(point.Y)}\" data-cfx-percent=\"{F(percent)}\"{donutMetadata}{offsetMetadata} d=\"{BuildSlicePath(sliceCx, sliceCy, radius, inner, start, end)}\" fill=\"{PieSliceFill(chart, series, pointIndex, id)}\" fill-rule=\"evenodd\" stroke=\"{t.CardBackground.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.SliceSeparatorStrokeWidth)}\"/>");
+            writer
+                .StartElement("path")
+                .Attribute("data-cfx-role", sliceRole)
+                .Attribute("data-cfx-point", pointIndex)
+                .Attribute("data-cfx-label", label)
+                .Attribute("data-cfx-value", point.Y)
+                .Attribute("data-cfx-percent", percent);
+            if (series.Kind == ChartSeriesKind.Donut) writer.Attribute("data-cfx-inner-radius-ratio", chart.Options.DonutInnerRadiusRatio);
+            if (offset > 0) writer.Attribute("data-cfx-slice-offset", PieSliceOffset(series, pointIndex));
+            writer
+                .Attribute("d", BuildSlicePath(sliceCx, sliceCy, radius, inner, start, end))
+                .Attribute("fill", PieSliceFill(chart, series, pointIndex, id))
+                .Attribute("fill-rule", "evenodd")
+                .Attribute("stroke", t.CardBackground.ToCss())
+                .Attribute("stroke-width", ChartVisualPrimitives.SliceSeparatorStrokeWidth)
+                .EndEmptyElement()
+                .Line();
 
             if (ShouldDrawDataLabels(chart, series) && sweep > 0.22) {
                 var placement = DataLabelPlacement(chart, series);
@@ -63,11 +78,29 @@ public sealed partial class SvgChartRenderer {
                     var maxLabelWidth = Math.Max(24, radius * 1.08);
                     var fontSize = TextFontSizeForSvgWidth(sliceText, maxLabelWidth, StyleFontSize(style, t.DataLabelFontSize));
                     sliceText = TrimSvgLabelToWidth(sliceText, fontSize, maxLabelWidth);
-                    if (sliceText.Length > 0) sb.AppendLine($"<text data-cfx-role=\"data-label\" x=\"{F(x)}\" y=\"{F(y)}\" text-anchor=\"middle\" fill=\"{StyleColor(style, t.CardBackground).ToCss()}\" font-family=\"{SvgFontFamily(StyleFontFamily(chart, style))}\" font-size=\"{F(fontSize)}\" font-weight=\"{StyleWeight(style, "750")}\"{SvgTextStyleAttributes(style)}>{Escape(sliceText)}</text>");
+                    if (sliceText.Length > 0) {
+                        writer
+                            .StartElement("text")
+                            .Attribute("data-cfx-role", "data-label")
+                            .Attribute("x", x)
+                            .Attribute("y", y)
+                            .Attribute("text-anchor", "middle")
+                            .Attribute("fill", StyleColor(style, t.CardBackground).ToCss())
+                            .Attribute("font-family", SvgFontFamily(StyleFontFamily(chart, style)))
+                            .Attribute("font-size", fontSize)
+                            .Attribute("font-weight", StyleWeight(style, "750"));
+                        WritePieTextStyleAttributes(writer, style);
+                        writer
+                            .Text(sliceText)
+                            .EndElement()
+                            .Line();
+                    }
                 } else if (isSideLabel) {
                     outsideLabels.Add(new PieLabelCandidate(pointIndex, sliceText, mid, x, y - 4, sliceCx, sliceCy, isLeftSide));
                 } else {
-                    DrawPieLabelConnector(sb, chart, series, pointIndex, sliceCx, sliceCy, radius, mid, x, y - 4);
+                    DrawPieLabelConnector(writer, chart, series, pointIndex, sliceCx, sliceCy, radius, mid, x, y - 4);
+                    sb.Append(writer.Build());
+                    writer = new SvgMarkupWriter(1024);
                     DrawDataLabel(sb, chart, sliceText, x, y, plot, series: series, pointIndex: pointIndex);
                 }
             }
@@ -75,6 +108,7 @@ public sealed partial class SvgChartRenderer {
             start = end;
         }
 
+        sb.Append(writer.Build());
         DrawPieOutsideLabels(sb, chart, outsideLabels, radius, plot, series);
 
         if (series.Kind == ChartSeriesKind.Donut && chart.Options.ShowDonutCenterLabel && series.ShowDataLabels != false) {
@@ -87,8 +121,10 @@ public sealed partial class SvgChartRenderer {
             var centerGroupHeight = valueFontSize + centerLineGap + labelFontSize;
             var valueY = cy - centerGroupHeight / 2.0 + valueFontSize / 2.0;
             var labelY = valueY + valueFontSize / 2.0 + centerLineGap + labelFontSize / 2.0;
-            DrawSvgTextCenteredX(sb, chart, "donut-total-label", centerValue, cx, valueY, t.Text, valueFontSize, centerLabelWidth, "850");
-            DrawSvgTextCenteredX(sb, chart, "donut-title", centerLabel, cx, labelY, t.MutedText, labelFontSize, centerLabelWidth, "650");
+            var centerWriter = new SvgMarkupWriter(512);
+            DrawSvgTextCenteredX(centerWriter, chart, "donut-total-label", centerValue, cx, valueY, t.Text, valueFontSize, centerLabelWidth, "850");
+            DrawSvgTextCenteredX(centerWriter, chart, "donut-title", centerLabel, cx, labelY, t.MutedText, labelFontSize, centerLabelWidth, "650");
+            sb.Append(centerWriter.Build());
         }
 
         if (chart.Options.ShowLegend) DrawSliceLegend(sb, chart, series, legendValues, plot, total);
@@ -99,7 +135,13 @@ public sealed partial class SvgChartRenderer {
         var area = SliceLegendArea(chart, plot, values);
         var rows = BuildSliceLegendRows(chart, series, values, total, area.Width);
         var y = SliceLegendStartY(chart, area, rows.Count);
-        sb.AppendLine($"<g data-cfx-role=\"slice-legend\" data-cfx-position=\"{chart.Options.LegendPosition}\">");
+        var writer = new SvgMarkupWriter(2048);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "slice-legend")
+            .Attribute("data-cfx-position", chart.Options.LegendPosition.ToString())
+            .EndStartElement()
+            .Line();
         foreach (var row in rows) {
             if (y > area.Bottom - 4) break;
             var x = SliceLegendRowX(chart, area, row.Width);
@@ -110,19 +152,73 @@ public sealed partial class SvgChartRenderer {
                 var labelFontSize = TextFontSizeForSvgWidth(item.Label, labelMaxWidth, t.LegendFontSize);
                 var label = TrimSvgLabelToWidth(item.Label, labelFontSize, labelMaxWidth);
                 if (item.IsZero) {
-                    sb.AppendLine($"<rect data-cfx-role=\"slice-legend-swatch\" data-cfx-point=\"{item.PointIndex}\" data-cfx-zero=\"true\" x=\"{F(itemX)}\" y=\"{F(y - ChartVisualPrimitives.SliceLegendSwatchSize + 1)}\" width=\"{F(ChartVisualPrimitives.SliceLegendSwatchSize)}\" height=\"{F(ChartVisualPrimitives.SliceLegendSwatchSize)}\" rx=\"{F(ChartVisualPrimitives.SliceLegendSwatchRadius)}\" fill=\"{item.Color.ToCss()}\" fill-opacity=\"{F(ChartVisualPrimitives.PolarAreaZeroSlotFillOpacity)}\" stroke=\"{item.Color.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.PolarAreaZeroSlotStrokeOpacity)}\"/>");
+                    writer
+                        .StartElement("rect")
+                        .Attribute("data-cfx-role", "slice-legend-swatch")
+                        .Attribute("data-cfx-point", item.PointIndex)
+                        .Attribute("data-cfx-zero", true)
+                        .Attribute("x", itemX)
+                        .Attribute("y", y - ChartVisualPrimitives.SliceLegendSwatchSize + 1)
+                        .Attribute("width", ChartVisualPrimitives.SliceLegendSwatchSize)
+                        .Attribute("height", ChartVisualPrimitives.SliceLegendSwatchSize)
+                        .Attribute("rx", ChartVisualPrimitives.SliceLegendSwatchRadius)
+                        .Attribute("fill", item.Color.ToCss())
+                        .Attribute("fill-opacity", ChartVisualPrimitives.PolarAreaZeroSlotFillOpacity)
+                        .Attribute("stroke", item.Color.ToCss())
+                        .Attribute("stroke-opacity", ChartVisualPrimitives.PolarAreaZeroSlotStrokeOpacity)
+                        .EndEmptyElement()
+                        .Line();
                 } else {
-                    sb.AppendLine($"<rect data-cfx-role=\"slice-legend-swatch\" data-cfx-point=\"{item.PointIndex}\" x=\"{F(itemX)}\" y=\"{F(y - ChartVisualPrimitives.SliceLegendSwatchSize + 1)}\" width=\"{F(ChartVisualPrimitives.SliceLegendSwatchSize)}\" height=\"{F(ChartVisualPrimitives.SliceLegendSwatchSize)}\" rx=\"{F(ChartVisualPrimitives.SliceLegendSwatchRadius)}\" fill=\"{item.Color.ToCss()}\"/>");
+                    writer
+                        .StartElement("rect")
+                        .Attribute("data-cfx-role", "slice-legend-swatch")
+                        .Attribute("data-cfx-point", item.PointIndex)
+                        .Attribute("x", itemX)
+                        .Attribute("y", y - ChartVisualPrimitives.SliceLegendSwatchSize + 1)
+                        .Attribute("width", ChartVisualPrimitives.SliceLegendSwatchSize)
+                        .Attribute("height", ChartVisualPrimitives.SliceLegendSwatchSize)
+                        .Attribute("rx", ChartVisualPrimitives.SliceLegendSwatchRadius)
+                        .Attribute("fill", item.Color.ToCss())
+                        .EndEmptyElement()
+                        .Line();
                 }
                 var labelColor = item.IsZero ? t.MutedText : t.Text;
-                if (label.Length > 0) sb.AppendLine($"<text data-cfx-role=\"slice-legend-label\" data-cfx-point=\"{item.PointIndex}\" x=\"{F(itemX + ChartVisualPrimitives.SliceLegendSwatchSize + 6)}\" y=\"{F(y)}\" fill=\"{labelColor.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(labelFontSize)}\" font-weight=\"650\">{Escape(label)}</text>");
-                sb.AppendLine($"<text data-cfx-role=\"slice-legend-percent\" data-cfx-point=\"{item.PointIndex}\" x=\"{F(itemX + item.Width - 10)}\" y=\"{F(y)}\" text-anchor=\"end\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(t.LegendFontSize)}\">{item.Percent}</text>");
+                if (label.Length > 0) {
+                    writer
+                        .StartElement("text")
+                        .Attribute("data-cfx-role", "slice-legend-label")
+                        .Attribute("data-cfx-point", item.PointIndex)
+                        .Attribute("x", itemX + ChartVisualPrimitives.SliceLegendSwatchSize + 6)
+                        .Attribute("y", y)
+                        .Attribute("fill", labelColor.ToCss())
+                        .Attribute("font-family", SvgFontFamily(t.FontFamily))
+                        .Attribute("font-size", labelFontSize)
+                        .Attribute("font-weight", "650")
+                        .Text(label)
+                        .EndElement()
+                        .Line();
+                }
+
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "slice-legend-percent")
+                    .Attribute("data-cfx-point", item.PointIndex)
+                    .Attribute("x", itemX + item.Width - 10)
+                    .Attribute("y", y)
+                    .Attribute("text-anchor", "end")
+                    .Attribute("fill", t.MutedText.ToCss())
+                    .Attribute("font-family", SvgFontFamily(t.FontFamily))
+                    .Attribute("font-size", t.LegendFontSize)
+                    .Text(item.Percent)
+                    .EndElement()
+                    .Line();
             }
 
             y += SliceLegendRowHeight(chart);
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
     private static ChartRect PieChartPlot(Chart chart, ChartRect plot, IReadOnlyList<IndexedPieValue> values) {
@@ -246,7 +342,9 @@ public sealed partial class SvgChartRenderer {
             var maxLabelWidth = label.IsLeftSide ? label.X - plot.Left - 6 : plot.Right - label.X - 6;
             var text = TrimSvgLabelToWidth(label.Text, fontSize, Math.Max(8, maxLabelWidth));
             if (text.Length == 0) continue;
-            DrawPieLabelConnector(sb, chart, series, label.PointIndex, label.SliceCx, label.SliceCy, radius, label.Angle, label.X, label.Y);
+            var writer = new SvgMarkupWriter(256);
+            DrawPieLabelConnector(writer, chart, series, label.PointIndex, label.SliceCx, label.SliceCy, radius, label.Angle, label.X, label.Y);
+            sb.Append(writer.Build());
             DrawHorizontalValueLabel(sb, chart, text, label.X, label.Y, anchor, plot, series, label.PointIndex);
         }
     }
@@ -286,7 +384,13 @@ public sealed partial class SvgChartRenderer {
     private static ChartColor PieConnectorColor(Chart chart, ChartSeries series, int pointIndex) =>
         chart.Options.DataLabelConnectorColor ?? PieSliceColor(chart, series, pointIndex);
 
-    private static void DrawPieLabelConnector(StringBuilder sb, Chart chart, ChartSeries series, int pointIndex, double cx, double cy, double radius, double angle, double labelX, double labelY) {
+    private static void WritePieTextStyleAttributes(SvgMarkupWriter writer, ChartTextStyle? style) {
+        if (style == null) return;
+        if (style.Italic) writer.Attribute("font-style", "italic");
+        if (style.Underline) writer.Attribute("text-decoration", "underline");
+    }
+
+    private static void DrawPieLabelConnector(SvgMarkupWriter writer, Chart chart, ChartSeries series, int pointIndex, double cx, double cy, double radius, double angle, double labelX, double labelY) {
         var cos = Math.Cos(angle);
         var sin = Math.Sin(angle);
         var startX = cx + cos * radius * 1.01;
@@ -309,7 +413,20 @@ public sealed partial class SvgChartRenderer {
             d = $"M {F(startX)} {F(startY)} L {F(elbowX)} {F(elbowY)} L {F(tickStartX)} {F(labelY)} L {F(targetX)} {F(labelY)}";
         }
 
-        sb.AppendLine($"<path data-cfx-role=\"data-label-connector\" data-cfx-point=\"{pointIndex}\" data-cfx-connector-style=\"{chart.Options.DataLabelConnectorStyle}\" d=\"{d}\" fill=\"none\" stroke=\"{PieConnectorColor(chart, series, pointIndex).ToCss()}\" stroke-width=\"{F(chart.Options.DataLabelConnectorStrokeWidth)}\" stroke-opacity=\"{F(chart.Options.DataLabelConnectorOpacity)}\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>");
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", "data-label-connector")
+            .Attribute("data-cfx-point", pointIndex)
+            .Attribute("data-cfx-connector-style", chart.Options.DataLabelConnectorStyle.ToString())
+            .Attribute("d", d)
+            .Attribute("fill", "none")
+            .Attribute("stroke", PieConnectorColor(chart, series, pointIndex).ToCss())
+            .Attribute("stroke-width", chart.Options.DataLabelConnectorStrokeWidth)
+            .Attribute("stroke-opacity", chart.Options.DataLabelConnectorOpacity)
+            .Attribute("stroke-linecap", "round")
+            .Attribute("stroke-linejoin", "round")
+            .EndEmptyElement()
+            .Line();
     }
 
     private sealed class PieLabelCandidate {

--- a/ChartForgeX/Svg/SvgChartRenderer.RadialBar.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.RadialBar.cs
@@ -34,7 +34,14 @@ public sealed partial class SvgChartRenderer {
         var centerDiskRadius = Math.Max(26, outerRadius - count * (stroke + gap) - 2);
         var showLabels = series.ShowDataLabels != false;
 
-        sb.AppendLine($"<g data-cfx-role=\"radial-bar-chart\" data-cfx-radius-scale=\"{F(chart.Options.RadialBarRadiusScale)}\" data-cfx-stroke-scale=\"{F(chart.Options.RadialBarStrokeScale)}\">");
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "radial-bar-chart")
+            .Attribute("data-cfx-radius-scale", chart.Options.RadialBarRadiusScale)
+            .Attribute("data-cfx-stroke-scale", chart.Options.RadialBarStrokeScale)
+            .EndStartElement()
+            .Line();
         for (var i = 0; i < count; i++) {
             var point = series.Points[i];
             var ratio = Clamp(point.Y / 100.0, 0, 1);
@@ -46,28 +53,72 @@ public sealed partial class SvgChartRenderer {
             var summary = label + ": " + valueLabel;
             var end = start + Math.PI * 2 * ratio;
 
-            sb.AppendLine($"<path data-cfx-role=\"radial-bar-track\" data-cfx-point=\"{i}\" data-cfx-label=\"{Escape(label)}\" d=\"{BuildRadialBarArc(cx, cy, radius, start, start + Math.PI * 2)}\" fill=\"none\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(stroke)}\" stroke-linecap=\"round\" opacity=\"{F(ChartVisualPrimitives.RadialTrackOpacity)}\"/>");
+            writer
+                .StartElement("path")
+                .Attribute("data-cfx-role", "radial-bar-track")
+                .Attribute("data-cfx-point", i)
+                .Attribute("data-cfx-label", label)
+                .Attribute("d", BuildRadialBarArc(cx, cy, radius, start, start + Math.PI * 2))
+                .Attribute("fill", "none")
+                .Attribute("stroke", t.Grid.ToCss())
+                .Attribute("stroke-width", stroke)
+                .Attribute("stroke-linecap", "round")
+                .Attribute("opacity", ChartVisualPrimitives.RadialTrackOpacity)
+                .EndEmptyElement()
+                .Line();
             if (ratio > 0) {
-                sb.AppendLine($"<path data-cfx-role=\"radial-bar-ring\" data-cfx-point=\"{i}\" data-cfx-label=\"{Escape(label)}\" data-cfx-value=\"{F(point.Y)}\" data-cfx-percent=\"{F(ratio)}\" role=\"img\" aria-label=\"{Escape(summary)}\" d=\"{BuildRadialBarArc(cx, cy, radius, start, end)}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(stroke)}\" stroke-linecap=\"round\"/>");
+                writer
+                    .StartElement("path")
+                    .Attribute("data-cfx-role", "radial-bar-ring")
+                    .Attribute("data-cfx-point", i)
+                    .Attribute("data-cfx-label", label)
+                    .Attribute("data-cfx-value", point.Y)
+                    .Attribute("data-cfx-percent", ratio)
+                    .Attribute("role", "img")
+                    .Attribute("aria-label", summary)
+                    .Attribute("d", BuildRadialBarArc(cx, cy, radius, start, end))
+                    .Attribute("fill", "none")
+                    .Attribute("stroke", color.ToCss())
+                    .Attribute("stroke-width", stroke)
+                    .Attribute("stroke-linecap", "round")
+                    .EndEmptyElement()
+                    .Line();
             }
         }
 
-        sb.AppendLine($"<circle data-cfx-role=\"radial-bar-center\" cx=\"{F(cx)}\" cy=\"{F(cy)}\" r=\"{F(centerDiskRadius)}\" fill=\"{t.CardBackground.ToCss()}\" fill-opacity=\"{F(ChartVisualPrimitives.RadialCenterFillOpacity)}\" stroke=\"{t.Grid.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.RadialCenterStrokeOpacity)}\"/>");
+        writer
+            .StartElement("circle")
+            .Attribute("data-cfx-role", "radial-bar-center")
+            .Attribute("cx", cx)
+            .Attribute("cy", cy)
+            .Attribute("r", centerDiskRadius)
+            .Attribute("fill", t.CardBackground.ToCss())
+            .Attribute("fill-opacity", ChartVisualPrimitives.RadialCenterFillOpacity)
+            .Attribute("stroke", t.Grid.ToCss())
+            .Attribute("stroke-opacity", ChartVisualPrimitives.RadialCenterStrokeOpacity)
+            .EndEmptyElement()
+            .Line();
         if (showLabels && chart.Options.ShowRadialBarCenterLabel) {
-            DrawSvgTextCenteredX(sb, chart, "radial-bar-total", centerLabel, cx, cy - t.TitleFontSize * 0.42, t.Text, Math.Max(26, t.TitleFontSize * 1.32), labelWidth, "850", t.CardBackground, 3.2);
-            DrawSvgTextCenteredX(sb, chart, "radial-bar-title", series.Name, cx, cy + t.LegendFontSize + 14, t.MutedText, Math.Max(9, t.LegendFontSize - 1), labelWidth, "700", t.CardBackground, 2.4, middleBaseline: false);
+            DrawSvgTextCenteredX(writer, chart, "radial-bar-total", centerLabel, cx, cy - t.TitleFontSize * 0.42, t.Text, Math.Max(26, t.TitleFontSize * 1.32), labelWidth, "850", t.CardBackground, 3.2);
+            DrawSvgTextCenteredX(writer, chart, "radial-bar-title", series.Name, cx, cy + t.LegendFontSize + 14, t.MutedText, Math.Max(9, t.LegendFontSize - 1), labelWidth, "700", t.CardBackground, 2.4, middleBaseline: false);
         }
-        if (chart.Options.ShowLegend) DrawRadialBarLegend(sb, chart, plot, series);
-        sb.AppendLine("</g>");
+        if (chart.Options.ShowLegend) DrawRadialBarLegend(writer, chart, plot, series);
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
-    private static void DrawRadialBarLegend(StringBuilder sb, Chart chart, ChartRect plot, ChartSeries series) {
+    private static void DrawRadialBarLegend(SvgMarkupWriter writer, Chart chart, ChartRect plot, ChartSeries series) {
         var t = chart.Options.Theme;
         var fontSize = t.LegendFontSize;
         var area = RadialBarLegendArea(chart, plot, series);
         var rows = BuildRadialBarLegendRows(chart, series, area.Width);
         var y = RadialBarLegendStartY(chart, area, rows.Count);
-        sb.AppendLine($"<g data-cfx-role=\"radial-bar-legend\" data-cfx-position=\"{chart.Options.LegendPosition}\">");
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "radial-bar-legend")
+            .Attribute("data-cfx-position", chart.Options.LegendPosition.ToString())
+            .EndStartElement()
+            .Line();
         foreach (var row in rows) {
             if (y > area.Bottom - 4) break;
             var x = RadialBarLegendRowX(chart, area, row.Width);
@@ -77,15 +128,52 @@ public sealed partial class SvgChartRenderer {
                 var labelMaxWidth = Math.Max(8, item.Width - valueWidth - ChartVisualPrimitives.RadialLegendMarkerRadius * 2 - 26);
                 var labelFontSize = TextFontSizeForSvgWidth(item.Label, labelMaxWidth, fontSize);
                 var label = TrimSvgLabelToWidth(item.Label, labelFontSize, labelMaxWidth);
-                sb.AppendLine($"<circle data-cfx-role=\"radial-bar-legend-marker\" data-cfx-point=\"{item.PointIndex}\" cx=\"{F(itemX)}\" cy=\"{F(y - 4)}\" r=\"{F(ChartVisualPrimitives.RadialLegendMarkerRadius)}\" fill=\"{item.Color.ToCss()}\"/>");
-                if (label.Length > 0) sb.AppendLine($"<text data-cfx-role=\"radial-bar-legend-label\" data-cfx-point=\"{item.PointIndex}\" x=\"{F(itemX + 13)}\" y=\"{F(y)}\" fill=\"{t.Text.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(labelFontSize)}\" font-weight=\"700\">{Escape(label)}</text>");
-                sb.AppendLine($"<text data-cfx-role=\"radial-bar-legend-value\" data-cfx-point=\"{item.PointIndex}\" x=\"{F(itemX + item.Width - 10)}\" y=\"{F(y)}\" text-anchor=\"end\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(fontSize)}\" font-weight=\"700\">{Escape(item.Value)}</text>");
+                writer
+                    .StartElement("circle")
+                    .Attribute("data-cfx-role", "radial-bar-legend-marker")
+                    .Attribute("data-cfx-point", item.PointIndex)
+                    .Attribute("cx", itemX)
+                    .Attribute("cy", y - 4)
+                    .Attribute("r", ChartVisualPrimitives.RadialLegendMarkerRadius)
+                    .Attribute("fill", item.Color.ToCss())
+                    .EndEmptyElement()
+                    .Line();
+                if (label.Length > 0) {
+                    writer
+                        .StartElement("text")
+                        .Attribute("data-cfx-role", "radial-bar-legend-label")
+                        .Attribute("data-cfx-point", item.PointIndex)
+                        .Attribute("x", itemX + 13)
+                        .Attribute("y", y)
+                        .Attribute("fill", t.Text.ToCss())
+                        .Attribute("font-family", SvgFontFamily(t.FontFamily))
+                        .Attribute("font-size", labelFontSize)
+                        .Attribute("font-weight", "700")
+                        .Text(label)
+                        .EndElement()
+                        .Line();
+                }
+
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "radial-bar-legend-value")
+                    .Attribute("data-cfx-point", item.PointIndex)
+                    .Attribute("x", itemX + item.Width - 10)
+                    .Attribute("y", y)
+                    .Attribute("text-anchor", "end")
+                    .Attribute("fill", t.MutedText.ToCss())
+                    .Attribute("font-family", SvgFontFamily(t.FontFamily))
+                    .Attribute("font-size", fontSize)
+                    .Attribute("font-weight", "700")
+                    .Text(item.Value)
+                    .EndElement()
+                    .Line();
             }
 
             y += RadialBarLegendRowHeight(chart);
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
     }
 
     private static ChartRect RadialBarPlot(Chart chart, ChartRect plot, ChartSeries series) {

--- a/ChartForgeX/Svg/SvgChartRenderer.RangeArea.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.RangeArea.cs
@@ -31,14 +31,24 @@ public sealed partial class SvgChartRenderer {
         var middleLine = BuildLinePath(middlePath, false);
         var summary = series.Name + " interval area with " + lower.Count.ToString(System.Globalization.CultureInfo.InvariantCulture) + " point(s)";
 
-        sb.AppendLine($"<g data-cfx-role=\"range-area-series\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{lower.Count}\" role=\"img\" aria-label=\"{Escape(summary)}\">");
-        sb.AppendLine($"<path data-cfx-role=\"range-area\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{lower.Count}\" d=\"{BuildClosedPolygonPath(upperPath, lowerPath)}\" fill=\"url(#{id}-area{index})\" opacity=\"{F(ChartVisualPrimitives.RangeAreaFillOpacity)}\"/>");
-        sb.AppendLine($"<path data-cfx-role=\"range-area-midline\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{middle.Count}\" d=\"{middleLine}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.RangeAreaMidlineStrokeWidth)}\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-dasharray=\"{F(ChartVisualPrimitives.RangeAreaDash)} {F(ChartVisualPrimitives.RangeAreaGap)}\" opacity=\"{F(ChartVisualPrimitives.RangeAreaMidlineOpacity)}\"/>");
-        sb.AppendLine($"<path data-cfx-role=\"range-area-upper-halo\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{upper.Count}\" d=\"{upperLine}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(series.StrokeWidth + ChartVisualPrimitives.RangeAreaHaloStrokeExtra)}\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"{F(ChartVisualPrimitives.StrokeHaloOpacity)}\"/>");
-        sb.AppendLine($"<path data-cfx-role=\"range-area-lower-halo\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{lower.Count}\" d=\"{lowerLine}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(series.StrokeWidth + ChartVisualPrimitives.RangeAreaHaloStrokeExtra)}\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"{F(ChartVisualPrimitives.StrokeHaloOpacity)}\"/>");
-        sb.AppendLine($"<path data-cfx-role=\"range-area-upper\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{upper.Count}\" d=\"{upperLine}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(Math.Max(ChartVisualPrimitives.RangeAreaMinStrokeWidth, series.StrokeWidth))}\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>");
-        sb.AppendLine($"<path data-cfx-role=\"range-area-lower\" data-cfx-series=\"{index}\" data-cfx-interval-count=\"{lower.Count}\" d=\"{lowerLine}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(Math.Max(ChartVisualPrimitives.RangeAreaMinStrokeWidth, series.StrokeWidth))}\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"{F(ChartVisualPrimitives.RangeAreaLowerStrokeOpacity)}\"/>");
-        sb.AppendLine("</g>");
+        var writer = new SvgMarkupWriter(2048);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "range-area-series")
+            .Attribute("data-cfx-series", index)
+            .Attribute("data-cfx-interval-count", lower.Count)
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .EndStartElement()
+            .Line();
+        WriteRangeAreaPath(writer, "range-area", index, lower.Count, BuildClosedPolygonPath(upperPath, lowerPath), $"url(#{id}-area{index})", null, null, null);
+        WriteRangeAreaPath(writer, "range-area-midline", index, middle.Count, middleLine, "none", color.ToCss(), ChartVisualPrimitives.RangeAreaMidlineStrokeWidth, ChartVisualPrimitives.RangeAreaMidlineOpacity, true);
+        WriteRangeAreaPath(writer, "range-area-upper-halo", index, upper.Count, upperLine, "none", color.ToCss(), series.StrokeWidth + ChartVisualPrimitives.RangeAreaHaloStrokeExtra, ChartVisualPrimitives.StrokeHaloOpacity);
+        WriteRangeAreaPath(writer, "range-area-lower-halo", index, lower.Count, lowerLine, "none", color.ToCss(), series.StrokeWidth + ChartVisualPrimitives.RangeAreaHaloStrokeExtra, ChartVisualPrimitives.StrokeHaloOpacity);
+        WriteRangeAreaPath(writer, "range-area-upper", index, upper.Count, upperLine, "none", color.ToCss(), Math.Max(ChartVisualPrimitives.RangeAreaMinStrokeWidth, series.StrokeWidth), null);
+        WriteRangeAreaPath(writer, "range-area-lower", index, lower.Count, lowerLine, "none", color.ToCss(), Math.Max(ChartVisualPrimitives.RangeAreaMinStrokeWidth, series.StrokeWidth), ChartVisualPrimitives.RangeAreaLowerStrokeOpacity);
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
 
         if (!ShouldDrawDataLabels(chart, series)) return;
         var reservedLabels = new List<ChartLabelBounds>();
@@ -52,5 +62,30 @@ public sealed partial class SvgChartRenderer {
             var label = FormatValue(chart, low.Y) + "-" + FormatValue(chart, high.Y);
             DrawRangeIntervalLabel(sb, chart, series, item, plot, reservedLabels, label, x, yLow, yHigh);
         }
+    }
+
+    private static void WriteRangeAreaPath(SvgMarkupWriter writer, string role, int seriesIndex, int intervalCount, string path, string fill, string? stroke, double? strokeWidth, double? opacity, bool dashed = false) {
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", role)
+            .Attribute("data-cfx-series", seriesIndex)
+            .Attribute("data-cfx-interval-count", intervalCount)
+            .Attribute("d", path)
+            .Attribute("fill", fill);
+        if (stroke != null) {
+            writer
+                .Attribute("stroke", stroke)
+                .Attribute("stroke-width", strokeWidth.GetValueOrDefault())
+                .Attribute("stroke-linecap", "round")
+                .Attribute("stroke-linejoin", "round");
+            if (dashed) {
+                writer.Attribute("stroke-dasharray", SvgMarkupWriter.FormatNumber(ChartVisualPrimitives.RangeAreaDash) + " " + SvgMarkupWriter.FormatNumber(ChartVisualPrimitives.RangeAreaGap));
+            }
+        }
+
+        writer
+            .OptionalAttribute("opacity", opacity)
+            .EndEmptyElement()
+            .Line();
     }
 }

--- a/ChartForgeX/Svg/SvgChartRenderer.Sankey.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Sankey.cs
@@ -15,9 +15,14 @@ public sealed partial class SvgChartRenderer {
         if (model.Nodes.Count == 0 || model.Links.Count == 0) return;
         var showDataLabels = chart.Series.First(series => series.Kind == ChartSeriesKind.Sankey).ShowDataLabels ?? chart.Options.ShowDataLabels;
         var t = chart.Options.Theme;
-        sb.AppendLine("<g data-cfx-role=\"sankey-chart\">");
-        DrawSankeyNodeGradients(sb, chart, id);
-        foreach (var link in model.Links) DrawSankeyLink(sb, chart, model, link);
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "sankey-chart")
+            .EndStartElement()
+            .Line();
+        DrawSankeyNodeGradients(writer, chart, id);
+        foreach (var link in model.Links) DrawSankeyLink(writer, chart, model, link);
         foreach (var node in model.Nodes) {
             var labelMaxWidth = Math.Max(64, plot.Width / Math.Max(2, model.MaxLayer + 1) * 0.62);
             var anchor = node.Layer == model.MaxLayer ? "end" : "start";
@@ -28,8 +33,37 @@ public sealed partial class SvgChartRenderer {
             var borderStroke = ChartVisualPrimitives.SankeyNodeBorderStrokeWidth;
             var borderInset = borderStroke / 2.0;
             var radius = Math.Min(ChartVisualPrimitives.SankeyNodeCornerRadiusMax, model.NodeWidth / 2);
-            sb.AppendLine($"<rect data-cfx-role=\"sankey-node\" data-cfx-node=\"{node.Index}\" data-cfx-layer=\"{node.Layer}\" data-cfx-label=\"{Escape(node.Label)}\" data-cfx-value=\"{F(node.Value)}\" role=\"img\" aria-label=\"{Escape(summary)}\" x=\"{F(node.X)}\" y=\"{F(node.Y)}\" width=\"{F(model.NodeWidth)}\" height=\"{F(node.Height)}\" rx=\"{F(radius)}\" fill=\"url(#{id}-sankeyFill{node.Index % t.Palette.Length})\"/>");
-            sb.AppendLine($"<rect data-cfx-role=\"sankey-node-border\" x=\"{F(node.X + borderInset)}\" y=\"{F(node.Y + borderInset)}\" width=\"{F(Math.Max(0, model.NodeWidth - borderStroke))}\" height=\"{F(Math.Max(0, node.Height - borderStroke))}\" rx=\"{F(Math.Max(0, radius - borderInset))}\" fill=\"none\" stroke=\"{t.CardBackground.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.SankeyNodeBorderOpacity)}\" stroke-width=\"{F(borderStroke)}\"/>");
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-role", "sankey-node")
+                .Attribute("data-cfx-node", node.Index)
+                .Attribute("data-cfx-layer", node.Layer)
+                .Attribute("data-cfx-label", node.Label)
+                .Attribute("data-cfx-value", node.Value)
+                .Attribute("role", "img")
+                .Attribute("aria-label", summary)
+                .Attribute("x", node.X)
+                .Attribute("y", node.Y)
+                .Attribute("width", model.NodeWidth)
+                .Attribute("height", node.Height)
+                .Attribute("rx", radius)
+                .Attribute("fill", $"url(#{id}-sankeyFill{node.Index % t.Palette.Length})")
+                .EndEmptyElement()
+                .Line();
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-role", "sankey-node-border")
+                .Attribute("x", node.X + borderInset)
+                .Attribute("y", node.Y + borderInset)
+                .Attribute("width", Math.Max(0, model.NodeWidth - borderStroke))
+                .Attribute("height", Math.Max(0, node.Height - borderStroke))
+                .Attribute("rx", Math.Max(0, radius - borderInset))
+                .Attribute("fill", "none")
+                .Attribute("stroke", t.CardBackground.ToCss())
+                .Attribute("stroke-opacity", ChartVisualPrimitives.SankeyNodeBorderOpacity)
+                .Attribute("stroke-width", borderStroke)
+                .EndEmptyElement()
+                .Line();
             if (showDataLabels && label.Length > 0) {
                 var labelY = node.Y + node.Height / 2;
                 var labelWidth = EstimateTextWidth(label, labelFontSize);
@@ -37,24 +71,73 @@ public sealed partial class SvgChartRenderer {
                 var padY = ChartVisualPrimitives.SankeyLabelBackdropPaddingY;
                 var backdropX = anchor == "end" ? labelX - labelWidth - padX : labelX - padX;
                 var backdropY = labelY - labelFontSize / 2 - padY;
-                sb.AppendLine($"<rect data-cfx-role=\"sankey-node-label-backdrop\" data-cfx-node=\"{node.Index}\" x=\"{F(backdropX)}\" y=\"{F(backdropY)}\" width=\"{F(labelWidth + padX * 2)}\" height=\"{F(labelFontSize + padY * 2)}\" rx=\"{F(Math.Min(6, (labelFontSize + padY * 2) / 2))}\" fill=\"{t.CardBackground.ToCss()}\" fill-opacity=\"{F(ChartVisualPrimitives.SankeyLabelBackdropOpacity)}\" stroke=\"{t.PlotBorder.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.SankeyLabelBackdropBorderOpacity)}\"/>");
-                sb.AppendLine($"<text data-cfx-role=\"sankey-node-label\" x=\"{F(labelX)}\" y=\"{F(labelY)}\" text-anchor=\"{anchor}\" dominant-baseline=\"middle\" fill=\"{t.MutedText.ToCss()}\" stroke=\"{t.CardBackground.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.SankeyLabelStrokeWidth)}\" paint-order=\"stroke fill\" stroke-linejoin=\"round\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(labelFontSize)}\" font-weight=\"700\">{Escape(label)}</text>");
+                writer
+                    .StartElement("rect")
+                    .Attribute("data-cfx-role", "sankey-node-label-backdrop")
+                    .Attribute("data-cfx-node", node.Index)
+                    .Attribute("x", backdropX)
+                    .Attribute("y", backdropY)
+                    .Attribute("width", labelWidth + padX * 2)
+                    .Attribute("height", labelFontSize + padY * 2)
+                    .Attribute("rx", Math.Min(6, (labelFontSize + padY * 2) / 2))
+                    .Attribute("fill", t.CardBackground.ToCss())
+                    .Attribute("fill-opacity", ChartVisualPrimitives.SankeyLabelBackdropOpacity)
+                    .Attribute("stroke", t.PlotBorder.ToCss())
+                    .Attribute("stroke-opacity", ChartVisualPrimitives.SankeyLabelBackdropBorderOpacity)
+                    .EndEmptyElement()
+                    .Line();
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "sankey-node-label")
+                    .Attribute("x", labelX)
+                    .Attribute("y", labelY)
+                    .Attribute("text-anchor", anchor)
+                    .Attribute("dominant-baseline", "middle")
+                    .Attribute("fill", t.MutedText.ToCss())
+                    .Attribute("stroke", t.CardBackground.ToCss())
+                    .Attribute("stroke-width", ChartVisualPrimitives.SankeyLabelStrokeWidth)
+                    .Attribute("paint-order", "stroke fill")
+                    .Attribute("stroke-linejoin", "round")
+                    .Attribute("font-family", SvgFontFamily(t.FontFamily))
+                    .Attribute("font-size", labelFontSize)
+                    .Attribute("font-weight", "700")
+                    .Text(label)
+                    .EndElement()
+                    .Line();
             }
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
-    private static void DrawSankeyNodeGradients(StringBuilder sb, Chart chart, string id) {
-        sb.AppendLine("<defs>");
+    private static void DrawSankeyNodeGradients(SvgMarkupWriter writer, Chart chart, string id) {
+        writer.StartElement("defs").EndStartElement().Line();
         for (var i = 0; i < chart.Options.Theme.Palette.Length; i++) {
             var color = chart.Options.Theme.Palette[i];
-            sb.AppendLine($"<linearGradient id=\"{id}-sankeyFill{i}\" x1=\"0\" x2=\"0\" y1=\"0\" y2=\"1\"><stop offset=\"0%\" stop-color=\"{SankeyNodeGradientTop(color).ToHex()}\"/><stop offset=\"100%\" stop-color=\"{SankeyNodeGradientBottom(color).ToHex()}\"/></linearGradient>");
+            writer
+                .StartElement("linearGradient")
+                .Attribute("id", $"{id}-sankeyFill{i}")
+                .Attribute("x1", 0)
+                .Attribute("x2", 0)
+                .Attribute("y1", 0)
+                .Attribute("y2", 1)
+                .EndStartElement()
+                .StartElement("stop")
+                .Attribute("offset", "0%")
+                .Attribute("stop-color", SankeyNodeGradientTop(color).ToHex())
+                .EndEmptyElement()
+                .StartElement("stop")
+                .Attribute("offset", "100%")
+                .Attribute("stop-color", SankeyNodeGradientBottom(color).ToHex())
+                .EndEmptyElement()
+                .EndElement()
+                .Line();
         }
-        sb.AppendLine("</defs>");
+        writer.EndElement().Line();
     }
 
-    private static void DrawSankeyLink(StringBuilder sb, Chart chart, SankeyModel model, SankeyLink link) {
+    private static void DrawSankeyLink(SvgMarkupWriter writer, Chart chart, SankeyModel model, SankeyLink link) {
         var source = model.Nodes[link.Source];
         var target = model.Nodes[link.Target];
         var color = chart.Options.Theme.Palette[source.Index % chart.Options.Theme.Palette.Length];
@@ -67,7 +150,24 @@ public sealed partial class SvgChartRenderer {
             " L " + F(x1) + " " + F(link.TargetY + half) +
             " C " + F(midX) + " " + F(link.TargetY + half) + " " + F(midX) + " " + F(link.SourceY + half) + " " + F(x0) + " " + F(link.SourceY + half) + " Z";
         var summary = source.Label + " to " + target.Label + ": " + FormatValue(chart, link.Value);
-        sb.AppendLine($"<path data-cfx-role=\"sankey-link\" data-cfx-source=\"{link.Source}\" data-cfx-target=\"{link.Target}\" data-cfx-value=\"{F(link.Value)}\" data-cfx-source-label=\"{Escape(source.Label)}\" data-cfx-target-label=\"{Escape(target.Label)}\" role=\"img\" aria-label=\"{Escape(summary)}\" d=\"{path}\" fill=\"{color.ToCss()}\" fill-opacity=\"{F(ChartVisualPrimitives.SankeyLinkFillOpacity)}\" stroke=\"{color.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.SankeyLinkStrokeOpacity)}\" stroke-width=\"{F(ChartVisualPrimitives.SankeyLinkStrokeWidth)}\"/>");
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", "sankey-link")
+            .Attribute("data-cfx-source", link.Source)
+            .Attribute("data-cfx-target", link.Target)
+            .Attribute("data-cfx-value", link.Value)
+            .Attribute("data-cfx-source-label", source.Label)
+            .Attribute("data-cfx-target-label", target.Label)
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .Attribute("d", path)
+            .Attribute("fill", color.ToCss())
+            .Attribute("fill-opacity", ChartVisualPrimitives.SankeyLinkFillOpacity)
+            .Attribute("stroke", color.ToCss())
+            .Attribute("stroke-opacity", ChartVisualPrimitives.SankeyLinkStrokeOpacity)
+            .Attribute("stroke-width", ChartVisualPrimitives.SankeyLinkStrokeWidth)
+            .EndEmptyElement()
+            .Line();
     }
 
     private static SankeyModel BuildSankeyModel(Chart chart, ChartRect plot) {

--- a/ChartForgeX/Svg/SvgMarkupWriter.cs
+++ b/ChartForgeX/Svg/SvgMarkupWriter.cs
@@ -180,9 +180,6 @@ internal sealed class SvgMarkupWriter {
                 case '"' when escapeQuotes:
                     builder.Append("&quot;");
                     break;
-                case '\'' when escapeQuotes:
-                    builder.Append("&#39;");
-                    break;
                 default:
                     builder.Append(ch);
                     break;


### PR DESCRIPTION
## Summary

- Migrates additional SVG chart surfaces to `SvgMarkupWriter`: Pie/Donut, RadialBar, Funnel, RangeArea, CalendarHeatmap, Sankey, HorizontalBar, horizontal axes, and the SVG grid shell.
- Preserves existing metadata order, native titles/descriptions, labels, legends, scale behavior, and renderer-specific accessibility output while reducing direct string markup appends.
- Keeps apostrophes literal in writer attributes so existing double-quoted font-family stacks remain compatible with previous SVG output.

## Validation

- `git diff --check`
- `dotnet build ChartForgeX.sln -c Debug -m:1 -nr:false`
- `dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Debug --no-build` - passed, 242/242
- `dotnet build ChartForgeX.Examples\ChartForgeX.Examples.csproj -c Release -m:1 -nr:false`
- `dotnet ChartForgeX.Examples\bin\Release\net8.0\ChartForgeX.Examples.dll`
- `.\Build.ps1 -Configuration Release` - passed, including release tests, examples generation, and package creation
- `git diff --cached --check`
