### PR TITLE
Add ChartForgeX color tokens and overlay theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added explicit SVG ID scope overloads for deterministic raw SVG embedding.
 - Added expressive built-in themes, CSS font stack presets, and fluent theme/palette customization helpers.
 - Added reusable brand kits and curated brand-kit presets for executive, product, people-infographic, editorial, and accessible report styles.
+- Added named `ChartColors`, stable CSS/System.Drawing web color lookup, alpha/opacity helpers, a command-center palette, and a transparent dark overlay theme for charts rendered over imagery or wallpapers.
 - Added sunburst partition charts for nested hierarchy composition.
 - Added pictorial charts with built-in repeated symbol rows, configurable columns/max scale, true partial symbol fills, value-per-symbol Isotype scaling with wrapped icon rows, optional value labels, symbol scale/empty-opacity controls, per-item colors, and custom SVG path symbols with PNG fallback shapes.
 - Added slider-style progress-bar charts for infographic controls and compact survey scorecards, with handle visibility, thickness, and track-opacity controls.

--- a/ChartForgeX.Tests/SmokeTests/CoreRenderingTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/CoreRenderingTests.cs
@@ -364,15 +364,25 @@ internal static partial class SmokeTests {
         theme.Palette = palette;
         palette[0] = ChartColor.White;
         Assert(theme.Palette[0].R == ChartColor.Black.R && theme.Palette[0].G == ChartColor.Black.G && theme.Palette[0].B == ChartColor.Black.B, "Themes should snapshot assigned palettes instead of retaining caller-owned arrays.");
+        Assert(ChartColors.Emerald400.WithAlpha(172).A == 172, "Named chart colors should support explicit alpha values.");
+        Assert(ChartColors.Emerald400.WithOpacity(0.5).A == 128, "Named chart colors should support opacity helpers.");
+        Assert(ChartColors.Emerald400.WithAlpha(172).ToHexRgba() == "#34D399AC", "Named chart colors should round-trip to RGBA hex.");
+        Assert(ChartColors.GetNamedColors().Count >= 142, "ChartForgeX should expose the stable System.Drawing/CSS named color set.");
+        Assert(ChartColors.TryGet("RebeccaPurple", out var rebecca) && rebecca.ToHex() == "#663399", "Named color lookup should include modern CSS colors.");
+        Assert(ChartColor.Parse("DarkSlateGrey").ToHex() == ChartColors.DarkSlateGray.ToHex(), "Named color parsing should support grey aliases.");
+        Assert(ChartColor.Parse("#34D399").ToHex() == ChartColors.Emerald400.ToHex(), "Color parsing should keep hex support.");
         var pastel = ChartPalettes.Pastel;
         pastel[0] = ChartColor.Black;
         Assert(ChartPalettes.Pastel[0].R != ChartColor.Black.R || ChartPalettes.Pastel[0].G != ChartColor.Black.G || ChartPalettes.Pastel[0].B != ChartColor.Black.B, "Palette presets should return fresh arrays so callers can mutate local copies safely.");
-        foreach (var namedTheme in new[] { ChartTheme.Colorblind(), ChartTheme.Aurora(), ChartTheme.Editorial(), ChartTheme.Candy(), ChartTheme.Terminal(), ChartTheme.Minimal() }) {
+        var overlayTheme = ChartTheme.TransparentOverlayDark();
+        Assert(overlayTheme.Background.A == 0 && overlayTheme.CardBackground.A > 0 && overlayTheme.CardBackground.A < 255, "Transparent overlay themes should keep the chart background clear and use a translucent card.");
+        Assert(overlayTheme.Palette.Length >= 8, "Transparent overlay themes should expose a broad operational palette.");
+        foreach (var namedTheme in new[] { ChartTheme.Colorblind(), ChartTheme.Aurora(), ChartTheme.Editorial(), ChartTheme.Candy(), ChartTheme.Terminal(), ChartTheme.TransparentOverlayDark(), ChartTheme.Minimal() }) {
             Assert(namedTheme.Palette.Length >= 8, "Built-in style themes should provide broad qualitative palettes.");
             Assert(namedTheme.FontFamily.Length > 0, "Built-in style themes should define a font stack.");
             Assert(namedTheme.Text.A > 0 && namedTheme.MutedText.A > 0 && namedTheme.Grid.A > 0, "Built-in style themes should define core visual tokens.");
         }
-        foreach (var preset in new[] { ChartPalettes.Report, ChartPalettes.Colorblind, ChartPalettes.Vivid, ChartPalettes.Pastel, ChartPalettes.Editorial, ChartPalettes.Jewel, ChartPalettes.Terminal }) {
+        foreach (var preset in new[] { ChartPalettes.Report, ChartPalettes.Colorblind, ChartPalettes.Vivid, ChartPalettes.Pastel, ChartPalettes.Editorial, ChartPalettes.Jewel, ChartPalettes.Terminal, ChartPalettes.CommandCenter }) {
             Assert(preset.Length >= 8, "Reusable palette presets should provide enough colors for multi-series charts.");
         }
     }

--- a/ChartForgeX.Tests/SmokeTests/CoreRenderingTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/CoreRenderingTests.cs
@@ -370,6 +370,11 @@ internal static partial class SmokeTests {
         Assert(ChartColors.GetNamedColors().Count >= 142, "ChartForgeX should expose the stable System.Drawing/CSS named color set.");
         Assert(ChartColors.TryGet("RebeccaPurple", out var rebecca) && rebecca.ToHex() == "#663399", "Named color lookup should include modern CSS colors.");
         Assert(ChartColor.Parse("DarkSlateGrey").ToHex() == ChartColors.DarkSlateGray.ToHex(), "Named color parsing should support grey aliases.");
+        Assert(ChartColors.TryGet("Slate950", out var slate) && slate.ToHex() == ChartColors.Slate950.ToHex(), "Named color lookup should include ChartForgeX design tokens.");
+        Assert(ChartColor.Parse("emerald400").ToHex() == ChartColors.Emerald400.ToHex(), "Named color parsing should support ChartForgeX design tokens.");
+        Assert(ChartColors.GetTokenColors().Count >= 29, "ChartForgeX should expose its design token color set.");
+        var tokenPalette = ChartPalettes.FromHex("Slate950", "Blue400", "Emerald400");
+        Assert(tokenPalette[0].ToHex() == ChartColors.Slate950.ToHex() && tokenPalette[2].ToHex() == ChartColors.Emerald400.ToHex(), "Palette parsing should accept ChartForgeX design token names.");
         Assert(ChartColor.Parse("#34D399").ToHex() == ChartColors.Emerald400.ToHex(), "Color parsing should keep hex support.");
         var pastel = ChartPalettes.Pastel;
         pastel[0] = ChartColor.Black;

--- a/ChartForgeX/Primitives/ChartColor.cs
+++ b/ChartForgeX/Primitives/ChartColor.cs
@@ -56,6 +56,23 @@ public readonly struct ChartColor {
     public static ChartColor FromRgba(byte r, byte g, byte b, byte a) => new(r, g, b, a);
 
     /// <summary>
+    /// Creates a copy of this color with a different alpha channel.
+    /// </summary>
+    /// <param name="alpha">The alpha channel.</param>
+    /// <returns>A chart color with the requested alpha channel.</returns>
+    public ChartColor WithAlpha(byte alpha) => new(R, G, B, alpha);
+
+    /// <summary>
+    /// Creates a copy of this color with opacity expressed as a unit interval.
+    /// </summary>
+    /// <param name="opacity">The opacity from zero to one.</param>
+    /// <returns>A chart color with the requested opacity.</returns>
+    public ChartColor WithOpacity(double opacity) {
+        if (double.IsNaN(opacity) || double.IsInfinity(opacity) || opacity < 0 || opacity > 1) throw new ArgumentOutOfRangeException(nameof(opacity), opacity, "Opacity must be between zero and one.");
+        return WithAlpha((byte)Math.Round(opacity * 255));
+    }
+
+    /// <summary>
     /// Creates a color from #RGB, #RGBA, #RRGGBB, or #RRGGBBAA notation.
     /// </summary>
     /// <param name="hex">The hexadecimal color string.</param>
@@ -84,10 +101,45 @@ public readonly struct ChartColor {
     }
 
     /// <summary>
+    /// Parses a named color or a hexadecimal color string.
+    /// </summary>
+    /// <param name="value">The named color or hexadecimal color string.</param>
+    /// <returns>A chart color.</returns>
+    public static ChartColor Parse(string value) {
+        if (TryParse(value, out var color)) return color;
+        throw new ArgumentException("Color must be a known ChartForgeX color name or use #RGB, #RGBA, #RRGGBB, or #RRGGBBAA notation.", nameof(value));
+    }
+
+    /// <summary>
+    /// Attempts to parse a named color or a hexadecimal color string.
+    /// </summary>
+    /// <param name="value">The named color or hexadecimal color string.</param>
+    /// <param name="color">The parsed chart color.</param>
+    /// <returns>True when parsing succeeds.</returns>
+    public static bool TryParse(string? value, out ChartColor color) {
+        color = default;
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        var trimmed = value!.Trim();
+        if (ChartColors.TryGet(trimmed, out color)) return true;
+        try {
+            color = FromHex(trimmed);
+            return true;
+        } catch (ArgumentException) {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Converts the color to a hexadecimal RGB string.
     /// </summary>
     /// <returns>A CSS-compatible hexadecimal color string.</returns>
     public string ToHex() => $"#{R:X2}{G:X2}{B:X2}";
+
+    /// <summary>
+    /// Converts the color to a hexadecimal RGBA string.
+    /// </summary>
+    /// <returns>A CSS-compatible hexadecimal color string with alpha.</returns>
+    public string ToHexRgba() => $"#{R:X2}{G:X2}{B:X2}{A:X2}";
 
     /// <summary>
     /// Converts the color to a CSS color string.

--- a/ChartForgeX/Primitives/ChartColors.cs
+++ b/ChartForgeX/Primitives/ChartColors.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+
+namespace ChartForgeX.Primitives;
+
+#pragma warning disable CS1591
+
+/// <summary>
+/// Provides dependency-free named color tokens for ChartForgeX themes and consumers.
+/// </summary>
+public static class ChartColors {
+    private static readonly Dictionary<string, ChartColor> NamedColors = new(StringComparer.OrdinalIgnoreCase) {
+        ["AliceBlue"] = AliceBlue, ["AntiqueWhite"] = AntiqueWhite, ["Aqua"] = Aqua, ["Aquamarine"] = Aquamarine,
+        ["Azure"] = Azure, ["Beige"] = Beige, ["Bisque"] = Bisque, ["Black"] = Black,
+        ["BlanchedAlmond"] = BlanchedAlmond, ["Blue"] = Blue, ["BlueViolet"] = BlueViolet, ["Brown"] = Brown,
+        ["BurlyWood"] = BurlyWood, ["CadetBlue"] = CadetBlue, ["Chartreuse"] = Chartreuse, ["Chocolate"] = Chocolate,
+        ["Coral"] = Coral, ["CornflowerBlue"] = CornflowerBlue, ["Cornsilk"] = Cornsilk, ["Crimson"] = Crimson,
+        ["Cyan"] = Cyan, ["DarkBlue"] = DarkBlue, ["DarkCyan"] = DarkCyan, ["DarkGoldenrod"] = DarkGoldenrod,
+        ["DarkGoldenRod"] = DarkGoldenrod, ["DarkGray"] = DarkGray, ["DarkGrey"] = DarkGray, ["DarkGreen"] = DarkGreen,
+        ["DarkKhaki"] = DarkKhaki, ["DarkMagenta"] = DarkMagenta, ["DarkOliveGreen"] = DarkOliveGreen, ["DarkOrange"] = DarkOrange,
+        ["DarkOrchid"] = DarkOrchid, ["DarkRed"] = DarkRed, ["DarkSalmon"] = DarkSalmon, ["DarkSeaGreen"] = DarkSeaGreen,
+        ["DarkSlateBlue"] = DarkSlateBlue, ["DarkSlateGray"] = DarkSlateGray, ["DarkSlateGrey"] = DarkSlateGray, ["DarkTurquoise"] = DarkTurquoise,
+        ["DarkViolet"] = DarkViolet, ["DeepPink"] = DeepPink, ["DeepSkyBlue"] = DeepSkyBlue, ["DimGray"] = DimGray,
+        ["DimGrey"] = DimGray, ["DodgerBlue"] = DodgerBlue, ["Firebrick"] = Firebrick, ["FloralWhite"] = FloralWhite,
+        ["ForestGreen"] = ForestGreen, ["Fuchsia"] = Fuchsia, ["Gainsboro"] = Gainsboro, ["GhostWhite"] = GhostWhite,
+        ["Gold"] = Gold, ["Goldenrod"] = Goldenrod, ["GoldenRod"] = Goldenrod, ["Gray"] = Gray,
+        ["Grey"] = Gray, ["Green"] = Green, ["GreenYellow"] = GreenYellow, ["Honeydew"] = Honeydew,
+        ["HotPink"] = HotPink, ["IndianRed"] = IndianRed, ["Indigo"] = Indigo, ["Ivory"] = Ivory,
+        ["Khaki"] = Khaki, ["Lavender"] = Lavender, ["LavenderBlush"] = LavenderBlush, ["LawnGreen"] = LawnGreen,
+        ["LemonChiffon"] = LemonChiffon, ["LightBlue"] = LightBlue, ["LightCoral"] = LightCoral, ["LightCyan"] = LightCyan,
+        ["LightGoldenrodYellow"] = LightGoldenrodYellow, ["LightGoldenRodYellow"] = LightGoldenrodYellow, ["LightGray"] = LightGray, ["LightGrey"] = LightGray,
+        ["LightGreen"] = LightGreen, ["LightPink"] = LightPink, ["LightSalmon"] = LightSalmon, ["LightSeaGreen"] = LightSeaGreen,
+        ["LightSkyBlue"] = LightSkyBlue, ["LightSlateGray"] = LightSlateGray, ["LightSlateGrey"] = LightSlateGray, ["LightSteelBlue"] = LightSteelBlue,
+        ["LightYellow"] = LightYellow, ["Lime"] = Lime, ["LimeGreen"] = LimeGreen, ["Linen"] = Linen,
+        ["Magenta"] = Magenta, ["Maroon"] = Maroon, ["MediumAquamarine"] = MediumAquamarine, ["MediumBlue"] = MediumBlue,
+        ["MediumOrchid"] = MediumOrchid, ["MediumPurple"] = MediumPurple, ["MediumSeaGreen"] = MediumSeaGreen, ["MediumSlateBlue"] = MediumSlateBlue,
+        ["MediumSpringGreen"] = MediumSpringGreen, ["MediumTurquoise"] = MediumTurquoise, ["MediumVioletRed"] = MediumVioletRed, ["MidnightBlue"] = MidnightBlue,
+        ["MintCream"] = MintCream, ["MistyRose"] = MistyRose, ["Moccasin"] = Moccasin, ["NavajoWhite"] = NavajoWhite,
+        ["Navy"] = Navy, ["OldLace"] = OldLace, ["Olive"] = Olive, ["OliveDrab"] = OliveDrab,
+        ["Orange"] = Orange, ["OrangeRed"] = OrangeRed, ["Orchid"] = Orchid, ["PaleGoldenrod"] = PaleGoldenrod,
+        ["PaleGoldenRod"] = PaleGoldenrod, ["PaleGreen"] = PaleGreen, ["PaleTurquoise"] = PaleTurquoise, ["PaleVioletRed"] = PaleVioletRed,
+        ["PapayaWhip"] = PapayaWhip, ["PeachPuff"] = PeachPuff, ["Peru"] = Peru, ["Pink"] = Pink,
+        ["Plum"] = Plum, ["PowderBlue"] = PowderBlue, ["Purple"] = Purple, ["RebeccaPurple"] = RebeccaPurple,
+        ["Red"] = Red, ["RosyBrown"] = RosyBrown, ["RoyalBlue"] = RoyalBlue, ["SaddleBrown"] = SaddleBrown,
+        ["Salmon"] = Salmon, ["SandyBrown"] = SandyBrown, ["SeaGreen"] = SeaGreen, ["SeaShell"] = SeaShell,
+        ["Sienna"] = Sienna, ["Silver"] = Silver, ["SkyBlue"] = SkyBlue, ["SlateBlue"] = SlateBlue,
+        ["SlateGray"] = SlateGray, ["SlateGrey"] = SlateGray, ["Snow"] = Snow, ["SpringGreen"] = SpringGreen,
+        ["SteelBlue"] = SteelBlue, ["Tan"] = Tan, ["Teal"] = Teal, ["Thistle"] = Thistle,
+        ["Tomato"] = Tomato, ["Transparent"] = Transparent, ["Turquoise"] = Turquoise, ["Violet"] = Violet,
+        ["Wheat"] = Wheat, ["White"] = White, ["WhiteSmoke"] = WhiteSmoke, ["Yellow"] = Yellow,
+        ["YellowGreen"] = YellowGreen
+    };
+
+    /// <summary>
+    /// Attempts to get a named color token.
+    /// </summary>
+    /// <param name="name">The color name.</param>
+    /// <param name="color">The resolved chart color.</param>
+    /// <returns>True when the name is known.</returns>
+    public static bool TryGet(string? name, out ChartColor color) {
+        color = default;
+        return !string.IsNullOrWhiteSpace(name) && NamedColors.TryGetValue(name!.Trim(), out color);
+    }
+
+    /// <summary>
+    /// Gets all stable named web colors known to ChartForgeX.
+    /// </summary>
+    /// <returns>A copy of the named color map.</returns>
+    public static IReadOnlyDictionary<string, ChartColor> GetNamedColors() => new Dictionary<string, ChartColor>(NamedColors, StringComparer.OrdinalIgnoreCase);
+
+    public static ChartColor Transparent => ChartColor.Transparent;
+    public static ChartColor AliceBlue => ChartColor.FromRgb(240, 248, 255);
+    public static ChartColor AntiqueWhite => ChartColor.FromRgb(250, 235, 215);
+    public static ChartColor Aqua => ChartColor.FromRgb(0, 255, 255);
+    public static ChartColor Aquamarine => ChartColor.FromRgb(127, 255, 212);
+    public static ChartColor Azure => ChartColor.FromRgb(240, 255, 255);
+    public static ChartColor Beige => ChartColor.FromRgb(245, 245, 220);
+    public static ChartColor Bisque => ChartColor.FromRgb(255, 228, 196);
+    public static ChartColor Black => ChartColor.FromRgb(0, 0, 0);
+    public static ChartColor BlanchedAlmond => ChartColor.FromRgb(255, 235, 205);
+    public static ChartColor Blue => ChartColor.FromRgb(0, 0, 255);
+    public static ChartColor BlueViolet => ChartColor.FromRgb(138, 43, 226);
+    public static ChartColor Brown => ChartColor.FromRgb(165, 42, 42);
+    public static ChartColor BurlyWood => ChartColor.FromRgb(222, 184, 135);
+    public static ChartColor CadetBlue => ChartColor.FromRgb(95, 158, 160);
+    public static ChartColor Chartreuse => ChartColor.FromRgb(127, 255, 0);
+    public static ChartColor Chocolate => ChartColor.FromRgb(210, 105, 30);
+    public static ChartColor Coral => ChartColor.FromRgb(255, 127, 80);
+    public static ChartColor CornflowerBlue => ChartColor.FromRgb(100, 149, 237);
+    public static ChartColor Cornsilk => ChartColor.FromRgb(255, 248, 220);
+    public static ChartColor Crimson => ChartColor.FromRgb(220, 20, 60);
+    public static ChartColor Cyan => ChartColor.FromRgb(0, 255, 255);
+    public static ChartColor DarkBlue => ChartColor.FromRgb(0, 0, 139);
+    public static ChartColor DarkCyan => ChartColor.FromRgb(0, 139, 139);
+    public static ChartColor DarkGoldenrod => ChartColor.FromRgb(184, 134, 11);
+    public static ChartColor DarkGray => ChartColor.FromRgb(169, 169, 169);
+    public static ChartColor DarkGrey => DarkGray;
+    public static ChartColor DarkGreen => ChartColor.FromRgb(0, 100, 0);
+    public static ChartColor DarkKhaki => ChartColor.FromRgb(189, 183, 107);
+    public static ChartColor DarkMagenta => ChartColor.FromRgb(139, 0, 139);
+    public static ChartColor DarkOliveGreen => ChartColor.FromRgb(85, 107, 47);
+    public static ChartColor DarkOrange => ChartColor.FromRgb(255, 140, 0);
+    public static ChartColor DarkOrchid => ChartColor.FromRgb(153, 50, 204);
+    public static ChartColor DarkRed => ChartColor.FromRgb(139, 0, 0);
+    public static ChartColor DarkSalmon => ChartColor.FromRgb(233, 150, 122);
+    public static ChartColor DarkSeaGreen => ChartColor.FromRgb(143, 188, 143);
+    public static ChartColor DarkSlateBlue => ChartColor.FromRgb(72, 61, 139);
+    public static ChartColor DarkSlateGray => ChartColor.FromRgb(47, 79, 79);
+    public static ChartColor DarkSlateGrey => DarkSlateGray;
+    public static ChartColor DarkTurquoise => ChartColor.FromRgb(0, 206, 209);
+    public static ChartColor DarkViolet => ChartColor.FromRgb(148, 0, 211);
+    public static ChartColor DeepPink => ChartColor.FromRgb(255, 20, 147);
+    public static ChartColor DeepSkyBlue => ChartColor.FromRgb(0, 191, 255);
+    public static ChartColor DimGray => ChartColor.FromRgb(105, 105, 105);
+    public static ChartColor DimGrey => DimGray;
+    public static ChartColor DodgerBlue => ChartColor.FromRgb(30, 144, 255);
+    public static ChartColor Firebrick => ChartColor.FromRgb(178, 34, 34);
+    public static ChartColor FloralWhite => ChartColor.FromRgb(255, 250, 240);
+    public static ChartColor ForestGreen => ChartColor.FromRgb(34, 139, 34);
+    public static ChartColor Fuchsia => ChartColor.FromRgb(255, 0, 255);
+    public static ChartColor Gainsboro => ChartColor.FromRgb(220, 220, 220);
+    public static ChartColor GhostWhite => ChartColor.FromRgb(248, 248, 255);
+    public static ChartColor Gold => ChartColor.FromRgb(255, 215, 0);
+    public static ChartColor Goldenrod => ChartColor.FromRgb(218, 165, 32);
+    public static ChartColor Gray => ChartColor.FromRgb(128, 128, 128);
+    public static ChartColor Grey => Gray;
+    public static ChartColor Green => ChartColor.FromRgb(0, 128, 0);
+    public static ChartColor GreenYellow => ChartColor.FromRgb(173, 255, 47);
+    public static ChartColor Honeydew => ChartColor.FromRgb(240, 255, 240);
+    public static ChartColor HotPink => ChartColor.FromRgb(255, 105, 180);
+    public static ChartColor IndianRed => ChartColor.FromRgb(205, 92, 92);
+    public static ChartColor Indigo => ChartColor.FromRgb(75, 0, 130);
+    public static ChartColor Ivory => ChartColor.FromRgb(255, 255, 240);
+    public static ChartColor Khaki => ChartColor.FromRgb(240, 230, 140);
+    public static ChartColor Lavender => ChartColor.FromRgb(230, 230, 250);
+    public static ChartColor LavenderBlush => ChartColor.FromRgb(255, 240, 245);
+    public static ChartColor LawnGreen => ChartColor.FromRgb(124, 252, 0);
+    public static ChartColor LemonChiffon => ChartColor.FromRgb(255, 250, 205);
+    public static ChartColor LightBlue => ChartColor.FromRgb(173, 216, 230);
+    public static ChartColor LightCoral => ChartColor.FromRgb(240, 128, 128);
+    public static ChartColor LightCyan => ChartColor.FromRgb(224, 255, 255);
+    public static ChartColor LightGoldenrodYellow => ChartColor.FromRgb(250, 250, 210);
+    public static ChartColor LightGray => ChartColor.FromRgb(211, 211, 211);
+    public static ChartColor LightGrey => LightGray;
+    public static ChartColor LightGreen => ChartColor.FromRgb(144, 238, 144);
+    public static ChartColor LightPink => ChartColor.FromRgb(255, 182, 193);
+    public static ChartColor LightSalmon => ChartColor.FromRgb(255, 160, 122);
+    public static ChartColor LightSeaGreen => ChartColor.FromRgb(32, 178, 170);
+    public static ChartColor LightSkyBlue => ChartColor.FromRgb(135, 206, 250);
+    public static ChartColor LightSlateGray => ChartColor.FromRgb(119, 136, 153);
+    public static ChartColor LightSlateGrey => LightSlateGray;
+    public static ChartColor LightSteelBlue => ChartColor.FromRgb(176, 196, 222);
+    public static ChartColor LightYellow => ChartColor.FromRgb(255, 255, 224);
+    public static ChartColor Lime => ChartColor.FromRgb(0, 255, 0);
+    public static ChartColor LimeGreen => ChartColor.FromRgb(50, 205, 50);
+    public static ChartColor Linen => ChartColor.FromRgb(250, 240, 230);
+    public static ChartColor Magenta => ChartColor.FromRgb(255, 0, 255);
+    public static ChartColor Maroon => ChartColor.FromRgb(128, 0, 0);
+    public static ChartColor MediumAquamarine => ChartColor.FromRgb(102, 205, 170);
+    public static ChartColor MediumBlue => ChartColor.FromRgb(0, 0, 205);
+    public static ChartColor MediumOrchid => ChartColor.FromRgb(186, 85, 211);
+    public static ChartColor MediumPurple => ChartColor.FromRgb(147, 112, 219);
+    public static ChartColor MediumSeaGreen => ChartColor.FromRgb(60, 179, 113);
+    public static ChartColor MediumSlateBlue => ChartColor.FromRgb(123, 104, 238);
+    public static ChartColor MediumSpringGreen => ChartColor.FromRgb(0, 250, 154);
+    public static ChartColor MediumTurquoise => ChartColor.FromRgb(72, 209, 204);
+    public static ChartColor MediumVioletRed => ChartColor.FromRgb(199, 21, 133);
+    public static ChartColor MidnightBlue => ChartColor.FromRgb(25, 25, 112);
+    public static ChartColor MintCream => ChartColor.FromRgb(245, 255, 250);
+    public static ChartColor MistyRose => ChartColor.FromRgb(255, 228, 225);
+    public static ChartColor Moccasin => ChartColor.FromRgb(255, 228, 181);
+    public static ChartColor NavajoWhite => ChartColor.FromRgb(255, 222, 173);
+    public static ChartColor Navy => ChartColor.FromRgb(0, 0, 128);
+    public static ChartColor OldLace => ChartColor.FromRgb(253, 245, 230);
+    public static ChartColor Olive => ChartColor.FromRgb(128, 128, 0);
+    public static ChartColor OliveDrab => ChartColor.FromRgb(107, 142, 35);
+    public static ChartColor Orange => ChartColor.FromRgb(255, 165, 0);
+    public static ChartColor OrangeRed => ChartColor.FromRgb(255, 69, 0);
+    public static ChartColor Orchid => ChartColor.FromRgb(218, 112, 214);
+    public static ChartColor PaleGoldenrod => ChartColor.FromRgb(238, 232, 170);
+    public static ChartColor PaleGreen => ChartColor.FromRgb(152, 251, 152);
+    public static ChartColor PaleTurquoise => ChartColor.FromRgb(175, 238, 238);
+    public static ChartColor PaleVioletRed => ChartColor.FromRgb(219, 112, 147);
+    public static ChartColor PapayaWhip => ChartColor.FromRgb(255, 239, 213);
+    public static ChartColor PeachPuff => ChartColor.FromRgb(255, 218, 185);
+    public static ChartColor Peru => ChartColor.FromRgb(205, 133, 63);
+    public static ChartColor Pink => ChartColor.FromRgb(255, 192, 203);
+    public static ChartColor Plum => ChartColor.FromRgb(221, 160, 221);
+    public static ChartColor PowderBlue => ChartColor.FromRgb(176, 224, 230);
+    public static ChartColor Purple => ChartColor.FromRgb(128, 0, 128);
+    public static ChartColor RebeccaPurple => ChartColor.FromRgb(102, 51, 153);
+    public static ChartColor Red => ChartColor.FromRgb(255, 0, 0);
+    public static ChartColor RosyBrown => ChartColor.FromRgb(188, 143, 143);
+    public static ChartColor RoyalBlue => ChartColor.FromRgb(65, 105, 225);
+    public static ChartColor SaddleBrown => ChartColor.FromRgb(139, 69, 19);
+    public static ChartColor Salmon => ChartColor.FromRgb(250, 128, 114);
+    public static ChartColor SandyBrown => ChartColor.FromRgb(244, 164, 96);
+    public static ChartColor SeaGreen => ChartColor.FromRgb(46, 139, 87);
+    public static ChartColor SeaShell => ChartColor.FromRgb(255, 245, 238);
+    public static ChartColor Sienna => ChartColor.FromRgb(160, 82, 45);
+    public static ChartColor Silver => ChartColor.FromRgb(192, 192, 192);
+    public static ChartColor SkyBlue => ChartColor.FromRgb(135, 206, 235);
+    public static ChartColor SlateBlue => ChartColor.FromRgb(106, 90, 205);
+    public static ChartColor SlateGray => ChartColor.FromRgb(112, 128, 144);
+    public static ChartColor SlateGrey => SlateGray;
+    public static ChartColor Snow => ChartColor.FromRgb(255, 250, 250);
+    public static ChartColor SpringGreen => ChartColor.FromRgb(0, 255, 127);
+    public static ChartColor SteelBlue => ChartColor.FromRgb(70, 130, 180);
+    public static ChartColor Tan => ChartColor.FromRgb(210, 180, 140);
+    public static ChartColor Teal => ChartColor.FromRgb(0, 128, 128);
+    public static ChartColor Thistle => ChartColor.FromRgb(216, 191, 216);
+    public static ChartColor Tomato => ChartColor.FromRgb(255, 99, 71);
+    public static ChartColor Turquoise => ChartColor.FromRgb(64, 224, 208);
+    public static ChartColor Violet => ChartColor.FromRgb(238, 130, 238);
+    public static ChartColor Wheat => ChartColor.FromRgb(245, 222, 179);
+    public static ChartColor White => ChartColor.FromRgb(255, 255, 255);
+    public static ChartColor WhiteSmoke => ChartColor.FromRgb(245, 245, 245);
+    public static ChartColor Yellow => ChartColor.FromRgb(255, 255, 0);
+    public static ChartColor YellowGreen => ChartColor.FromRgb(154, 205, 50);
+
+    public static ChartColor Slate50 => ChartColor.FromRgb(248, 250, 252);
+    public static ChartColor Slate100 => ChartColor.FromRgb(241, 245, 249);
+    public static ChartColor Slate200 => ChartColor.FromRgb(226, 232, 240);
+    public static ChartColor Slate300 => ChartColor.FromRgb(203, 213, 225);
+    public static ChartColor Slate400 => ChartColor.FromRgb(148, 163, 184);
+    public static ChartColor Slate500 => ChartColor.FromRgb(100, 116, 139);
+    public static ChartColor Slate600 => ChartColor.FromRgb(71, 85, 105);
+    public static ChartColor Slate700 => ChartColor.FromRgb(51, 65, 85);
+    public static ChartColor Slate800 => ChartColor.FromRgb(30, 41, 59);
+    public static ChartColor Slate900 => ChartColor.FromRgb(15, 23, 42);
+    public static ChartColor Slate950 => ChartColor.FromRgb(2, 6, 23);
+    public static ChartColor Sky400 => ChartColor.FromRgb(56, 189, 248);
+    public static ChartColor Sky500 => ChartColor.FromRgb(14, 165, 233);
+    public static ChartColor Blue400 => ChartColor.FromRgb(96, 165, 250);
+    public static ChartColor Blue600 => ChartColor.FromRgb(37, 99, 235);
+    public static ChartColor Cyan400 => ChartColor.FromRgb(34, 211, 238);
+    public static ChartColor Teal400 => ChartColor.FromRgb(45, 212, 191);
+    public static ChartColor Emerald400 => ChartColor.FromRgb(52, 211, 153);
+    public static ChartColor Emerald500 => ChartColor.FromRgb(16, 185, 129);
+    public static ChartColor Green400 => ChartColor.FromRgb(74, 222, 128);
+    public static ChartColor Lime400 => ChartColor.FromRgb(163, 230, 53);
+    public static ChartColor Amber400 => ChartColor.FromRgb(251, 191, 36);
+    public static ChartColor Yellow400 => ChartColor.FromRgb(250, 204, 21);
+    public static ChartColor Orange400 => ChartColor.FromRgb(251, 146, 60);
+    public static ChartColor Red400 => ChartColor.FromRgb(248, 113, 113);
+    public static ChartColor Rose400 => ChartColor.FromRgb(251, 113, 133);
+    public static ChartColor Pink400 => ChartColor.FromRgb(244, 114, 182);
+    public static ChartColor Violet400 => ChartColor.FromRgb(167, 139, 250);
+    public static ChartColor Purple400 => ChartColor.FromRgb(192, 132, 252);
+    public static ChartColor Indigo400 => ChartColor.FromRgb(129, 140, 248);
+}
+
+#pragma warning restore CS1591

--- a/ChartForgeX/Primitives/ChartColors.cs
+++ b/ChartForgeX/Primitives/ChartColors.cs
@@ -51,6 +51,17 @@ public static class ChartColors {
         ["YellowGreen"] = YellowGreen
     };
 
+    private static readonly Dictionary<string, ChartColor> TokenColors = new(StringComparer.OrdinalIgnoreCase) {
+        ["Slate50"] = Slate50, ["Slate100"] = Slate100, ["Slate200"] = Slate200, ["Slate300"] = Slate300,
+        ["Slate400"] = Slate400, ["Slate500"] = Slate500, ["Slate600"] = Slate600, ["Slate700"] = Slate700,
+        ["Slate800"] = Slate800, ["Slate900"] = Slate900, ["Slate950"] = Slate950,
+        ["Sky400"] = Sky400, ["Sky500"] = Sky500, ["Blue400"] = Blue400, ["Blue600"] = Blue600,
+        ["Cyan400"] = Cyan400, ["Teal400"] = Teal400, ["Emerald400"] = Emerald400, ["Emerald500"] = Emerald500,
+        ["Green400"] = Green400, ["Lime400"] = Lime400, ["Amber400"] = Amber400, ["Yellow400"] = Yellow400,
+        ["Orange400"] = Orange400, ["Red400"] = Red400, ["Rose400"] = Rose400, ["Pink400"] = Pink400,
+        ["Violet400"] = Violet400, ["Purple400"] = Purple400, ["Indigo400"] = Indigo400
+    };
+
     /// <summary>
     /// Attempts to get a named color token.
     /// </summary>
@@ -59,7 +70,9 @@ public static class ChartColors {
     /// <returns>True when the name is known.</returns>
     public static bool TryGet(string? name, out ChartColor color) {
         color = default;
-        return !string.IsNullOrWhiteSpace(name) && NamedColors.TryGetValue(name!.Trim(), out color);
+        if (string.IsNullOrWhiteSpace(name)) return false;
+        var trimmed = name!.Trim();
+        return NamedColors.TryGetValue(trimmed, out color) || TokenColors.TryGetValue(trimmed, out color);
     }
 
     /// <summary>
@@ -67,6 +80,12 @@ public static class ChartColors {
     /// </summary>
     /// <returns>A copy of the named color map.</returns>
     public static IReadOnlyDictionary<string, ChartColor> GetNamedColors() => new Dictionary<string, ChartColor>(NamedColors, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets all ChartForgeX design tokens used by palettes and overlay themes.
+    /// </summary>
+    /// <returns>A copy of the named token color map.</returns>
+    public static IReadOnlyDictionary<string, ChartColor> GetTokenColors() => new Dictionary<string, ChartColor>(TokenColors, StringComparer.OrdinalIgnoreCase);
 
     public static ChartColor Transparent => ChartColor.Transparent;
     public static ChartColor AliceBlue => ChartColor.FromRgb(240, 248, 255);

--- a/ChartForgeX/Themes/ChartPalettes.cs
+++ b/ChartForgeX/Themes/ChartPalettes.cs
@@ -15,7 +15,7 @@ public static class ChartPalettes {
         if (colors == null) throw new System.ArgumentNullException(nameof(colors));
         if (colors.Length == 0) throw new System.ArgumentException("Palette must contain at least one color.", nameof(colors));
         var palette = new ChartColor[colors.Length];
-        for (var i = 0; i < colors.Length; i++) palette[i] = ChartColor.FromHex(colors[i]);
+        for (var i = 0; i < colors.Length; i++) palette[i] = ChartColor.Parse(colors[i]);
         return palette;
     }
 
@@ -89,5 +89,13 @@ public static class ChartPalettes {
         ChartColor.FromRgb(34,197,94), ChartColor.FromRgb(56,189,248), ChartColor.FromRgb(250,204,21),
         ChartColor.FromRgb(192,132,252), ChartColor.FromRgb(248,113,113), ChartColor.FromRgb(45,212,191),
         ChartColor.FromRgb(251,146,60), ChartColor.FromRgb(163,230,53)
+    };
+
+    /// <summary>
+    /// Gets a bright overlay palette for transparent operational dashboards and wallpapers.
+    /// </summary>
+    public static ChartColor[] CommandCenter => new[] {
+        ChartColors.Blue400, ChartColors.Cyan400, ChartColors.Emerald400, ChartColors.Orange400,
+        ChartColors.Red400, ChartColors.Violet400, ChartColors.Pink400, ChartColors.Teal400
     };
 }

--- a/ChartForgeX/Themes/ChartPalettes.cs
+++ b/ChartForgeX/Themes/ChartPalettes.cs
@@ -7,9 +7,9 @@ namespace ChartForgeX.Themes;
 /// </summary>
 public static class ChartPalettes {
     /// <summary>
-    /// Creates a palette from hexadecimal color strings.
+    /// Creates a palette from named color tokens or hexadecimal color strings.
     /// </summary>
-    /// <param name="colors">The color strings in #RGB, #RGBA, #RRGGBB, or #RRGGBBAA notation.</param>
+    /// <param name="colors">The color strings as ChartForgeX color names, #RGB, #RGBA, #RRGGBB, or #RRGGBBAA notation.</param>
     /// <returns>A chart color palette.</returns>
     public static ChartColor[] FromHex(params string[] colors) {
         if (colors == null) throw new System.ArgumentNullException(nameof(colors));

--- a/ChartForgeX/Themes/ChartTheme.cs
+++ b/ChartForgeX/Themes/ChartTheme.cs
@@ -582,6 +582,32 @@ public sealed class ChartTheme {
     };
 
     /// <summary>
+    /// Creates a transparent dark overlay theme for charts rendered on existing imagery or wallpapers.
+    /// </summary>
+    /// <returns>A transparent overlay chart theme.</returns>
+    public static ChartTheme TransparentOverlayDark() => new() {
+        Background = ChartColors.Transparent,
+        CardBackground = ChartColors.Slate950.WithAlpha(172),
+        PlotBackground = ChartColors.Transparent,
+        CardBorder = ChartColors.Slate400.WithAlpha(64),
+        PlotBorder = ChartColors.Slate400.WithAlpha(34),
+        Text = ChartColors.White,
+        MutedText = ChartColors.Slate200.WithAlpha(230),
+        Grid = ChartColors.Slate400.WithAlpha(42),
+        Axis = ChartColors.Slate200.WithAlpha(110),
+        Positive = ChartColors.Emerald400,
+        Warning = ChartColors.Orange400,
+        Negative = ChartColors.Red400,
+        CornerRadius = 8,
+        PlotCornerRadius = 4,
+        ShadowOpacity = 0,
+        StrokeWidth = 2.7,
+        MarkerRadius = 3,
+        FontFamily = ChartFontStacks.SystemSans,
+        Palette = ChartPalettes.CommandCenter
+    };
+
+    /// <summary>
     /// Creates a crisp minimal theme for dense business dashboards.
     /// </summary>
     /// <returns>A minimal chart theme.</returns>
@@ -616,9 +642,7 @@ public sealed class ChartTheme {
         return value;
     }
 
-    private static ChartColor WithAlpha(ChartColor color, byte alpha) =>
-        ChartColor.FromRgba(color.R, color.G, color.B, alpha);
+    private static ChartColor WithAlpha(ChartColor color, byte alpha) => color.WithAlpha(alpha);
 
-    private static ChartColor WithMinimumAlpha(ChartColor color, byte alpha) =>
-        ChartColor.FromRgba(color.R, color.G, color.B, color.A < alpha ? alpha : color.A);
+    private static ChartColor WithMinimumAlpha(ChartColor color, byte alpha) => color.WithAlpha(color.A < alpha ? alpha : color.A);
 }

--- a/README.md
+++ b/README.md
@@ -380,10 +380,23 @@ Choose a visual system by audience first, then adjust palette or surface details
 | Accessibility-first categorical comparison | `ChartTheme.Colorblind()` | `ChartBrandKit.Accessible()` |
 | Playful scorecard, education, pictorial view | `ChartTheme.Candy()` | `ChartBrandKit.Product()` with pictorial shapes |
 | Dense operations or command-center view | `ChartTheme.Terminal()` | `ChartBrandKit.Accessible()` with `ChartSurfaceStyle.Compact` |
+| Transparent charts over imagery or wallpapers | `ChartTheme.TransparentOverlayDark()` | `ChartBrandKit.Accessible()` with `ChartSurfaceStyle.Glass` |
 
 Themes are complete visual presets for one chart. Brand kits are reusable brand tokens that can be layered onto charts, grids, or themes.
 
-Reusable palette presets are available through `ChartPalettes.Report`, `Colorblind`, `Vivid`, `Pastel`, `PeopleInfographic`, `Editorial`, `Jewel`, and `Terminal`. Each property returns a fresh array, so callers can safely modify a local copy before passing it to `WithPalette(...)`.
+Reusable palette presets are available through `ChartPalettes.Report`, `Colorblind`, `Vivid`, `Pastel`, `PeopleInfographic`, `Editorial`, `Jewel`, `Terminal`, and `CommandCenter`. Each property returns a fresh array, so callers can safely modify a local copy before passing it to `WithPalette(...)`.
+
+Named dependency-free color tokens are available through `ChartColors`, including the stable CSS/System.Drawing web color names (`AliceBlue`, `CornflowerBlue`, `DarkSlateGray`, `RebeccaPurple`, `WhiteSmoke`, and the `Grey` aliases) plus common report and overlay tokens such as `Slate950`, `Slate200`, `Blue400`, `Cyan400`, `Teal400`, `Emerald400`, `Orange400`, `Red400`, and `Violet400`. `ChartColor.Parse(...)` accepts names or hex, and `ChartColor` also has `WithAlpha(...)`, `WithOpacity(...)`, and `ToHexRgba()` helpers for transparent chart surfaces:
+
+```csharp
+var overlay = Chart.Create()
+    .WithTheme(ChartTheme.TransparentOverlayDark())
+    .WithPalette(ChartPalettes.CommandCenter)
+    .AddDonut("Disk C", Points(72, 28), ChartColors.Red400);
+
+var panel = ChartColors.Slate950.WithAlpha(172);
+var named = ChartColor.Parse("RebeccaPurple");
+```
 
 You can also paste colors directly from a design tool:
 


### PR DESCRIPTION
## Summary
- add dependency-free `ChartColors` named tokens for the stable CSS/System.Drawing web color set plus grey aliases and `RebeccaPurple`
- add `ChartColor.Parse(...)` / `TryParse(...)` so callers can use named colors or hex strings without System.Drawing/ImageSharp
- add `ChartColor.WithAlpha(...)`, `WithOpacity(...)`, and `ToHexRgba()` helpers for transparent chart surfaces
- add `ChartPalettes.CommandCenter` and `ChartTheme.TransparentOverlayDark()` for charts rendered over imagery or wallpapers
- document the new color/theme surface and cover it in smoke tests

## Notes
- System.Drawing exposes 175 `KnownColor` entries on this machine: 142 stable non-system colors and 33 dynamic OS/theme colors
- This PR intentionally includes the stable named web colors and excludes dynamic system colors such as `ActiveBorder` / `ControlText`, because their RGB values are environment-dependent

## Validation
- `dotnet build ChartForgeX.sln -c Release -m:1 -nr:false`
- `dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Release --no-build -m:1 -nr:false` (`242/242`)
- `git diff --check`