### PR TITLE
Migrate specialized SVG renderers to markup writer

### DIFF
--- a/ChartForgeX/Svg/SvgChartRenderer.Bullet.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Bullet.cs
@@ -23,7 +23,12 @@ public sealed partial class SvgChartRenderer {
         var rowHeight = Math.Min(64, plot.Height / Math.Max(1, rows.Length));
         var barHeight = Math.Max(16, Math.Min(26, rowHeight * 0.38));
 
-        sb.AppendLine("<g data-cfx-role=\"bullet-chart\">");
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "bullet-chart")
+            .EndStartElement()
+            .Line();
         for (var rowIndex = 0; rowIndex < rows.Length; rowIndex++) {
             var row = rows[rowIndex];
             var y = plot.Top + rowHeight * rowIndex + rowHeight / 2;
@@ -45,29 +50,82 @@ public sealed partial class SvgChartRenderer {
             var valueLabel = TrimSvgLabelToWidth(rawValueLabel, valueLabelFontSize, valueLabelMaxWidth);
             var showLabels = row.series.ShowDataLabels != false;
 
-            sb.AppendLine($"<g data-cfx-role=\"bullet-row\" data-cfx-series=\"{row.index}\" data-cfx-status=\"{status}\" data-cfx-label=\"{Escape(row.series.Name)}\" data-cfx-value=\"{F(actualValue)}\" data-cfx-target=\"{F(targetValue)}\" data-cfx-min=\"{F(min)}\" data-cfx-max=\"{F(max)}\" role=\"group\" aria-label=\"{Escape(rowSummary)}\">");
-            if (showLabels && rowLabel.Length > 0) sb.AppendLine($"<text data-cfx-role=\"bullet-row-label\" x=\"{F(basePlot.Left)}\" y=\"{F(y + 4)}\" fill=\"{t.Text.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(rowLabelFontSize)}\" font-weight=\"700\">{Escape(rowLabel)}</text>");
-            DrawBulletRanges(sb, row.series, plot, y, barHeight, min, max, accent);
+            writer
+                .StartElement("g")
+                .Attribute("data-cfx-role", "bullet-row")
+                .Attribute("data-cfx-series", row.index)
+                .Attribute("data-cfx-status", status)
+                .Attribute("data-cfx-label", row.series.Name)
+                .Attribute("data-cfx-value", F(actualValue))
+                .Attribute("data-cfx-target", F(targetValue))
+                .Attribute("data-cfx-min", F(min))
+                .Attribute("data-cfx-max", F(max))
+                .Attribute("role", "group")
+                .Attribute("aria-label", rowSummary)
+                .EndStartElement()
+                .Line();
+            if (showLabels && rowLabel.Length > 0) {
+                WriteBulletText(writer, "bullet-row-label", basePlot.Left, y + 4, rowLabel, t.Text.ToCss(), BulletFontFamily(t.FontFamily), rowLabelFontSize, "700");
+            }
+            DrawBulletRanges(writer, row.series, plot, y, barHeight, min, max, accent);
 
             var value = Clamp(actualValue, min, max);
             var target = Clamp(targetValue, min, max);
             var valueX = BulletX(plot, min, max, value);
             var targetX = BulletX(plot, min, max, target);
-            sb.AppendLine($"<rect data-cfx-role=\"bullet-value\" data-cfx-series=\"{row.index}\" data-cfx-value=\"{F(actualValue)}\" x=\"{F(plot.Left)}\" y=\"{F(y - barHeight * 0.24)}\" width=\"{F(Math.Max(2, valueX - plot.Left))}\" height=\"{F(barHeight * 0.48)}\" rx=\"{F(barHeight * 0.24)}\" fill=\"url(#{id}-seriesFill{row.index})\"/>");
-            sb.AppendLine($"<line data-cfx-role=\"bullet-target\" data-cfx-series=\"{row.index}\" data-cfx-target=\"{F(targetValue)}\" x1=\"{F(targetX)}\" y1=\"{F(y - barHeight * 0.68)}\" x2=\"{F(targetX)}\" y2=\"{F(y + barHeight * 0.68)}\" stroke=\"{t.Text.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.BulletTargetStrokeWidth)}\" stroke-linecap=\"round\"/>");
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-role", "bullet-value")
+                .Attribute("data-cfx-series", row.index)
+                .Attribute("data-cfx-value", F(actualValue))
+                .Attribute("x", F(plot.Left))
+                .Attribute("y", F(y - barHeight * 0.24))
+                .Attribute("width", F(Math.Max(2, valueX - plot.Left)))
+                .Attribute("height", F(barHeight * 0.48))
+                .Attribute("rx", F(barHeight * 0.24))
+                .Attribute("fill", "url(#" + id + "-seriesFill" + row.index + ")")
+                .EndEmptyElement()
+                .Line()
+                .StartElement("line")
+                .Attribute("data-cfx-role", "bullet-target")
+                .Attribute("data-cfx-series", row.index)
+                .Attribute("data-cfx-target", F(targetValue))
+                .Attribute("x1", F(targetX))
+                .Attribute("y1", F(y - barHeight * 0.68))
+                .Attribute("x2", F(targetX))
+                .Attribute("y2", F(y + barHeight * 0.68))
+                .Attribute("stroke", t.Text.ToCss())
+                .Attribute("stroke-width", F(ChartVisualPrimitives.BulletTargetStrokeWidth))
+                .Attribute("stroke-linecap", "round")
+                .EndEmptyElement()
+                .Line();
             if (showLabels) {
-                DrawBulletTargetLabel(sb, chart, FormatValue(chart, targetValue), targetX, y - barHeight * 0.92, plot);
-                sb.AppendLine($"<circle data-cfx-role=\"bullet-status-marker\" data-cfx-status=\"{status}\" cx=\"{F(plot.Right + 8)}\" cy=\"{F(y)}\" r=\"{F(ChartVisualPrimitives.StatusMarkerRadius)}\" fill=\"{statusColor.ToCss()}\" stroke=\"{t.CardBackground.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.StatusMarkerStrokeWidth)}\"/>");
-                if (valueLabel.Length > 0) sb.AppendLine($"<text data-cfx-role=\"bullet-value-label\" x=\"{F(plot.Right + 18)}\" y=\"{F(y + 4)}\" fill=\"{t.Text.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(valueLabelFontSize)}\" font-weight=\"800\">{Escape(valueLabel)}</text>");
+                DrawBulletTargetLabel(writer, chart, FormatValue(chart, targetValue), targetX, y - barHeight * 0.92, plot);
+                writer
+                    .StartElement("circle")
+                    .Attribute("data-cfx-role", "bullet-status-marker")
+                    .Attribute("data-cfx-status", status)
+                    .Attribute("cx", F(plot.Right + 8))
+                    .Attribute("cy", F(y))
+                    .Attribute("r", F(ChartVisualPrimitives.StatusMarkerRadius))
+                    .Attribute("fill", statusColor.ToCss())
+                    .Attribute("stroke", t.CardBackground.ToCss())
+                    .Attribute("stroke-width", F(ChartVisualPrimitives.StatusMarkerStrokeWidth))
+                    .EndEmptyElement()
+                    .Line();
+                if (valueLabel.Length > 0) {
+                    WriteBulletText(writer, "bullet-value-label", plot.Right + 18, y + 4, valueLabel, t.Text.ToCss(), BulletFontFamily(t.FontFamily), valueLabelFontSize, "800");
+                }
             }
-            sb.AppendLine("</g>");
+            writer.EndElement().Line();
         }
 
-        DrawBulletAxis(sb, chart, plot, rows[0].series, basePlot.Bottom - 12);
-        sb.AppendLine("</g>");
+        DrawBulletAxis(writer, chart, plot, rows[0].series, basePlot.Bottom - 12);
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
-    private static void DrawBulletTargetLabel(StringBuilder sb, Chart chart, string label, double x, double y, ChartRect plot) {
+    private static void DrawBulletTargetLabel(SvgMarkupWriter writer, Chart chart, string label, double x, double y, ChartRect plot) {
         var t = chart.Options.Theme;
         var text = "target " + label;
         var maxWidth = Math.Max(8, plot.Width - 8);
@@ -81,10 +139,26 @@ public sealed partial class SvgChartRenderer {
         if (anchor == "start") safeX = Clamp(x, plot.Left + 4, plot.Right - width - 4);
         if (anchor == "end") safeX = Clamp(x, plot.Left + width + 4, plot.Right - 4);
         var safeY = Clamp(y, plot.Top + fontSize, plot.Bottom - 4);
-        sb.AppendLine($"<text data-cfx-role=\"bullet-target-label\" x=\"{F(safeX)}\" y=\"{F(safeY)}\" text-anchor=\"{anchor}\" fill=\"{t.MutedText.ToCss()}\" stroke=\"{t.CardBackground.ToCss()}\" stroke-width=\"3\" paint-order=\"stroke fill\" stroke-linejoin=\"round\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(fontSize)}\" font-weight=\"650\">{Escape(text)}</text>");
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", "bullet-target-label")
+            .Attribute("x", F(safeX))
+            .Attribute("y", F(safeY))
+            .Attribute("text-anchor", anchor)
+            .Attribute("fill", t.MutedText.ToCss())
+            .Attribute("stroke", t.CardBackground.ToCss())
+            .Attribute("stroke-width", "3")
+            .Attribute("paint-order", "stroke fill")
+            .Attribute("stroke-linejoin", "round")
+            .Attribute("font-family", BulletFontFamily(t.FontFamily))
+            .Attribute("font-size", F(fontSize))
+            .Attribute("font-weight", "650")
+            .Raw(Escape(text))
+            .EndElement()
+            .Line();
     }
 
-    private static void DrawBulletRanges(StringBuilder sb, ChartSeries series, ChartRect plot, double y, double barHeight, double min, double max, ChartColor accent) {
+    private static void DrawBulletRanges(SvgMarkupWriter writer, ChartSeries series, ChartRect plot, double y, double barHeight, double min, double max, ChartColor accent) {
         var previous = min;
         var ends = BulletRangeEnds(series, min, max);
         for (var i = 0; i < ends.Length; i++) {
@@ -93,30 +167,83 @@ public sealed partial class SvgChartRenderer {
             var x = BulletX(plot, min, max, previous);
             var width = BulletX(plot, min, max, end) - x;
             var opacity = Math.Max(0.10, 0.30 - i * 0.055);
-            sb.AppendLine($"<rect data-cfx-role=\"bullet-range\" x=\"{F(x)}\" y=\"{F(y - barHeight / 2)}\" width=\"{F(width)}\" height=\"{F(barHeight)}\" rx=\"{F(barHeight / 2)}\" fill=\"{accent.ToCss()}\" opacity=\"{F(opacity)}\"/>");
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-role", "bullet-range")
+                .Attribute("x", F(x))
+                .Attribute("y", F(y - barHeight / 2))
+                .Attribute("width", F(width))
+                .Attribute("height", F(barHeight))
+                .Attribute("rx", F(barHeight / 2))
+                .Attribute("fill", accent.ToCss())
+                .Attribute("opacity", F(opacity))
+                .EndEmptyElement()
+                .Line();
             previous = end;
         }
     }
 
-    private static void DrawBulletAxis(StringBuilder sb, Chart chart, ChartRect plot, ChartSeries reference, double y) {
+    private static void DrawBulletAxis(SvgMarkupWriter writer, Chart chart, ChartRect plot, ChartSeries reference, double y) {
         if (!chart.Options.ShowAxes) return;
         var t = chart.Options.Theme;
         var min = BulletMin(reference);
         var max = BulletMax(reference);
         if (Math.Abs(max - min) < 0.000001) max = min + 1;
         var ticks = new[] { min, min + (max - min) / 2, max };
-        sb.AppendLine("<g data-cfx-role=\"bullet-axis\">");
-        sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(y)}\" x2=\"{F(plot.Right)}\" y2=\"{F(y)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.BulletAxisStrokeWidth)}\"/>");
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "bullet-axis")
+            .EndStartElement()
+            .Line()
+            .StartElement("line")
+            .Attribute("x1", F(plot.Left))
+            .Attribute("y1", F(y))
+            .Attribute("x2", F(plot.Right))
+            .Attribute("y2", F(y))
+            .Attribute("stroke", t.Axis.ToCss())
+            .Attribute("stroke-width", F(ChartVisualPrimitives.BulletAxisStrokeWidth))
+            .EndEmptyElement()
+            .Line();
         foreach (var tick in ticks) {
             var x = BulletX(plot, min, max, tick);
             var label = FormatValue(chart, tick);
             var anchor = EdgeAwareAnchor(label, x, plot, t.TickLabelFontSize);
             var safeX = EdgeAwareTextX(label, x, plot, t.TickLabelFontSize);
-            sb.AppendLine($"<line data-cfx-role=\"bullet-axis-tick\" x1=\"{F(x)}\" y1=\"{F(y - 4)}\" x2=\"{F(x)}\" y2=\"{F(y + 4)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.BulletAxisStrokeWidth)}\"/>");
-            sb.AppendLine($"<text data-cfx-role=\"bullet-axis-label\" x=\"{F(safeX)}\" y=\"{F(y + 20)}\" text-anchor=\"{anchor}\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(t.TickLabelFontSize)}\">{Escape(label)}</text>");
+            writer
+                .StartElement("line")
+                .Attribute("data-cfx-role", "bullet-axis-tick")
+                .Attribute("x1", F(x))
+                .Attribute("y1", F(y - 4))
+                .Attribute("x2", F(x))
+                .Attribute("y2", F(y + 4))
+                .Attribute("stroke", t.Axis.ToCss())
+                .Attribute("stroke-width", F(ChartVisualPrimitives.BulletAxisStrokeWidth))
+                .EndEmptyElement()
+                .Line();
+            WriteBulletText(writer, "bullet-axis-label", safeX, y + 20, label, t.MutedText.ToCss(), BulletFontFamily(t.FontFamily), t.TickLabelFontSize, null, anchor);
         }
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
     }
+
+    private static void WriteBulletText(SvgMarkupWriter writer, string role, double x, double y, string text, string fill, string fontFamily, double fontSize, string? fontWeight, string? textAnchor = null) {
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", role)
+            .Attribute("x", F(x))
+            .Attribute("y", F(y));
+        if (textAnchor != null) writer.Attribute("text-anchor", textAnchor);
+        writer
+            .Attribute("fill", fill)
+            .Attribute("font-family", fontFamily)
+            .Attribute("font-size", F(fontSize));
+        if (fontWeight != null) writer.Attribute("font-weight", fontWeight);
+        writer
+            .Raw(Escape(text))
+            .EndElement()
+            .Line();
+    }
+
+    private static string BulletFontFamily(string value) => string.IsNullOrWhiteSpace(value) ? "system-ui, sans-serif" : value;
 
     private static double BulletMin(ChartSeries series) => series.Points[0].X;
 

--- a/ChartForgeX/Svg/SvgChartRenderer.Gantt.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Gantt.cs
@@ -33,18 +33,47 @@ public sealed partial class SvgChartRenderer {
         var startXs = new double[items.Count];
         var endXs = new double[items.Count];
 
-        sb.AppendLine("<g data-cfx-role=\"gantt-chart\">");
-        DrawGanttItemGradients(sb, id, items);
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "gantt-chart")
+            .EndStartElement()
+            .Line();
+        DrawGanttItemGradients(writer, id, items);
         foreach (var tick in ticks) {
             var x = ProjectTimelineX(tick, min, max, plot);
-            if (chart.Options.ShowGrid) sb.AppendLine($"<line x1=\"{F(x)}\" y1=\"{F(plot.Top)}\" x2=\"{F(x)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" opacity=\"{F(ChartVisualPrimitives.TimelineGridOpacity)}\"/>");
+            if (chart.Options.ShowGrid) {
+                writer
+                    .StartElement("line")
+                    .Attribute("x1", F(x))
+                    .Attribute("y1", F(plot.Top))
+                    .Attribute("x2", F(x))
+                    .Attribute("y2", F(plot.Bottom))
+                    .Attribute("stroke", t.Grid.ToCss())
+                    .Attribute("stroke-width", F(ChartVisualPrimitives.GridStrokeWidth))
+                    .Attribute("opacity", F(ChartVisualPrimitives.TimelineGridOpacity))
+                    .EndEmptyElement()
+                    .Line();
+            }
+
             if (chart.Options.ShowAxes) {
                 var rawLabel = FormatTimelineTick(chart, tick);
                 var labelFontSize = TextFontSizeForSvgWidth(rawLabel, tickLabelWidth, t.TickLabelFontSize);
                 var label = TrimSvgLabelToWidth(rawLabel, labelFontSize, tickLabelWidth);
                 var anchor = EdgeAwareAnchor(label, x, plot, labelFontSize);
                 var labelX = EdgeAwareTextX(label, x, plot, labelFontSize);
-                sb.AppendLine($"<text data-cfx-role=\"gantt-tick-label\" x=\"{F(labelX)}\" y=\"{F(plot.Bottom + 22)}\" text-anchor=\"{anchor}\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(labelFontSize)}\">{Escape(label)}</text>");
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "gantt-tick-label")
+                    .Attribute("x", F(labelX))
+                    .Attribute("y", F(plot.Bottom + 22))
+                    .Attribute("text-anchor", anchor)
+                    .Attribute("fill", t.MutedText.ToCss())
+                    .Attribute("font-family", GanttFontFamily(t.FontFamily))
+                    .Attribute("font-size", F(labelFontSize))
+                    .Raw(Escape(label))
+                    .EndElement()
+                    .Line();
             }
         }
 
@@ -54,50 +83,103 @@ public sealed partial class SvgChartRenderer {
             rowCenters[i] = centerY;
             startXs[i] = ProjectTimelineX(item.Start, min, max, plot);
             endXs[i] = ProjectTimelineX(item.End, min, max, plot);
-            if (chart.Options.ShowGrid) sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(centerY)}\" x2=\"{F(plot.Right)}\" y2=\"{F(centerY)}\" stroke=\"{t.Grid.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" opacity=\"{F(ChartVisualPrimitives.TimelineRowGridOpacity)}\"/>");
+            if (chart.Options.ShowGrid) {
+                writer
+                    .StartElement("line")
+                    .Attribute("x1", F(plot.Left))
+                    .Attribute("y1", F(centerY))
+                    .Attribute("x2", F(plot.Right))
+                    .Attribute("y2", F(centerY))
+                    .Attribute("stroke", t.Grid.ToCss())
+                    .Attribute("stroke-width", F(ChartVisualPrimitives.GridStrokeWidth))
+                    .Attribute("opacity", F(ChartVisualPrimitives.TimelineRowGridOpacity))
+                    .EndEmptyElement()
+                    .Line();
+            }
+
             if (chart.Options.ShowAxes) {
                 var rowLabelFontSize = TextFontSizeForSvgWidth(item.Name, rowLabelWidth, t.TickLabelFontSize);
                 var rowLabel = TrimSvgLabelToWidth(item.Name, rowLabelFontSize, rowLabelWidth);
-                sb.AppendLine($"<text data-cfx-role=\"gantt-row-label\" x=\"{F(plot.Left - 14)}\" y=\"{F(centerY)}\" text-anchor=\"end\" dominant-baseline=\"middle\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(rowLabelFontSize)}\" font-weight=\"650\">{Escape(rowLabel)}</text>");
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "gantt-row-label")
+                    .Attribute("x", F(plot.Left - 14))
+                    .Attribute("y", F(centerY))
+                    .Attribute("text-anchor", "end")
+                    .Attribute("dominant-baseline", "middle")
+                    .Attribute("fill", t.MutedText.ToCss())
+                    .Attribute("font-family", GanttFontFamily(t.FontFamily))
+                    .Attribute("font-size", F(rowLabelFontSize))
+                    .Attribute("font-weight", "650")
+                    .Raw(Escape(rowLabel))
+                    .EndElement()
+                    .Line();
             }
         }
 
         for (var i = 0; i < items.Count; i++) {
-            if (items[i].DependsOn >= 0 && items[i].DependsOn < i) DrawGanttDependency(sb, plot, endXs[items[i].DependsOn], rowCenters[items[i].DependsOn], startXs[i], rowCenters[i], t.Axis);
+            if (items[i].DependsOn >= 0 && items[i].DependsOn < i) DrawGanttDependency(writer, plot, endXs[items[i].DependsOn], rowCenters[items[i].DependsOn], startXs[i], rowCenters[i], t.Axis);
         }
 
-        if (chart.Options.GanttToday.HasValue) DrawGanttToday(sb, chart, plot, min, max);
+        if (chart.Options.GanttToday.HasValue) DrawGanttToday(writer, chart, plot, min, max);
 
         for (var i = 0; i < items.Count; i++) {
             var item = items[i];
             if (item.Milestone) {
-                DrawGanttMilestone(sb, chart, item, id, startXs[i], rowCenters[i], rowHeight);
+                DrawGanttMilestone(writer, chart, item, id, startXs[i], rowCenters[i], rowHeight);
                 continue;
             }
 
             var left = Math.Min(startXs[i], endXs[i]);
             var width = Math.Max(2, Math.Abs(endXs[i] - startXs[i]));
-            DrawGanttTask(sb, chart, item, id, i, left, rowCenters[i] - rowHeight / 2, width, rowHeight);
+            DrawGanttTask(writer, chart, item, id, i, left, rowCenters[i] - rowHeight / 2, width, rowHeight);
         }
 
         if (chart.Options.ShowAxes) {
-            sb.AppendLine($"<line x1=\"{F(plot.Left)}\" y1=\"{F(plot.Bottom)}\" x2=\"{F(plot.Right)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Axis.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.AxisStrokeWidth)}\"/>");
-            DrawSvgXAxisTitle(sb, chart, plot, plot.Bottom + 49, "gantt-x-axis-title");
+            writer
+                .StartElement("line")
+                .Attribute("x1", F(plot.Left))
+                .Attribute("y1", F(plot.Bottom))
+                .Attribute("x2", F(plot.Right))
+                .Attribute("y2", F(plot.Bottom))
+                .Attribute("stroke", t.Axis.ToCss())
+                .Attribute("stroke-width", F(ChartVisualPrimitives.AxisStrokeWidth))
+                .EndEmptyElement()
+                .Line();
+            DrawGanttSvgXAxisTitle(writer, chart, plot, plot.Bottom + 49, "gantt-x-axis-title");
             if (!string.IsNullOrWhiteSpace(chart.YAxisTitle)) {
                 var widestLabel = items.Max(item => EstimateTextWidth(item.Name, t.TickLabelFontSize));
-                DrawSvgYAxisTitle(sb, chart, plot, Math.Max(24, plot.Left - widestLabel - 46), "gantt-y-axis-title");
+                DrawGanttSvgYAxisTitle(writer, chart, plot, Math.Max(24, plot.Left - widestLabel - 46), "gantt-y-axis-title");
             }
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
-    private static void DrawGanttItemGradients(StringBuilder sb, string id, IReadOnlyList<GanttItem> items) {
-        sb.AppendLine("<defs>");
+    private static void DrawGanttItemGradients(SvgMarkupWriter writer, string id, IReadOnlyList<GanttItem> items) {
+        writer.StartElement("defs").EndStartElement().Line();
         foreach (var item in items) {
-            sb.AppendLine($"<linearGradient id=\"{id}-ganttFill{item.SeriesIndex}\" x1=\"0\" x2=\"0\" y1=\"0\" y2=\"1\"><stop offset=\"0%\" stop-color=\"{GanttTaskGradientTop(item.Color).ToHex()}\"/><stop offset=\"100%\" stop-color=\"{GanttTaskGradientBottom(item.Color).ToHex()}\"/></linearGradient>");
+            writer
+                .StartElement("linearGradient")
+                .Attribute("id", id + "-ganttFill" + item.SeriesIndex.ToString(CultureInfo.InvariantCulture))
+                .Attribute("x1", "0")
+                .Attribute("x2", "0")
+                .Attribute("y1", "0")
+                .Attribute("y2", "1")
+                .EndStartElement()
+                .StartElement("stop")
+                .Attribute("offset", "0%")
+                .Attribute("stop-color", GanttTaskGradientTop(item.Color).ToHex())
+                .EndEmptyElement()
+                .StartElement("stop")
+                .Attribute("offset", "100%")
+                .Attribute("stop-color", GanttTaskGradientBottom(item.Color).ToHex())
+                .EndEmptyElement()
+                .EndElement()
+                .Line();
         }
-        sb.AppendLine("</defs>");
+        writer.EndElement().Line();
     }
 
     private static List<GanttItem> BuildGanttItems(Chart chart) {
@@ -114,44 +196,220 @@ public sealed partial class SvgChartRenderer {
         return items;
     }
 
-    private static void DrawGanttTask(StringBuilder sb, Chart chart, GanttItem item, string id, int row, double left, double y, double width, double height) {
+    private static void DrawGanttTask(SvgMarkupWriter writer, Chart chart, GanttItem item, string id, int row, double left, double y, double width, double height) {
         var t = chart.Options.Theme;
         var radius = Math.Min(ChartVisualPrimitives.GanttTaskCornerRadiusMax, height / 2);
         var progressWidth = Math.Max(0, width * item.Progress);
         var summary = item.Name + ": " + FormatTimelineTick(chart, item.Start) + " to " + FormatTimelineTick(chart, item.End) + ", " + FormatPercent(item.Progress) + " complete";
         var borderStroke = ChartVisualPrimitives.GanttTaskBorderStrokeWidth;
         var borderInset = borderStroke / 2.0;
-        sb.AppendLine($"<rect data-cfx-role=\"gantt-task\" data-cfx-row=\"{row}\" data-cfx-start=\"{F(item.Start)}\" data-cfx-end=\"{F(item.End)}\" data-cfx-progress=\"{F(item.Progress)}\" role=\"img\" aria-label=\"{Escape(summary)}\" x=\"{F(left)}\" y=\"{F(y)}\" width=\"{F(width)}\" height=\"{F(height)}\" rx=\"{F(radius)}\" fill=\"{item.Color.ToCss()}\" opacity=\"{F(ChartVisualPrimitives.GanttTaskTrackOpacity)}\"/>");
-        if (progressWidth > 0.5) sb.AppendLine($"<rect data-cfx-role=\"gantt-progress\" x=\"{F(left)}\" y=\"{F(y)}\" width=\"{F(progressWidth)}\" height=\"{F(height)}\" rx=\"{F(radius)}\" fill=\"url(#{id}-ganttFill{item.SeriesIndex})\"/>");
-        sb.AppendLine($"<rect data-cfx-role=\"gantt-task-border\" x=\"{F(left + borderInset)}\" y=\"{F(y + borderInset)}\" width=\"{F(Math.Max(0, width - borderStroke))}\" height=\"{F(Math.Max(0, height - borderStroke))}\" rx=\"{F(Math.Max(0, radius - borderInset))}\" fill=\"none\" stroke=\"{t.CardBackground.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.GanttTaskBorderOpacity)}\" stroke-width=\"{F(borderStroke)}\"/>");
+        writer
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "gantt-task")
+            .Attribute("data-cfx-row", row)
+            .Attribute("data-cfx-start", F(item.Start))
+            .Attribute("data-cfx-end", F(item.End))
+            .Attribute("data-cfx-progress", F(item.Progress))
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .Attribute("x", F(left))
+            .Attribute("y", F(y))
+            .Attribute("width", F(width))
+            .Attribute("height", F(height))
+            .Attribute("rx", F(radius))
+            .Attribute("fill", item.Color.ToCss())
+            .Attribute("opacity", F(ChartVisualPrimitives.GanttTaskTrackOpacity))
+            .EndEmptyElement()
+            .Line();
+        if (progressWidth > 0.5) {
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-role", "gantt-progress")
+                .Attribute("x", F(left))
+                .Attribute("y", F(y))
+                .Attribute("width", F(progressWidth))
+                .Attribute("height", F(height))
+                .Attribute("rx", F(radius))
+                .Attribute("fill", "url(#" + id + "-ganttFill" + item.SeriesIndex.ToString(CultureInfo.InvariantCulture) + ")")
+                .EndEmptyElement()
+                .Line();
+        }
+
+        writer
+            .StartElement("rect")
+            .Attribute("data-cfx-role", "gantt-task-border")
+            .Attribute("x", F(left + borderInset))
+            .Attribute("y", F(y + borderInset))
+            .Attribute("width", F(Math.Max(0, width - borderStroke)))
+            .Attribute("height", F(Math.Max(0, height - borderStroke)))
+            .Attribute("rx", F(Math.Max(0, radius - borderInset)))
+            .Attribute("fill", "none")
+            .Attribute("stroke", t.CardBackground.ToCss())
+            .Attribute("stroke-opacity", F(ChartVisualPrimitives.GanttTaskBorderOpacity))
+            .Attribute("stroke-width", F(borderStroke))
+            .EndEmptyElement()
+            .Line();
         var inset = Math.Min(radius, width / 3);
-        if (width > inset * 2 + 3) sb.AppendLine($"<line data-cfx-role=\"gantt-task-highlight\" x1=\"{F(left + inset)}\" y1=\"{F(y + ChartVisualPrimitives.GanttTaskHighlightOffsetY)}\" x2=\"{F(left + width - inset)}\" y2=\"{F(y + ChartVisualPrimitives.GanttTaskHighlightOffsetY)}\" stroke=\"#fff\" stroke-opacity=\"{F(ChartVisualPrimitives.GanttTaskHighlightOpacity)}\" stroke-width=\"{F(ChartVisualPrimitives.GridStrokeWidth)}\" stroke-linecap=\"round\"/>");
-        if (item.ShowDataLabels && width >= 74) DrawSvgTextCenteredX(sb, chart, "gantt-progress-label", FormatPercent(item.Progress), left + width / 2, y + height / 2, HeatmapTextColor(item.Color), t.DataLabelFontSize, width - 8, "750", t.CardBackground, 2.2);
+        if (width > inset * 2 + 3) {
+            writer
+                .StartElement("line")
+                .Attribute("data-cfx-role", "gantt-task-highlight")
+                .Attribute("x1", F(left + inset))
+                .Attribute("y1", F(y + ChartVisualPrimitives.GanttTaskHighlightOffsetY))
+                .Attribute("x2", F(left + width - inset))
+                .Attribute("y2", F(y + ChartVisualPrimitives.GanttTaskHighlightOffsetY))
+                .Attribute("stroke", "#fff")
+                .Attribute("stroke-opacity", F(ChartVisualPrimitives.GanttTaskHighlightOpacity))
+                .Attribute("stroke-width", F(ChartVisualPrimitives.GridStrokeWidth))
+                .Attribute("stroke-linecap", "round")
+                .EndEmptyElement()
+                .Line();
+        }
+
+        if (item.ShowDataLabels && width >= 74) DrawGanttSvgTextCenteredX(writer, chart, "gantt-progress-label", FormatPercent(item.Progress), left + width / 2, y + height / 2, HeatmapTextColor(item.Color), t.DataLabelFontSize, width - 8, "750", t.CardBackground, 2.2);
     }
 
-    private static void DrawGanttMilestone(StringBuilder sb, Chart chart, GanttItem item, string id, double x, double centerY, double rowHeight) {
+    private static void DrawGanttMilestone(SvgMarkupWriter writer, Chart chart, GanttItem item, string id, double x, double centerY, double rowHeight) {
         var size = Math.Max(8, rowHeight * 0.44);
         var summary = item.Name + ": milestone at " + FormatTimelineTick(chart, item.Start);
         var points = F(x) + "," + F(centerY - size) + " " + F(x + size) + "," + F(centerY) + " " + F(x) + "," + F(centerY + size) + " " + F(x - size) + "," + F(centerY);
-        sb.AppendLine($"<polygon data-cfx-role=\"gantt-milestone\" data-cfx-start=\"{F(item.Start)}\" role=\"img\" aria-label=\"{Escape(summary)}\" points=\"{points}\" fill=\"url(#{id}-ganttFill{item.SeriesIndex})\" stroke=\"{chart.Options.Theme.CardBackground.ToCss()}\" stroke-opacity=\"{F(ChartVisualPrimitives.GanttTaskBorderOpacity)}\" stroke-width=\"{F(ChartVisualPrimitives.GanttTaskBorderStrokeWidth)}\"/>");
+        writer
+            .StartElement("polygon")
+            .Attribute("data-cfx-role", "gantt-milestone")
+            .Attribute("data-cfx-start", F(item.Start))
+            .Attribute("role", "img")
+            .Attribute("aria-label", summary)
+            .Attribute("points", points)
+            .Attribute("fill", "url(#" + id + "-ganttFill" + item.SeriesIndex.ToString(CultureInfo.InvariantCulture) + ")")
+            .Attribute("stroke", chart.Options.Theme.CardBackground.ToCss())
+            .Attribute("stroke-opacity", F(ChartVisualPrimitives.GanttTaskBorderOpacity))
+            .Attribute("stroke-width", F(ChartVisualPrimitives.GanttTaskBorderStrokeWidth))
+            .EndEmptyElement()
+            .Line();
     }
 
-    private static void DrawGanttDependency(StringBuilder sb, ChartRect plot, double fromX, double fromY, double toX, double toY, ChartColor color) {
+    private static void DrawGanttDependency(SvgMarkupWriter writer, ChartRect plot, double fromX, double fromY, double toX, double toY, ChartColor color) {
         var midX = Clamp(fromX + Math.Max(ChartVisualPrimitives.GanttDependencyMinMidOffset, (toX - fromX) / 2), plot.Left, plot.Right);
         var endX = Clamp(toX - ChartVisualPrimitives.GanttDependencyEndpointInset, plot.Left, plot.Right);
         var targetX = Clamp(toX, plot.Left, plot.Right);
         var path = "M " + F(Clamp(fromX + ChartVisualPrimitives.GanttDependencyEndpointInset, plot.Left, plot.Right)) + " " + F(fromY) + " H " + F(midX) + " V " + F(toY) + " H " + F(endX);
-        sb.AppendLine($"<path data-cfx-role=\"gantt-dependency\" d=\"{path}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GanttDependencyStrokeWidth)}\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-dasharray=\"{F(ChartVisualPrimitives.GanttDependencyDash)} {F(ChartVisualPrimitives.GanttDependencyGap)}\" opacity=\"{F(ChartVisualPrimitives.GanttDependencyOpacity)}\"/>");
-        sb.AppendLine($"<path data-cfx-role=\"gantt-dependency-arrow\" d=\"M {F(endX)} {F(toY - ChartVisualPrimitives.GanttDependencyArrowSize)} L {F(targetX)} {F(toY)} L {F(endX)} {F(toY + ChartVisualPrimitives.GanttDependencyArrowSize)}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GanttDependencyStrokeWidth)}\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"{F(ChartVisualPrimitives.GanttDependencyOpacity)}\"/>");
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", "gantt-dependency")
+            .Attribute("d", path)
+            .Attribute("fill", "none")
+            .Attribute("stroke", color.ToCss())
+            .Attribute("stroke-width", F(ChartVisualPrimitives.GanttDependencyStrokeWidth))
+            .Attribute("stroke-linecap", "round")
+            .Attribute("stroke-linejoin", "round")
+            .Attribute("stroke-dasharray", F(ChartVisualPrimitives.GanttDependencyDash) + " " + F(ChartVisualPrimitives.GanttDependencyGap))
+            .Attribute("opacity", F(ChartVisualPrimitives.GanttDependencyOpacity))
+            .EndEmptyElement()
+            .Line();
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-role", "gantt-dependency-arrow")
+            .Attribute("d", "M " + F(endX) + " " + F(toY - ChartVisualPrimitives.GanttDependencyArrowSize) + " L " + F(targetX) + " " + F(toY) + " L " + F(endX) + " " + F(toY + ChartVisualPrimitives.GanttDependencyArrowSize))
+            .Attribute("fill", "none")
+            .Attribute("stroke", color.ToCss())
+            .Attribute("stroke-width", F(ChartVisualPrimitives.GanttDependencyStrokeWidth))
+            .Attribute("stroke-linecap", "round")
+            .Attribute("stroke-linejoin", "round")
+            .Attribute("opacity", F(ChartVisualPrimitives.GanttDependencyOpacity))
+            .EndEmptyElement()
+            .Line();
     }
 
-    private static void DrawGanttToday(StringBuilder sb, Chart chart, ChartRect plot, double min, double max) {
+    private static void DrawGanttToday(SvgMarkupWriter writer, Chart chart, ChartRect plot, double min, double max) {
         var t = chart.Options.Theme;
         var x = ProjectTimelineX(chart.Options.GanttToday!.Value, min, max, plot);
         if (x < plot.Left || x > plot.Right) return;
-        sb.AppendLine($"<line data-cfx-role=\"gantt-today\" x1=\"{F(x)}\" y1=\"{F(plot.Top)}\" x2=\"{F(x)}\" y2=\"{F(plot.Bottom)}\" stroke=\"{t.Warning.ToCss()}\" stroke-width=\"{F(ChartVisualPrimitives.GanttTodayStrokeWidth)}\" stroke-dasharray=\"6 5\"/>");
-        DrawSvgTextCenteredX(sb, chart, "gantt-today-label", "Today", x, plot.Top - 8, t.Warning, t.TickLabelFontSize, 62, "750", t.CardBackground, 2.2, middleBaseline: false);
+        writer
+            .StartElement("line")
+            .Attribute("data-cfx-role", "gantt-today")
+            .Attribute("x1", F(x))
+            .Attribute("y1", F(plot.Top))
+            .Attribute("x2", F(x))
+            .Attribute("y2", F(plot.Bottom))
+            .Attribute("stroke", t.Warning.ToCss())
+            .Attribute("stroke-width", F(ChartVisualPrimitives.GanttTodayStrokeWidth))
+            .Attribute("stroke-dasharray", "6 5")
+            .EndEmptyElement()
+            .Line();
+        DrawGanttSvgTextCenteredX(writer, chart, "gantt-today-label", "Today", x, plot.Top - 8, t.Warning, t.TickLabelFontSize, 62, "750", t.CardBackground, 2.2, middleBaseline: false);
     }
+
+    private static void DrawGanttSvgXAxisTitle(SvgMarkupWriter writer, Chart chart, ChartRect plot, double y, string role) {
+        if (string.IsNullOrWhiteSpace(chart.XAxisTitle)) return;
+        DrawGanttSvgTextCenteredX(writer, chart, role, chart.XAxisTitle, plot.Left + plot.Width / 2, y, chart.Options.Theme.MutedText, chart.Options.Theme.AxisTitleFontSize, plot.Width - 4, "600", middleBaseline: false, style: chart.Options.AxisTitleStyle);
+    }
+
+    private static void DrawGanttSvgYAxisTitle(SvgMarkupWriter writer, Chart chart, ChartRect plot, double axisX, string role) {
+        if (string.IsNullOrWhiteSpace(chart.YAxisTitle)) return;
+        var t = chart.Options.Theme;
+        var maxWidth = Math.Max(40, plot.Height * 0.72);
+        var style = chart.Options.AxisTitleStyle;
+        var fontSize = TextFontSizeForSvgWidth(chart.YAxisTitle, maxWidth, StyleFontSize(style, t.AxisTitleFontSize));
+        var text = TrimSvgLabelToWidth(chart.YAxisTitle, fontSize, maxWidth);
+        if (text.Length == 0) return;
+
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", role)
+            .Attribute("transform", "translate(" + F(axisX) + " " + F(plot.Top + plot.Height / 2) + ") rotate(-90)")
+            .Attribute("text-anchor", "middle")
+            .Attribute("fill", StyleColor(style, t.MutedText).ToCss())
+            .Attribute("font-family", GanttFontFamily(StyleFontFamily(chart, style)))
+            .Attribute("font-size", F(fontSize))
+            .Attribute("font-weight", StyleWeight(style, "600"));
+        WriteGanttSvgTextStyleAttributes(writer, style);
+        writer
+            .Raw(Escape(text))
+            .EndElement()
+            .Line();
+    }
+
+    private static void DrawGanttSvgTextCenteredX(SvgMarkupWriter writer, Chart chart, string role, string text, double centerX, double y, ChartColor fill, double fontSize, double maxWidth, string fontWeight, ChartColor? stroke = null, double strokeWidth = 0, bool middleBaseline = true, ChartTextStyle? style = null) {
+        var preferredFontSize = StyleFontSize(style, fontSize);
+        var fittedFontSize = TextFontSizeForSvgWidth(text, Math.Max(8, maxWidth), preferredFontSize);
+        var fittedText = TrimSvgLabelToWidth(text, fittedFontSize, Math.Max(8, maxWidth));
+        if (fittedText.Length == 0) return;
+
+        writer
+            .StartElement("text")
+            .Attribute("data-cfx-role", role)
+            .Attribute("x", F(centerX))
+            .Attribute("y", F(y))
+            .Attribute("text-anchor", "middle");
+        if (middleBaseline) writer.Attribute("dominant-baseline", "middle");
+        writer.Attribute("fill", StyleColor(style, fill).ToCss());
+        if (stroke.HasValue && strokeWidth > 0) {
+            writer
+                .Attribute("stroke", stroke.Value.ToCss())
+                .Attribute("stroke-width", F(strokeWidth))
+                .Attribute("paint-order", "stroke fill")
+                .Attribute("stroke-linejoin", "round");
+        }
+
+        writer
+            .Attribute("font-family", GanttFontFamily(StyleFontFamily(chart, style)))
+            .Attribute("font-size", F(fittedFontSize))
+            .Attribute("font-weight", StyleWeight(style, fontWeight));
+        WriteGanttSvgTextStyleAttributes(writer, style);
+        writer
+            .Raw(Escape(fittedText))
+            .EndElement()
+            .Line();
+    }
+
+    private static void WriteGanttSvgTextStyleAttributes(SvgMarkupWriter writer, ChartTextStyle? style) {
+        if (style == null) return;
+        if (style.Italic) writer.Attribute("font-style", "italic");
+        if (style.Underline) writer.Attribute("text-decoration", "underline");
+    }
+
+    private static string GanttFontFamily(string value) =>
+        string.IsNullOrWhiteSpace(value) ? "system-ui, sans-serif" : value;
 
     private static ChartRect ApplyGanttReserve(Chart chart, ChartRect plot, IReadOnlyList<GanttItem> items) {
         var t = chart.Options.Theme;

--- a/ChartForgeX/Svg/SvgChartRenderer.Pictorial.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Pictorial.cs
@@ -33,7 +33,21 @@ public sealed partial class SvgChartRenderer {
         var startY = plot.Top + Math.Max(0, (plot.Height - totalHeight) / 2);
         var customSymbol = chart.Options.PictorialSvgPathData != null;
         var valuePerSymbolMetadata = valuePerSymbol.HasValue ? F(valuePerSymbol.Value) : "proportional";
-        sb.AppendLine($"<g data-cfx-role=\"pictorial-chart\" data-cfx-shape=\"{chart.Options.PictorialShape}\" data-cfx-custom-symbol=\"{(customSymbol ? "true" : "false")}\" data-cfx-png-fallback-shape=\"{chart.Options.PictorialPngFallbackShape}\" data-cfx-columns=\"{columns}\" data-cfx-maximum=\"{F(max)}\" data-cfx-value-per-symbol=\"{valuePerSymbolMetadata}\" data-cfx-show-values=\"{(showValues ? "true" : "false")}\" data-cfx-symbol-scale=\"{F(chart.Options.PictorialSymbolScale)}\" data-cfx-empty-opacity=\"{F(chart.Options.PictorialEmptyOpacity)}\">");
+        var writer = new SvgMarkupWriter(4096);
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "pictorial-chart")
+            .Attribute("data-cfx-shape", chart.Options.PictorialShape.ToString())
+            .Attribute("data-cfx-custom-symbol", customSymbol)
+            .Attribute("data-cfx-png-fallback-shape", chart.Options.PictorialPngFallbackShape.ToString())
+            .Attribute("data-cfx-columns", columns)
+            .Attribute("data-cfx-maximum", max)
+            .Attribute("data-cfx-value-per-symbol", valuePerSymbolMetadata)
+            .Attribute("data-cfx-show-values", showValues)
+            .Attribute("data-cfx-symbol-scale", chart.Options.PictorialSymbolScale)
+            .Attribute("data-cfx-empty-opacity", chart.Options.PictorialEmptyOpacity)
+            .EndStartElement()
+            .Line();
         var symbolRow = 0;
         for (var i = 0; i < values.Length; i++) {
             var rowsForItem = symbolRows[i];
@@ -44,7 +58,20 @@ public sealed partial class SvgChartRenderer {
             var labelFontSize = TextFontSizeForSvgWidth(rawLabel, labelMaxWidth, t.TickLabelFontSize);
             var label = TrimSvgLabelToWidth(rawLabel, labelFontSize, labelMaxWidth);
             if (label.Length > 0) {
-                sb.AppendLine($"<text data-cfx-role=\"pictorial-label\" data-cfx-point=\"{i}\" x=\"{F(plot.Left + labelWidth - 8)}\" y=\"{F(labelY + labelFontSize / 3.0)}\" text-anchor=\"end\" fill=\"{t.MutedText.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(labelFontSize)}\" font-weight=\"700\">{Escape(label)}</text>");
+                writer
+                    .StartElement("text")
+                    .Attribute("data-cfx-role", "pictorial-label")
+                    .Attribute("data-cfx-point", i)
+                    .Attribute("x", plot.Left + labelWidth - 8)
+                    .Attribute("y", labelY + labelFontSize / 3.0)
+                    .Attribute("text-anchor", "end")
+                    .Attribute("fill", t.MutedText.ToCss())
+                    .Attribute("font-family", SvgFontFamily(t.FontFamily))
+                    .Attribute("font-size", labelFontSize)
+                    .Attribute("font-weight", "700")
+                    .Raw(Escape(label))
+                    .EndElement()
+                    .Line();
             }
             var color = PictorialItemColor(series, t, i);
             var filled = valuePerSymbol.HasValue ? values[i].Y / valuePerSymbol.Value : values[i].Y / max * columns;
@@ -55,7 +82,7 @@ public sealed partial class SvgChartRenderer {
                     var x = startX + column * (symbolSize + gap);
                     var emptyColor = PictorialOpacity(t.Grid, chart.Options.PictorialEmptyOpacity);
                     var symbolId = id + "-pictorial-" + i.ToString(System.Globalization.CultureInfo.InvariantCulture) + "-" + row.ToString(System.Globalization.CultureInfo.InvariantCulture) + "-" + column.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                    DrawPictorialSymbol(sb, chart.Options, symbolId, x + symbolSize / 2, y, symbolSize / 2, color, emptyColor, amount, row);
+                    DrawPictorialSymbol(writer, chart.Options, symbolId, x + symbolSize / 2, y, symbolSize / 2, color, emptyColor, amount, row);
                 }
             }
 
@@ -65,14 +92,29 @@ public sealed partial class SvgChartRenderer {
                 var valueFontSize = TextFontSizeForSvgWidth(rawValue, valueMaxWidth, t.DataLabelFontSize);
                 var value = TrimSvgLabelToWidth(rawValue, valueFontSize, valueMaxWidth);
                 if (value.Length > 0) {
-                    sb.AppendLine($"<text data-cfx-role=\"pictorial-value\" data-cfx-point=\"{i}\" data-cfx-label=\"{Escape(label)}\" data-cfx-value=\"{F(values[i].Y)}\" x=\"{F(startX + symbolArea + 12)}\" y=\"{F(labelY + valueFontSize / 3.0)}\" fill=\"{t.Text.ToCss()}\" font-family=\"{SvgFontFamily(t.FontFamily)}\" font-size=\"{F(valueFontSize)}\" font-weight=\"800\">{Escape(value)}</text>");
+                    writer
+                        .StartElement("text")
+                        .Attribute("data-cfx-role", "pictorial-value")
+                        .Attribute("data-cfx-point", i)
+                        .Attribute("data-cfx-label", label)
+                        .Attribute("data-cfx-value", values[i].Y)
+                        .Attribute("x", startX + symbolArea + 12)
+                        .Attribute("y", labelY + valueFontSize / 3.0)
+                        .Attribute("fill", t.Text.ToCss())
+                        .Attribute("font-family", SvgFontFamily(t.FontFamily))
+                        .Attribute("font-size", valueFontSize)
+                        .Attribute("font-weight", "800")
+                        .Raw(Escape(value))
+                        .EndElement()
+                        .Line();
                 }
             }
 
             symbolRow += rowsForItem;
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
+        sb.Append(writer.Build());
     }
 
     private static int[] BuildPictorialSymbolRows(ChartPoint[] values, int columns, double? valuePerSymbol) {
@@ -84,55 +126,157 @@ public sealed partial class SvgChartRenderer {
         return rows;
     }
 
-    private static void DrawPictorialSymbol(StringBuilder sb, ChartOptions options, string symbolId, double cx, double cy, double radius, ChartColor fillColor, ChartColor emptyColor, double fillAmount, int row) {
+    private static void DrawPictorialSymbol(SvgMarkupWriter writer, ChartOptions options, string symbolId, double cx, double cy, double radius, ChartColor fillColor, ChartColor emptyColor, double fillAmount, int row) {
         var fill = F(fillAmount);
-        sb.AppendLine($"<g data-cfx-role=\"pictorial-symbol\" data-cfx-fill=\"{fill}\" data-cfx-row=\"{row}\" data-cfx-partial-fill=\"{(fillAmount > 0 && fillAmount < 1 ? "clip" : "none")}\">");
+        writer
+            .StartElement("g")
+            .Attribute("data-cfx-role", "pictorial-symbol")
+            .Attribute("data-cfx-fill", fill)
+            .Attribute("data-cfx-row", row)
+            .Attribute("data-cfx-partial-fill", fillAmount > 0 && fillAmount < 1 ? "clip" : "none")
+            .EndStartElement()
+            .Line();
         if (fillAmount <= 0) {
-            AppendPictorialSymbolShape(sb, options, cx, cy, radius, emptyColor, "empty");
+            AppendPictorialSymbolShape(writer, options, cx, cy, radius, emptyColor, "empty");
         } else if (fillAmount >= 1) {
-            AppendPictorialSymbolShape(sb, options, cx, cy, radius, fillColor, "fill");
+            AppendPictorialSymbolShape(writer, options, cx, cy, radius, fillColor, "fill");
         } else {
-            AppendPictorialSymbolShape(sb, options, cx, cy, radius, emptyColor, "empty");
-            sb.AppendLine($"<clipPath id=\"{symbolId}-clip\"><rect x=\"{F(cx - radius)}\" y=\"{F(cy - radius)}\" width=\"{F(radius * 2 * fillAmount)}\" height=\"{F(radius * 2)}\"/></clipPath>");
-            sb.AppendLine($"<g clip-path=\"url(#{symbolId}-clip)\">");
-            AppendPictorialSymbolShape(sb, options, cx, cy, radius, fillColor, "partial-fill");
-            sb.AppendLine("</g>");
+            AppendPictorialSymbolShape(writer, options, cx, cy, radius, emptyColor, "empty");
+            writer
+                .StartElement("clipPath")
+                .Attribute("id", symbolId + "-clip")
+                .EndStartElement()
+                .StartElement("rect")
+                .Attribute("x", cx - radius)
+                .Attribute("y", cy - radius)
+                .Attribute("width", radius * 2 * fillAmount)
+                .Attribute("height", radius * 2)
+                .EndEmptyElement()
+                .EndElement()
+                .Line()
+                .StartElement("g")
+                .Attribute("clip-path", "url(#" + symbolId + "-clip)")
+                .EndStartElement()
+                .Line();
+            AppendPictorialSymbolShape(writer, options, cx, cy, radius, fillColor, "partial-fill");
+            writer.EndElement().Line();
         }
 
-        sb.AppendLine("</g>");
+        writer.EndElement().Line();
     }
 
-    private static void AppendPictorialSymbolShape(StringBuilder sb, ChartOptions options, double cx, double cy, double radius, ChartColor color, string layer) {
+    private static void AppendPictorialSymbolShape(SvgMarkupWriter writer, ChartOptions options, double cx, double cy, double radius, ChartColor color, string layer) {
         if (options.PictorialSvgPathData != null) {
             var vb = options.PictorialSvgPathViewBox;
             var scaleX = radius * 2 / vb.Width;
             var scaleY = radius * 2 / vb.Height;
-            sb.AppendLine($"<path data-cfx-symbol-layer=\"{layer}\" data-cfx-custom-symbol=\"true\" d=\"{options.PictorialSvgPathData}\" transform=\"translate({F(cx - radius)} {F(cy - radius)}) scale({F(scaleX)} {F(scaleY)}) translate({F(-vb.X)} {F(-vb.Y)})\" fill=\"{color.ToCss()}\"/>");
+            writer
+                .StartElement("path")
+                .Attribute("data-cfx-symbol-layer", layer)
+                .Attribute("data-cfx-custom-symbol", "true")
+                .Attribute("d", options.PictorialSvgPathData)
+                .Attribute("transform", $"translate({F(cx - radius)} {F(cy - radius)}) scale({F(scaleX)} {F(scaleY)}) translate({F(-vb.X)} {F(-vb.Y)})")
+                .Attribute("fill", color.ToCss())
+                .EndEmptyElement()
+                .Line();
             return;
         }
 
         var shape = options.PictorialShape;
         if (shape == ChartPictorialShape.Square) {
-            sb.AppendLine($"<rect data-cfx-symbol-layer=\"{layer}\" x=\"{F(cx - radius)}\" y=\"{F(cy - radius)}\" width=\"{F(radius * 2)}\" height=\"{F(radius * 2)}\" rx=\"{F(radius * 0.26)}\" fill=\"{color.ToCss()}\"/>");
+            writer
+                .StartElement("rect")
+                .Attribute("data-cfx-symbol-layer", layer)
+                .Attribute("x", cx - radius)
+                .Attribute("y", cy - radius)
+                .Attribute("width", radius * 2)
+                .Attribute("height", radius * 2)
+                .Attribute("rx", radius * 0.26)
+                .Attribute("fill", color.ToCss())
+                .EndEmptyElement()
+                .Line();
         } else if (shape == ChartPictorialShape.Diamond) {
-            sb.AppendLine($"<path data-cfx-symbol-layer=\"{layer}\" d=\"M {F(cx)} {F(cy - radius)} L {F(cx + radius)} {F(cy)} L {F(cx)} {F(cy + radius)} L {F(cx - radius)} {F(cy)} Z\" fill=\"{color.ToCss()}\"/>");
+            WritePictorialPath(writer, layer, $"M {F(cx)} {F(cy - radius)} L {F(cx + radius)} {F(cy)} L {F(cx)} {F(cy + radius)} L {F(cx - radius)} {F(cy)} Z", color);
         } else if (shape == ChartPictorialShape.Triangle) {
-            sb.AppendLine($"<path data-cfx-symbol-layer=\"{layer}\" d=\"M {F(cx)} {F(cy - radius)} L {F(cx + radius)} {F(cy + radius)} L {F(cx - radius)} {F(cy + radius)} Z\" fill=\"{color.ToCss()}\"/>");
+            WritePictorialPath(writer, layer, $"M {F(cx)} {F(cy - radius)} L {F(cx + radius)} {F(cy + radius)} L {F(cx - radius)} {F(cy + radius)} Z", color);
         } else if (shape == ChartPictorialShape.Star) {
-            sb.AppendLine($"<path data-cfx-symbol-layer=\"{layer}\" d=\"{BuildStarPath(cx, cy, radius, radius * 0.44)}\" fill=\"{color.ToCss()}\"/>");
+            WritePictorialPath(writer, layer, BuildStarPath(cx, cy, radius, radius * 0.44), color);
         } else if (shape == ChartPictorialShape.Heart) {
-            sb.AppendLine($"<path data-cfx-symbol-layer=\"{layer}\" d=\"{BuildHeartPath(cx, cy, radius)}\" fill=\"{color.ToCss()}\"/>");
+            WritePictorialPath(writer, layer, BuildHeartPath(cx, cy, radius), color);
         } else if (shape == ChartPictorialShape.Shield) {
-            sb.AppendLine($"<path data-cfx-symbol-layer=\"{layer}\" d=\"M {F(cx)} {F(cy - radius)} C {F(cx + radius * 0.72)} {F(cy - radius * 0.72)} {F(cx + radius * 0.82)} {F(cy - radius * 0.64)} {F(cx + radius * 0.82)} {F(cy - radius * 0.22)} C {F(cx + radius * 0.82)} {F(cy + radius * 0.48)} {F(cx + radius * 0.35)} {F(cy + radius * 0.85)} {F(cx)} {F(cy + radius)} C {F(cx - radius * 0.35)} {F(cy + radius * 0.85)} {F(cx - radius * 0.82)} {F(cy + radius * 0.48)} {F(cx - radius * 0.82)} {F(cy - radius * 0.22)} C {F(cx - radius * 0.82)} {F(cy - radius * 0.64)} {F(cx - radius * 0.72)} {F(cy - radius * 0.72)} {F(cx)} {F(cy - radius)} Z\" fill=\"{color.ToCss()}\"/>");
+            WritePictorialPath(writer, layer, $"M {F(cx)} {F(cy - radius)} C {F(cx + radius * 0.72)} {F(cy - radius * 0.72)} {F(cx + radius * 0.82)} {F(cy - radius * 0.64)} {F(cx + radius * 0.82)} {F(cy - radius * 0.22)} C {F(cx + radius * 0.82)} {F(cy + radius * 0.48)} {F(cx + radius * 0.35)} {F(cy + radius * 0.85)} {F(cx)} {F(cy + radius)} C {F(cx - radius * 0.35)} {F(cy + radius * 0.85)} {F(cx - radius * 0.82)} {F(cy + radius * 0.48)} {F(cx - radius * 0.82)} {F(cy - radius * 0.22)} C {F(cx - radius * 0.82)} {F(cy - radius * 0.64)} {F(cx - radius * 0.72)} {F(cy - radius * 0.72)} {F(cx)} {F(cy - radius)} Z", color);
         } else if (shape == ChartPictorialShape.Check) {
-            sb.AppendLine($"<path data-cfx-symbol-layer=\"{layer}\" d=\"M {F(cx - radius * 0.72)} {F(cy - radius * 0.02)} L {F(cx - radius * 0.22)} {F(cy + radius * 0.52)} L {F(cx + radius * 0.76)} {F(cy - radius * 0.56)}\" fill=\"none\" stroke=\"{color.ToCss()}\" stroke-width=\"{F(Math.Max(2, radius * 0.34))}\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>");
+            writer
+                .StartElement("path")
+                .Attribute("data-cfx-symbol-layer", layer)
+                .Attribute("d", $"M {F(cx - radius * 0.72)} {F(cy - radius * 0.02)} L {F(cx - radius * 0.22)} {F(cy + radius * 0.52)} L {F(cx + radius * 0.76)} {F(cy - radius * 0.56)}")
+                .Attribute("fill", "none")
+                .Attribute("stroke", color.ToCss())
+                .Attribute("stroke-width", Math.Max(2, radius * 0.34))
+                .Attribute("stroke-linecap", "round")
+                .Attribute("stroke-linejoin", "round")
+                .EndEmptyElement()
+                .Line();
         } else if (shape == ChartPictorialShape.Person) {
-            sb.AppendLine($"<g data-cfx-symbol-layer=\"{layer}\" fill=\"{color.ToCss()}\"><circle cx=\"{F(cx)}\" cy=\"{F(cy - radius * 0.48)}\" r=\"{F(radius * 0.34)}\"/><path d=\"M {F(cx - radius * 0.64)} {F(cy + radius * 0.74)} C {F(cx - radius * 0.56)} {F(cy + radius * 0.02)} {F(cx - radius * 0.34)} {F(cy - radius * 0.04)} {F(cx)} {F(cy - radius * 0.04)} C {F(cx + radius * 0.34)} {F(cy - radius * 0.04)} {F(cx + radius * 0.56)} {F(cy + radius * 0.02)} {F(cx + radius * 0.64)} {F(cy + radius * 0.74)} Z\"/></g>");
+            writer
+                .StartElement("g")
+                .Attribute("data-cfx-symbol-layer", layer)
+                .Attribute("fill", color.ToCss())
+                .EndStartElement()
+                .StartElement("circle")
+                .Attribute("cx", cx)
+                .Attribute("cy", cy - radius * 0.48)
+                .Attribute("r", radius * 0.34)
+                .EndEmptyElement()
+                .StartElement("path")
+                .Attribute("d", $"M {F(cx - radius * 0.64)} {F(cy + radius * 0.74)} C {F(cx - radius * 0.56)} {F(cy + radius * 0.02)} {F(cx - radius * 0.34)} {F(cy - radius * 0.04)} {F(cx)} {F(cy - radius * 0.04)} C {F(cx + radius * 0.34)} {F(cy - radius * 0.04)} {F(cx + radius * 0.56)} {F(cy + radius * 0.02)} {F(cx + radius * 0.64)} {F(cy + radius * 0.74)} Z")
+                .EndEmptyElement()
+                .EndElement()
+                .Line();
         } else if (shape == ChartPictorialShape.PersonDress) {
-            sb.AppendLine($"<g data-cfx-symbol-layer=\"{layer}\" fill=\"{color.ToCss()}\"><circle cx=\"{F(cx)}\" cy=\"{F(cy - radius * 0.55)}\" r=\"{F(radius * 0.30)}\"/><path d=\"M {F(cx)} {F(cy - radius * 0.12)} L {F(cx + radius * 0.62)} {F(cy + radius * 0.72)} L {F(cx - radius * 0.62)} {F(cy + radius * 0.72)} Z\"/><rect x=\"{F(cx - radius * 0.30)}\" y=\"{F(cy - radius * 0.18)}\" width=\"{F(radius * 0.60)}\" height=\"{F(radius * 0.36)}\" rx=\"{F(radius * 0.14)}\"/></g>");
+            writer
+                .StartElement("g")
+                .Attribute("data-cfx-symbol-layer", layer)
+                .Attribute("fill", color.ToCss())
+                .EndStartElement()
+                .StartElement("circle")
+                .Attribute("cx", cx)
+                .Attribute("cy", cy - radius * 0.55)
+                .Attribute("r", radius * 0.30)
+                .EndEmptyElement()
+                .StartElement("path")
+                .Attribute("d", $"M {F(cx)} {F(cy - radius * 0.12)} L {F(cx + radius * 0.62)} {F(cy + radius * 0.72)} L {F(cx - radius * 0.62)} {F(cy + radius * 0.72)} Z")
+                .EndEmptyElement()
+                .StartElement("rect")
+                .Attribute("x", cx - radius * 0.30)
+                .Attribute("y", cy - radius * 0.18)
+                .Attribute("width", radius * 0.60)
+                .Attribute("height", radius * 0.36)
+                .Attribute("rx", radius * 0.14)
+                .EndEmptyElement()
+                .EndElement()
+                .Line();
         } else {
-            sb.AppendLine($"<circle data-cfx-symbol-layer=\"{layer}\" cx=\"{F(cx)}\" cy=\"{F(cy)}\" r=\"{F(radius)}\" fill=\"{color.ToCss()}\"/>");
+            writer
+                .StartElement("circle")
+                .Attribute("data-cfx-symbol-layer", layer)
+                .Attribute("cx", cx)
+                .Attribute("cy", cy)
+                .Attribute("r", radius)
+                .Attribute("fill", color.ToCss())
+                .EndEmptyElement()
+                .Line();
         }
+    }
+
+    private static void WritePictorialPath(SvgMarkupWriter writer, string layer, string path, ChartColor color) {
+        writer
+            .StartElement("path")
+            .Attribute("data-cfx-symbol-layer", layer)
+            .Attribute("d", path)
+            .Attribute("fill", color.ToCss())
+            .EndEmptyElement()
+            .Line();
     }
 
     private static ChartColor PictorialOpacity(ChartColor color, double opacity) =>


### PR DESCRIPTION
## Summary

- Migrates the Bullet, Gantt, and Pictorial SVG renderers from raw SVG string appends to `SvgMarkupWriter`.
- Preserves renderer-specific metadata, role/aria labels, numeric formatting, labels, gradients, task/milestone/dependency output, bullet ranges/targets/status markers, and pictorial symbol/clip behavior.
- Keeps the batch scoped to specialized chart renderers; map/DottedMap and root/helper surfaces remain separate follow-up work.

## Validation

- `git diff --check`
- `dotnet build ChartForgeX.sln -c Debug -m:1 -nr:false`
- `dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Debug --no-build` - passed, 242/242
- `dotnet build ChartForgeX.Examples\ChartForgeX.Examples.csproj -c Release -m:1 -nr:false`
- `dotnet ChartForgeX.Examples\bin\Release\net8.0\ChartForgeX.Examples.dll`
- `.\Build.ps1 -Configuration Release` - passed, including release tests, examples generation, and package creation
- `git diff --cached --check`
