### PR TITLE
Add reusable metric card visual blocks

### DIFF
--- a/ChartForgeX.Examples/WellnessDashboardExamples.cs
+++ b/ChartForgeX.Examples/WellnessDashboardExamples.cs
@@ -13,11 +13,15 @@ internal static class WellnessDashboardExamples {
     private static readonly ChartColor Orange = ChartColor.FromHex("#FF9F4A");
     private static readonly ChartColor Yellow = ChartColor.FromHex("#FFCD62");
     private static readonly ChartColor Green = ChartColor.FromHex("#BDE765");
+    private static readonly ChartColor Cyan = ChartColor.FromHex("#38BDF8");
+    private static readonly ChartColor Emerald = ChartColor.FromHex("#34D399");
 
     public static void Write(string output, ChartPngOutputScale pngOutputScale) {
         SaveLayeredRadial(output, pngOutputScale);
         SaveWeightCard(output, (int)pngOutputScale);
         SaveCaloriesCard(output, (int)pngOutputScale);
+        SavePowerBgInfoStatsSection(output, (int)pngOutputScale);
+        SaveReportMetricStrip(output, (int)pngOutputScale);
     }
 
     private static void SaveLayeredRadial(string output, ChartPngOutputScale pngOutputScale) {
@@ -90,6 +94,7 @@ internal static class WellnessDashboardExamples {
             .WithTheme(WellnessTheme())
             .WithIcon(VisualIcon.ForkKnife)
             .WithMetric("Eaten calories", "1750 kcal")
+            .WithMiniBars(new[] { 42d, 56d, 49d, 64d, 71d }, maximum: 100, color: Orange, mutedColor: Muted.WithAlpha(72))
             .WithCaption("Logged intake");
 
         var burned = MetricCard.Create()
@@ -97,6 +102,7 @@ internal static class WellnessDashboardExamples {
             .WithTheme(WellnessTheme())
             .WithIcon(VisualIcon.Flame)
             .WithMetric("Burned calories", "510 kcal")
+            .WithMiniBars(new[] { 22d, 34d, 39d, 32d, 46d }, maximum: 60, color: Green, mutedColor: Muted.WithAlpha(72))
             .WithCaption("Activity estimate");
 
         var macros = Chart.Create()
@@ -131,6 +137,95 @@ internal static class WellnessDashboardExamples {
         grid.SaveSvg(Path.Combine(output, "wellness-calories-intake-dashboard.svg"));
         grid.SaveHtml(Path.Combine(output, "wellness-calories-intake-dashboard.html"));
         grid.SavePng(Path.Combine(output, "wellness-calories-intake-dashboard.png"));
+    }
+
+    private static void SavePowerBgInfoStatsSection(string output, int outputScale) {
+        var theme = ChartTheme.ReportDark()
+            .WithSurfaceColors(ChartColor.FromHex("#101319"), ChartColor.FromHex("#171B22"), ChartColor.FromHex("#171B22"), ChartColor.FromHex("#222834"), ChartColor.FromHex("#2A3240"))
+            .WithTextColors(ChartColor.FromHex("#F8FAFC"), ChartColor.FromHex("#A6ADBB"))
+            .WithPalette(Emerald.ToHex(), Cyan.ToHex(), Yellow.ToHex(), Orange.ToHex())
+            .WithCornerRadius(18, 10);
+
+        MetricCard Card(string label, string value, string trend, string caption, string symbol, VisualStatus status, double[] history, ChartColor color) =>
+            MetricCard.Create()
+                .WithSize(320, 176)
+                .WithTheme(theme)
+                .WithMetric(label, value)
+                .WithTrend(trend)
+                .WithCaption(caption)
+                .WithSymbol(symbol)
+                .WithBadgePlacement(MetricCardBadgePlacement.TopLeft)
+                .WithStatus(status)
+                .WithAction("View details")
+                .WithMiniBars(history, maximum: 100, color: color, mutedColor: ChartColor.FromHex("#64748B").WithAlpha(112));
+
+        MetricCard SparkCard(string label, string value, string trend, string caption, string symbol, VisualStatus status, double[] history, ChartColor color) =>
+            MetricCard.Create()
+                .WithSize(320, 176)
+                .WithTheme(theme)
+                .WithMetric(label, value)
+                .WithTrend(trend)
+                .WithCaption(caption)
+                .WithSymbol(symbol)
+                .WithBadgePlacement(MetricCardBadgePlacement.TopLeft)
+                .WithStatus(status)
+                .WithAction("View details")
+                .WithMiniSparkline(history, color: color, fillColor: color.WithAlpha(42));
+
+        var cards = new[] {
+            SparkCard("CPU Load", "38%", "-6%", "5 minute trend", "CPU", VisualStatus.Positive, new[] { 52d, 48d, 44d, 41d, 38d }, Emerald),
+            Card("Memory Used", "71%", "+4%", "since boot", "RAM", VisualStatus.Warning, new[] { 55d, 59d, 63d, 68d, 71d }, Yellow),
+            Card("Disk Free", "128 GB", "-12 GB", "system volume", "SSD", VisualStatus.Positive, new[] { 92d, 87d, 82d, 76d, 71d }, Cyan),
+            SparkCard("Network", "842 Mbps", "+18%", "active adapter", "LAN", VisualStatus.Info, new[] { 24d, 48d, 37d, 64d, 82d }, Orange)
+        };
+
+        var grid = VisualGrid.CreateMetricStrip("Endpoint Snapshot", cards)
+            .WithSubtitle("PowerBGInfo-style reusable metric cards with embedded micro visuals.")
+            .WithTheme(theme)
+            .WithPngOutputScale(outputScale);
+
+        grid.SaveSvg(Path.Combine(output, "powerbginfo-endpoint-snapshot.svg"));
+        grid.SaveHtml(Path.Combine(output, "powerbginfo-endpoint-snapshot.html"));
+        grid.SavePng(Path.Combine(output, "powerbginfo-endpoint-snapshot.png"));
+    }
+
+    private static void SaveReportMetricStrip(string output, int outputScale) {
+        var theme = ChartTheme.ReportLight()
+            .WithSurfaceColors(ChartColor.FromHex("#F8FAFC"), ChartColor.FromHex("#FFFFFF"), ChartColor.FromHex("#FFFFFF"), ChartColor.FromHex("#EFF4FB"), ChartColor.FromHex("#D8E1EF"))
+            .WithTextColors(ChartColor.FromHex("#172033"), ChartColor.FromHex("#647086"))
+            .WithPalette("#2563EB", "#14B8A6", "#F59E0B", "#EF4444")
+            .WithCornerRadius(14, 8);
+
+        MetricCard Card(string label, string value, string trend, string caption, string symbol, VisualStatus status, double[] history, ChartColor color, bool sparkline) {
+            var card = MetricCard.Create()
+                .WithSize(300, 170)
+                .WithTheme(theme)
+                .WithMetric(label, value)
+                .WithTrend(trend)
+                .WithCaption(caption)
+                .WithSymbol(symbol)
+                .WithBadgePlacement(MetricCardBadgePlacement.TopLeft)
+                .WithStatus(status)
+                .WithAction("Open report", url: "#report-" + label.ToLowerInvariant().Replace(' ', '-'));
+            return sparkline
+                ? card.WithMiniSparkline(history, color: color, fillColor: color.WithAlpha(36))
+                : card.WithMiniBars(history, maximum: 100, color: color, mutedColor: ChartColor.FromHex("#CBD5E1").WithAlpha(160));
+        }
+
+        var cards = new[] {
+            Card("Patch Rate", "94%", "+4 pp", "last 30 days", "OK", VisualStatus.Positive, new[] { 80d, 84d, 88d, 91d, 94d }, ChartColor.FromHex("#2563EB"), true),
+            Card("Warnings", "18", "-7", "open controls", "WRN", VisualStatus.Warning, new[] { 72d, 64d, 51d, 42d, 35d }, ChartColor.FromHex("#F59E0B"), false),
+            Card("Coverage", "1,284", "+96", "assets scanned", "INV", VisualStatus.Info, new[] { 44d, 58d, 63d, 77d, 86d }, ChartColor.FromHex("#14B8A6"), true)
+        };
+
+        var grid = VisualGrid.CreateMetricStrip("Report Summary", cards, columns: 3, panelWidth: 300, panelHeight: 170)
+            .WithSubtitle("Light-theme metric strip for generated reports, email, and document surfaces.")
+            .WithTheme(theme)
+            .WithPngOutputScale(outputScale);
+
+        grid.SaveSvg(Path.Combine(output, "report-summary-metric-strip.svg"));
+        grid.SaveHtml(Path.Combine(output, "report-summary-metric-strip.html"));
+        grid.SavePng(Path.Combine(output, "report-summary-metric-strip.png"));
     }
 
     private static ChartTheme WellnessTheme() => ChartTheme.Minimal()

--- a/ChartForgeX.Examples/visual-baseline.json
+++ b/ChartForgeX.Examples/visual-baseline.json
@@ -582,14 +582,14 @@
       "width": 760,
       "height": 460,
       "svg": {
-        "minVisualNodes": 189,
+        "minVisualNodes": 94,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 634496,
-        "minDistinctColors": 1598,
+        "minDistinctColors": 1684,
         "maxEdgeInkPixels": 0
       }
     },
@@ -598,14 +598,14 @@
       "width": 760,
       "height": 460,
       "svg": {
-        "minVisualNodes": 181,
+        "minVisualNodes": 90,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 634496,
-        "minDistinctColors": 1437,
+        "minDistinctColors": 1523,
         "maxEdgeInkPixels": 0
       }
     },
@@ -614,14 +614,14 @@
       "width": 760,
       "height": 460,
       "svg": {
-        "minVisualNodes": 144,
+        "minVisualNodes": 72,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 634496,
-        "minDistinctColors": 1336,
+        "minDistinctColors": 1408,
         "maxEdgeInkPixels": 0
       }
     },
@@ -630,14 +630,14 @@
       "width": 760,
       "height": 460,
       "svg": {
-        "minVisualNodes": 123,
+        "minVisualNodes": 61,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 634496,
-        "minDistinctColors": 1509,
+        "minDistinctColors": 1505,
         "maxEdgeInkPixels": 0
       }
     },
@@ -646,14 +646,14 @@
       "width": 760,
       "height": 460,
       "svg": {
-        "minVisualNodes": 100,
+        "minVisualNodes": 50,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 634496,
-        "minDistinctColors": 1102,
+        "minDistinctColors": 1157,
         "maxEdgeInkPixels": 0
       }
     },
@@ -662,14 +662,14 @@
       "width": 760,
       "height": 460,
       "svg": {
-        "minVisualNodes": 186,
+        "minVisualNodes": 187,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 634496,
-        "minDistinctColors": 1190,
+        "minDistinctColors": 1246,
         "maxEdgeInkPixels": 0
       }
     },
@@ -678,14 +678,14 @@
       "width": 760,
       "height": 460,
       "svg": {
-        "minVisualNodes": 84,
+        "minVisualNodes": 42,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 634496,
-        "minDistinctColors": 1434,
+        "minDistinctColors": 1488,
         "maxEdgeInkPixels": 0
       }
     },
@@ -694,7 +694,7 @@
       "width": 1118,
       "height": 1550,
       "svg": {
-        "minVisualNodes": 2130,
+        "minVisualNodes": 1253,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
@@ -710,14 +710,14 @@
       "width": 760,
       "height": 460,
       "svg": {
-        "minVisualNodes": 653,
+        "minVisualNodes": 654,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 634496,
-        "minDistinctColors": 951,
+        "minDistinctColors": 969,
         "maxEdgeInkPixels": 0
       }
     },
@@ -882,6 +882,22 @@
       }
     },
     {
+      "name": "powerbginfo-endpoint-snapshot",
+      "width": 1376,
+      "height": 300,
+      "svg": {
+        "minVisualNodes": 33,
+        "maxClippedTextNodes": 0,
+        "maxNearEdgeTextNodes": 0
+      },
+      "png": {
+        "outputScale": 2,
+        "minVisiblePixels": 825600,
+        "minDistinctColors": 2008,
+        "maxEdgeInkPixels": 0
+      }
+    },
+    {
       "name": "remediation-impact-waterfall-dark",
       "width": 920,
       "height": 540,
@@ -914,6 +930,22 @@
       }
     },
     {
+      "name": "report-summary-metric-strip",
+      "width": 980,
+      "height": 294,
+      "svg": {
+        "minVisualNodes": 25,
+        "maxClippedTextNodes": 0,
+        "maxNearEdgeTextNodes": 0
+      },
+      "png": {
+        "outputScale": 2,
+        "minVisiblePixels": 576240,
+        "minDistinctColors": 2027,
+        "maxEdgeInkPixels": 0
+      }
+    },
+    {
       "name": "result-mix-donut",
       "width": 820,
       "height": 460,
@@ -934,7 +966,7 @@
       "width": 980,
       "height": 560,
       "svg": {
-        "minVisualNodes": 158,
+        "minVisualNodes": 79,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
@@ -950,14 +982,14 @@
       "width": 980,
       "height": 560,
       "svg": {
-        "minVisualNodes": 76,
+        "minVisualNodes": 38,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 1015616,
-        "minDistinctColors": 1024,
+        "minDistinctColors": 1038,
         "maxEdgeInkPixels": 0
       }
     },
@@ -966,14 +998,14 @@
       "width": 980,
       "height": 500,
       "svg": {
-        "minVisualNodes": 96,
+        "minVisualNodes": 63,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 901256,
-        "minDistinctColors": 1857,
+        "minDistinctColors": 1827,
         "maxEdgeInkPixels": 0
       }
     },
@@ -1126,14 +1158,14 @@
       "width": 980,
       "height": 560,
       "svg": {
-        "minVisualNodes": 657,
+        "minVisualNodes": 659,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
         "minVisiblePixels": 1015616,
-        "minDistinctColors": 1375,
+        "minDistinctColors": 1523,
         "maxEdgeInkPixels": 0
       }
     },
@@ -1158,14 +1190,14 @@
       "width": 1164,
       "height": 565,
       "svg": {
-        "minVisualNodes": 48,
+        "minVisualNodes": 30,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
-        "minVisiblePixels": 2500000,
-        "minDistinctColors": 2500,
+        "minVisiblePixels": 1315320,
+        "minDistinctColors": 1714,
         "maxEdgeInkPixels": 0
       }
     },
@@ -1174,14 +1206,14 @@
       "width": 560,
       "height": 560,
       "svg": {
-        "minVisualNodes": 16,
+        "minVisualNodes": 8,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
-        "minVisiblePixels": 1100000,
-        "minDistinctColors": 1200,
+        "minVisiblePixels": 566554,
+        "minDistinctColors": 653,
         "maxEdgeInkPixels": 0
       }
     },
@@ -1190,14 +1222,14 @@
       "width": 560,
       "height": 420,
       "svg": {
-        "minVisualNodes": 16,
+        "minVisualNodes": 8,
         "maxClippedTextNodes": 0,
         "maxNearEdgeTextNodes": 0
       },
       "png": {
         "outputScale": 2,
-        "minVisiblePixels": 900000,
-        "minDistinctColors": 1200,
+        "minVisiblePixels": 470400,
+        "minDistinctColors": 682,
         "maxEdgeInkPixels": 0
       }
     },

--- a/ChartForgeX.Tests/SmokeTests/VisualBlockTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualBlockTests.cs
@@ -50,16 +50,35 @@ internal static partial class SmokeTests {
         var metric = MetricCard.Create()
             .WithMetric("Coverage", 0.982, "P1")
             .WithIcon(VisualIcon.Lightning)
+            .WithBadgePlacement(MetricCardBadgePlacement.TopLeft)
             .WithTrend("+2.4 pp")
             .WithCaption("since previous run")
+            .WithAction("Open details", url: "#coverage")
             .WithStatus(VisualStatus.Positive)
+            .WithMiniBars(new[] { 72d, 78d, 83d, 80d, 98d }, maximum: 100)
             .WithTheme(ChartTheme.ReportLight())
             .WithSize(360, 190);
         var metricSvg = metric.ToSvg("visual-block-metric");
         Assert(metricSvg.Contains("data-cfx-role=\"metric-status-bar\"", StringComparison.Ordinal), "MetricCard should render status styling.");
         Assert(metricSvg.Contains("data-cfx-role=\"visual-icon\"", StringComparison.Ordinal), "MetricCard should render reusable built-in icons.");
+        Assert(metricSvg.Contains("data-cfx-placement=\"top-left\"", StringComparison.Ordinal), "MetricCard should render configurable badge placement.");
+        Assert(metricSvg.Contains("data-cfx-role=\"metric-action-label\"", StringComparison.Ordinal), "MetricCard should render optional footer action text.");
+        Assert(metricSvg.Contains("data-cfx-role=\"metric-action-symbol\"", StringComparison.Ordinal), "MetricCard should render optional footer action symbols.");
+        Assert(metricSvg.Contains("data-cfx-role=\"metric-action-link\"", StringComparison.Ordinal) && metricSvg.Contains("href=\"#coverage\"", StringComparison.Ordinal), "MetricCard should render safe action links in SVG/HTML outputs.");
+        Assert(metricSvg.Contains("data-cfx-role=\"metric-mini-bars\"", StringComparison.Ordinal), "MetricCard should render compact mini bar groups.");
+        Assert(metricSvg.Contains("data-cfx-role=\"metric-mini-bar-highlight\"", StringComparison.Ordinal), "MetricCard should emphasize one mini bar.");
         Assert(metric.ToHtmlFragment().Contains("chartforgex-visual-block", StringComparison.Ordinal), "MetricCard should render an embeddable HTML fragment.");
         Assert(metric.ToPng().Length > 64, "MetricCard should render PNG output.");
+
+        var sparkMetric = MetricCard.Create()
+            .WithMetric("Network", "842 Mbps")
+            .WithStatus(VisualStatus.Info)
+            .WithMiniSparkline(new[] { 42d, 36d, 31d, 28d, 24d, 18d });
+        var sparkSvg = sparkMetric.ToSvg("visual-block-metric-sparkline");
+        Assert(sparkSvg.Contains("data-cfx-role=\"metric-mini-sparkline\"", StringComparison.Ordinal), "MetricCard should render compact sparkline groups.");
+        Assert(sparkSvg.Contains("data-cfx-role=\"metric-mini-sparkline-current\"", StringComparison.Ordinal), "MetricCard sparklines should mark the current value.");
+        Assert(sparkSvg.Contains("842 Mbps", StringComparison.Ordinal), "MetricCard should shrink long values enough to fit beside micro visuals.");
+        Assert(sparkMetric.ToPng().Length > 64, "MetricCard sparkline should render PNG output.");
 
         var radialMetric = RadialMetricCard.Create()
             .WithMetric("Capacity left", "42%")
@@ -131,6 +150,13 @@ internal static partial class SmokeTests {
         Assert(stretchSvg.Contains("data-cfx-role=\"visual-grid-panel\"", StringComparison.Ordinal) && stretchSvg.Contains("preserveAspectRatio=\"none\"", StringComparison.Ordinal), "VisualGrid SVG stretch mode should remove child aspect-ratio locking.");
         Assert(stretchGrid.ToHtmlFragment().Contains("preserveAspectRatio=\"none\"", StringComparison.Ordinal), "VisualGrid HTML stretch mode should remove embedded SVG aspect-ratio locking.");
 
+        var strip = VisualGrid.CreateMetricStrip("Endpoint", new[] {
+            MetricCard.Create().WithMetric("CPU", "38%").WithMiniSparkline(new[] { 48d, 42d, 38d }),
+            MetricCard.Create().WithMetric("Memory", "71%").WithMiniBars(new[] { 55d, 63d, 71d }, maximum: 100)
+        }, columns: 2);
+        Assert(strip.ToSvg("visual-grid-metric-strip").Contains("Endpoint", StringComparison.Ordinal), "Metric strip preset should render the section title.");
+        Assert(strip.ToHtmlFragment().Contains("--cfx-visual-grid-columns:2", StringComparison.Ordinal), "Metric strip preset should honor the requested column count.");
+
         var autoGrid = VisualGrid.Create()
             .WithColumns(2)
             .Add(MetricCard.Create().WithMetric("Small", 1).WithSize(260, 140))
@@ -157,6 +183,17 @@ internal static partial class SmokeTests {
         AssertThrows<ArgumentOutOfRangeException>(() => new ChartListItem("bad").Status = (VisualStatus)999, "ChartList items should reject unknown status values.");
         AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().Status = (VisualStatus)999, "MetricCard should reject unknown status values.");
         AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().Icon = (VisualIcon)999, "MetricCard should reject unknown icon values.");
+        AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().BadgePlacement = (MetricCardBadgePlacement)999, "MetricCard should reject unknown badge placements.");
+        AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithAction(new string('x', 49)).ToSvg(), "MetricCard action labels should stay compact.");
+        AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithAction("Open", "longer").ToSvg(), "MetricCard action symbols should stay compact.");
+        AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithAction("Open", url: "javascript:alert(1)").ToSvg(), "MetricCard action URLs should reject scriptable URLs.");
+        AssertThrows<ArgumentException>(() => MetricCard.Create().WithMiniBars(Array.Empty<double>()), "MetricCard mini bars should reject empty value sets.");
+        AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().WithMiniBars(new[] { double.NaN }), "MetricCard mini bars should reject non-finite values.");
+        AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithMiniBars(new[] { 1d }, minimum: 2, maximum: 1).ToSvg(), "MetricCard mini bars should require maximum greater than minimum.");
+        AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithMiniBars(new[] { 1d }, highlightIndex: 2).ToSvg(), "MetricCard mini bar highlight index should reference an existing value.");
+        AssertThrows<ArgumentException>(() => MetricCard.Create().WithMiniSparkline(new[] { 1d }), "MetricCard mini sparklines should require at least two values.");
+        AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().WithMiniSparkline(new[] { 1d, double.PositiveInfinity }), "MetricCard mini sparklines should reject non-finite values.");
+        AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithMiniSparkline(new[] { 1d, 2d }, minimum: 3, maximum: 2).ToSvg(), "MetricCard mini sparklines should require maximum greater than minimum.");
         AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Missing", null).ToSvg(), "MetricCard should require a visible value.");
         AssertThrows<InvalidOperationException>(() => RadialMetricCard.Create().WithMetric("Missing", "1").ToSvg(), "RadialMetricCard should require at least one layer.");
         AssertThrows<InvalidOperationException>(() => RadialMetricCard.Create().AddLayer("Bad", 1, configure: _ => null!).ToSvg(), "RadialMetricCard should reject null fluent layer configuration results.");
@@ -165,5 +202,7 @@ internal static partial class SmokeTests {
         AssertThrows<ArgumentOutOfRangeException>(() => VisualGrid.Create().WithColumns(0), "VisualGrid should reject non-positive column counts.");
         AssertThrows<ArgumentOutOfRangeException>(() => VisualGrid.Create().PanelFit = (VisualGridPanelFit)999, "VisualGrid panel fit property should reject unknown values.");
         AssertThrows<InvalidOperationException>(() => VisualGrid.Create().ToSvg(), "VisualGrid should require at least one item.");
+        AssertThrows<ArgumentException>(() => VisualGrid.CreateMetricStrip("Empty", Array.Empty<MetricCard>()), "Metric strip preset should require at least one card.");
+        AssertThrows<ArgumentException>(() => VisualGrid.CreateMetricStrip("Bad", new MetricCard[] { null! }), "Metric strip preset should reject null cards.");
     }
 }

--- a/ChartForgeX/Rendering/ChartVisualPrimitives.cs
+++ b/ChartForgeX/Rendering/ChartVisualPrimitives.cs
@@ -76,6 +76,15 @@ internal static class ChartVisualPrimitives {
     public const double BarHighlightOpacity = 0.15;
     public const double BarHighlightStrokeWidth = 1;
     public const double BarHighlightInset = 1;
+    public const double MiniBarGap = 5;
+    public const double MiniBarDenseGap = 3;
+    public const double MiniBarMinWidth = 3;
+    public const double MiniBarMinHeight = 4;
+    public const double MiniBarRadiusMax = 5;
+    public const double MiniBarMutedOpacity = 0.82;
+    public const double MiniSparklineStrokeWidth = 2.4;
+    public const double MiniSparklineCurrentRadius = 3.2;
+    public const double MiniSparklineFillOpacity = 44.0 / 255.0;
 
     public const double GridStrokeWidth = 1;
     public const double GridVerticalOpacity = 0.42;

--- a/ChartForgeX/VisualBlocks/MetricCard.cs
+++ b/ChartForgeX/VisualBlocks/MetricCard.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.VisualBlocks;
+
+/// <summary>
+/// A compact KPI or metric card visual block.
+/// </summary>
+public sealed class MetricCard : VisualBlock<MetricCard> {
+    private readonly List<double> _miniBars = new();
+    private readonly List<double> _miniSparkline = new();
+    private string _label = string.Empty;
+    private string _value = string.Empty;
+    private string _caption = string.Empty;
+    private string _trend = string.Empty;
+    private string _symbol = string.Empty;
+    private string _actionLabel = string.Empty;
+    private string _actionSymbol = ">";
+    private string _actionUrl = string.Empty;
+    private int? _miniBarHighlightIndex;
+    private double? _miniBarMinimum;
+    private double? _miniBarMaximum;
+    private double? _miniSparklineMinimum;
+    private double? _miniSparklineMaximum;
+    private VisualIcon _icon;
+    private VisualStatus _status;
+    private MetricCardBadgePlacement _badgePlacement;
+
+    /// <summary>Gets compact bar values rendered inside the metric card.</summary>
+    public IReadOnlyList<double> MiniBars => _miniBars;
+
+    /// <summary>Gets compact sparkline values rendered inside the metric card.</summary>
+    public IReadOnlyList<double> MiniSparkline => _miniSparkline;
+
+    /// <summary>Gets or sets the metric label.</summary>
+    public string Label { get => _label; set => _label = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets the metric value.</summary>
+    public string Value { get => _value; set => _value = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets optional supporting text.</summary>
+    public string Caption { get => _caption; set => _caption = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets optional trend text.</summary>
+    public string Trend { get => _trend; set => _trend = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets an optional compact symbol rendered as a badge.</summary>
+    public string Symbol { get => _symbol; set => _symbol = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets optional footer action text.</summary>
+    public string ActionLabel { get => _actionLabel; set => _actionLabel = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets optional footer action symbol.</summary>
+    public string ActionSymbol { get => _actionSymbol; set => _actionSymbol = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets an optional URL for the footer action in SVG/HTML outputs.</summary>
+    public string ActionUrl { get => _actionUrl; set => _actionUrl = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets the zero-based mini bar to emphasize. When unset, the last mini bar is emphasized.</summary>
+    public int? MiniBarHighlightIndex {
+        get => _miniBarHighlightIndex;
+        set {
+            if (value.HasValue && value.Value < 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Mini bar highlight index must be non-negative.");
+            _miniBarHighlightIndex = value;
+        }
+    }
+
+    /// <summary>Gets or sets the optional lower bound used for mini bar scaling.</summary>
+    public double? MiniBarMinimum {
+        get => _miniBarMinimum;
+        set {
+            if (value.HasValue && !IsFinite(value.Value)) throw new ArgumentOutOfRangeException(nameof(value), value, "Mini bar minimum must be finite.");
+            _miniBarMinimum = value;
+        }
+    }
+
+    /// <summary>Gets or sets the optional upper bound used for mini bar scaling.</summary>
+    public double? MiniBarMaximum {
+        get => _miniBarMaximum;
+        set {
+            if (value.HasValue && !IsFinite(value.Value)) throw new ArgumentOutOfRangeException(nameof(value), value, "Mini bar maximum must be finite.");
+            _miniBarMaximum = value;
+        }
+    }
+
+    /// <summary>Gets or sets the optional lower bound used for mini sparkline scaling.</summary>
+    public double? MiniSparklineMinimum {
+        get => _miniSparklineMinimum;
+        set {
+            if (value.HasValue && !IsFinite(value.Value)) throw new ArgumentOutOfRangeException(nameof(value), value, "Mini sparkline minimum must be finite.");
+            _miniSparklineMinimum = value;
+        }
+    }
+
+    /// <summary>Gets or sets the optional upper bound used for mini sparkline scaling.</summary>
+    public double? MiniSparklineMaximum {
+        get => _miniSparklineMaximum;
+        set {
+            if (value.HasValue && !IsFinite(value.Value)) throw new ArgumentOutOfRangeException(nameof(value), value, "Mini sparkline maximum must be finite.");
+            _miniSparklineMaximum = value;
+        }
+    }
+
+    /// <summary>Gets or sets the optional color for the emphasized mini bar.</summary>
+    public ChartColor? MiniBarColor { get; set; }
+
+    /// <summary>Gets or sets the optional color for non-emphasized mini bars.</summary>
+    public ChartColor? MiniBarMutedColor { get; set; }
+
+    /// <summary>Gets or sets the optional stroke color for the mini sparkline.</summary>
+    public ChartColor? MiniSparklineColor { get; set; }
+
+    /// <summary>Gets or sets the optional fill color under the mini sparkline.</summary>
+    public ChartColor? MiniSparklineFillColor { get; set; }
+
+    /// <summary>Gets or sets an optional built-in icon rendered as a badge.</summary>
+    public VisualIcon Icon {
+        get => _icon;
+        set {
+            VisualBlockGuards.EnumDefined(value, nameof(value));
+            _icon = value;
+        }
+    }
+
+    /// <summary>Gets or sets the metric status.</summary>
+    public VisualStatus Status {
+        get => _status;
+        set {
+            VisualBlockGuards.EnumDefined(value, nameof(value));
+            _status = value;
+        }
+    }
+
+    /// <summary>Gets or sets the badge placement when an icon or symbol is configured.</summary>
+    public MetricCardBadgePlacement BadgePlacement {
+        get => _badgePlacement;
+        set {
+            VisualBlockGuards.EnumDefined(value, nameof(value));
+            _badgePlacement = value;
+        }
+    }
+
+    /// <summary>Gets a concise accessibility label.</summary>
+    public override string AccessibleName => Label.Length == 0 ? base.AccessibleName : Label;
+
+    /// <summary>Creates a new metric card.</summary>
+    public static MetricCard Create() => new();
+
+    /// <summary>Sets the primary metric label and value.</summary>
+    public MetricCard WithMetric(string label, object? value, string? format = null) {
+        Label = label ?? throw new ArgumentNullException(nameof(label));
+        Value = ChartTableCell.FromValue(value, format).Text;
+        return this;
+    }
+
+    /// <summary>Sets optional supporting text.</summary>
+    public MetricCard WithCaption(string caption) { Caption = caption ?? throw new ArgumentNullException(nameof(caption)); return this; }
+
+    /// <summary>Sets optional trend text.</summary>
+    public MetricCard WithTrend(string trend) { Trend = trend ?? throw new ArgumentNullException(nameof(trend)); return this; }
+
+    /// <summary>Sets an optional compact symbol rendered as a badge.</summary>
+    public MetricCard WithSymbol(string symbol) { Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol)); return this; }
+
+    /// <summary>Sets optional footer action text rendered in the metric card.</summary>
+    public MetricCard WithAction(string label, string? symbol = null, string? url = null) {
+        ActionLabel = label ?? throw new ArgumentNullException(nameof(label));
+        ActionSymbol = symbol ?? ">";
+        ActionUrl = url ?? string.Empty;
+        return this;
+    }
+
+    /// <summary>Clears optional footer action text from the metric card.</summary>
+    public MetricCard WithoutAction() {
+        ActionLabel = string.Empty;
+        ActionSymbol = ">";
+        ActionUrl = string.Empty;
+        return this;
+    }
+
+    /// <summary>Sets an optional built-in icon rendered as a badge.</summary>
+    public MetricCard WithIcon(VisualIcon icon) { Icon = icon; return this; }
+
+    /// <summary>Replaces compact bar values rendered inside the metric card.</summary>
+    public MetricCard WithMiniBars(IEnumerable<double> values, double? minimum = null, double? maximum = null, ChartColor? color = null, ChartColor? mutedColor = null, int? highlightIndex = null) {
+        if (values == null) throw new ArgumentNullException(nameof(values));
+        _miniBars.Clear();
+        foreach (var value in values) {
+            if (!IsFinite(value)) throw new ArgumentOutOfRangeException(nameof(values), value, "Mini bar values must be finite.");
+            _miniBars.Add(value);
+        }
+
+        if (_miniBars.Count == 0) throw new ArgumentException("Metric cards require at least one mini bar value when mini bars are configured.", nameof(values));
+        MiniBarMinimum = minimum;
+        MiniBarMaximum = maximum;
+        MiniBarColor = color;
+        MiniBarMutedColor = mutedColor;
+        MiniBarHighlightIndex = highlightIndex;
+        WithoutMiniSparkline();
+        return this;
+    }
+
+    /// <summary>Clears compact bar values from the metric card.</summary>
+    public MetricCard WithoutMiniBars() {
+        _miniBars.Clear();
+        MiniBarMinimum = null;
+        MiniBarMaximum = null;
+        MiniBarColor = null;
+        MiniBarMutedColor = null;
+        MiniBarHighlightIndex = null;
+        return this;
+    }
+
+    /// <summary>Replaces compact sparkline values rendered inside the metric card.</summary>
+    public MetricCard WithMiniSparkline(IEnumerable<double> values, double? minimum = null, double? maximum = null, ChartColor? color = null, ChartColor? fillColor = null) {
+        if (values == null) throw new ArgumentNullException(nameof(values));
+        _miniSparkline.Clear();
+        foreach (var value in values) {
+            if (!IsFinite(value)) throw new ArgumentOutOfRangeException(nameof(values), value, "Mini sparkline values must be finite.");
+            _miniSparkline.Add(value);
+        }
+
+        if (_miniSparkline.Count < 2) throw new ArgumentException("Metric card mini sparklines require at least two values.", nameof(values));
+        MiniSparklineMinimum = minimum;
+        MiniSparklineMaximum = maximum;
+        MiniSparklineColor = color;
+        MiniSparklineFillColor = fillColor;
+        WithoutMiniBars();
+        return this;
+    }
+
+    /// <summary>Clears compact sparkline values from the metric card.</summary>
+    public MetricCard WithoutMiniSparkline() {
+        _miniSparkline.Clear();
+        MiniSparklineMinimum = null;
+        MiniSparklineMaximum = null;
+        MiniSparklineColor = null;
+        MiniSparklineFillColor = null;
+        return this;
+    }
+
+    /// <summary>Sets the metric status.</summary>
+    public MetricCard WithStatus(VisualStatus status) {
+        Status = status;
+        return this;
+    }
+
+    /// <summary>Sets the badge placement when an icon or symbol is configured.</summary>
+    public MetricCard WithBadgePlacement(MetricCardBadgePlacement placement) {
+        BadgePlacement = placement;
+        return this;
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+}

--- a/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.cs
+++ b/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.cs
@@ -117,12 +117,26 @@ public sealed class PngVisualBlockRenderer {
         var theme = options.Theme;
         var content = VisualBlockRendering.ContentRect(options);
         var statusColor = VisualBlockRendering.StatusColor(theme, card.Status);
+        var hasAction = card.ActionLabel.Length > 0;
+        var footerHeight = hasAction ? Math.Min(46, Math.Max(36, options.Size.Height * 0.24)) : 0;
+        var footerY = options.Size.Height - footerHeight;
+        var detailBottom = hasAction ? footerY - 12 : options.Size.Height - options.Padding.Bottom;
+        var labelX = content.X;
+        var labelWidth = content.Width;
+        var valueYOffset = 0.0;
         if (card.Status != VisualStatus.None) canvas.FillRect(0, 0, 7, options.Size.Height, statusColor);
         if (card.Icon != VisualIcon.None || card.Symbol.Length > 0) {
             var badgeColor = card.Status == VisualStatus.None ? VisualBlockRendering.PaletteAt(theme, 0) : statusColor;
             var badgeRadius = Math.Min(24, Math.Max(15, options.Size.Height * 0.11));
-            var cx = options.Size.Width - options.Padding.Right - badgeRadius;
+            var leftBadge = card.BadgePlacement == MetricCardBadgePlacement.TopLeft;
+            var cx = leftBadge ? content.X + badgeRadius : options.Size.Width - options.Padding.Right - badgeRadius;
             var cy = options.Padding.Top + badgeRadius;
+            if (leftBadge) {
+                labelX = cx + badgeRadius + 12;
+                labelWidth = Math.Max(1, content.X + content.Width - labelX);
+                valueYOffset = Math.Max(8, badgeRadius * 0.55);
+            }
+
             canvas.DrawCircle(cx, cy, badgeRadius, badgeColor.WithAlpha(48));
             canvas.DrawCircleOutline(cx, cy, badgeRadius, badgeColor, 1);
             if (card.Icon != VisualIcon.None) DrawIcon(canvas, card.Icon, cx, cy, badgeRadius * 0.62, badgeColor);
@@ -130,11 +144,62 @@ public sealed class PngVisualBlockRenderer {
         }
 
         var labelSize = Math.Max(11, theme.SubtitleFontSize);
-        var valueSize = Math.Min(54, Math.Max(26, options.Size.Height * 0.22));
-        canvas.DrawTextEmphasized(content.X, content.Y, FitText(card.Label, labelSize, content.Width), theme.MutedText, labelSize);
-        canvas.DrawTextEmphasized(content.X, content.Y + labelSize + 18, FitText(card.Value, valueSize, content.Width), theme.Text, valueSize);
-        if (card.Trend.Length > 0) canvas.DrawTextEmphasized(content.X, options.Size.Height - options.Padding.Bottom - 28, FitText(card.Trend, theme.SubtitleFontSize, content.Width), statusColor, theme.SubtitleFontSize);
-        if (card.Caption.Length > 0) canvas.DrawText(content.X, options.Size.Height - options.Padding.Bottom - 10, FitText(card.Caption, Math.Max(10, theme.SubtitleFontSize - 1), content.Width), theme.MutedText, Math.Max(10, theme.SubtitleFontSize - 1));
+        var baseValueSize = Math.Min(54, Math.Max(26, options.Size.Height * 0.22));
+        var hasMicroVisual = card.MiniBars.Count > 0 || card.MiniSparkline.Count > 0;
+        var microWidth = hasMicroVisual ? Math.Min(112, Math.Max(58, content.Width * 0.32)) : 0;
+        var microHeight = Math.Min(56, Math.Max(34, options.Size.Height * 0.24));
+        var valueWidth = hasMicroVisual ? Math.Max(1, content.Width - microWidth - 18) : content.Width;
+        var valueSize = MetricValueFontSize(card.Value, baseValueSize, valueWidth);
+        canvas.DrawTextEmphasized(labelX, content.Y, FitText(card.Label, labelSize, labelWidth), theme.MutedText, labelSize);
+        canvas.DrawTextEmphasized(content.X, content.Y + labelSize + 18 + valueYOffset, FitText(card.Value, valueSize, valueWidth), theme.Text, valueSize);
+        if (card.MiniSparkline.Count > 0) DrawMetricMiniSparkline(canvas, card, content.X + content.Width - microWidth, content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset, microWidth, microHeight);
+        else if (card.MiniBars.Count > 0) DrawMetricMiniBars(canvas, card, content.X + content.Width - microWidth, content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset, microWidth, microHeight);
+        DrawMetricDetail(canvas, card, detailBottom, content.X, content.Width);
+        if (hasAction) DrawMetricAction(canvas, card, footerY, footerHeight, content.X, content.Width);
+    }
+
+    private static void DrawMetricDetail(RgbaCanvas canvas, MetricCard card, double bottom, double x, double width) {
+        var theme = card.Options.Theme;
+        var statusColor = VisualBlockRendering.StatusColor(theme, card.Status);
+        var trendSize = Math.Max(10, theme.SubtitleFontSize);
+        var captionSize = Math.Max(10, theme.SubtitleFontSize - 1);
+        var y = bottom - (card.Trend.Length > 0 && card.Caption.Length > 0 ? trendSize + 1 : trendSize);
+        if (card.Trend.Length > 0) {
+            var trendWidth = Math.Min(width * 0.42, RgbaCanvas.MeasureTextEmphasizedWidth(card.Trend, trendSize, null) + 10);
+            canvas.DrawTextEmphasized(x, y, FitText(card.Trend, trendSize, trendWidth), statusColor, trendSize);
+            if (card.Caption.Length > 0) canvas.DrawText(x + trendWidth + 5, y + 1, FitText(card.Caption, captionSize, Math.Max(1, width - trendWidth - 5)), theme.MutedText, captionSize);
+        } else if (card.Caption.Length > 0) {
+            canvas.DrawText(x, y, FitText(card.Caption, captionSize, width), theme.MutedText, captionSize);
+        }
+    }
+
+    private static void DrawMetricAction(RgbaCanvas canvas, MetricCard card, double footerY, double footerHeight, double x, double width) {
+        var theme = card.Options.Theme;
+        canvas.DrawLine(0, footerY, card.Options.Size.Width, footerY, theme.PlotBorder, 1);
+        var fontSize = Math.Max(10, theme.SubtitleFontSize);
+        var symbolWidth = Math.Min(24, RgbaCanvas.MeasureTextEmphasizedWidth(card.ActionSymbol, fontSize, null) + 6);
+        var y = footerY + (footerHeight - fontSize) * 0.52;
+        canvas.DrawText(x, y, FitText(card.ActionLabel, fontSize, Math.Max(1, width - symbolWidth - 8)), theme.MutedText, fontSize);
+        DrawAlignedText(canvas, card.ActionSymbol, x + width - symbolWidth, y, symbolWidth, VisualTextAlignment.Right, theme.Text, fontSize, true);
+    }
+
+    private static void DrawMetricMiniBars(RgbaCanvas canvas, MetricCard card, double x, double y, double width, double height) {
+        foreach (var bar in VisualBlockRendering.CreateMiniBars(card, x, y, width, height)) {
+            canvas.FillRoundedRect(bar.X, bar.Y, bar.Width, bar.Height, bar.Radius, bar.Color);
+        }
+    }
+
+    private static double MetricValueFontSize(string value, double requestedSize, double maxWidth) {
+        var measuredWidth = RgbaCanvas.MeasureTextEmphasizedWidth(value, requestedSize, null);
+        if (measuredWidth <= maxWidth) return requestedSize;
+        return Math.Max(22, Math.Floor(requestedSize * maxWidth / Math.Max(1, measuredWidth)));
+    }
+
+    private static void DrawMetricMiniSparkline(RgbaCanvas canvas, MetricCard card, double x, double y, double width, double height) {
+        var sparkline = VisualBlockRendering.CreateMiniSparkline(card, x, y, width, height);
+        canvas.FillPolygon(sparkline.Area, sparkline.FillColor);
+        for (var i = 1; i < sparkline.Points.Length; i++) canvas.DrawLine(sparkline.Points[i - 1].X, sparkline.Points[i - 1].Y, sparkline.Points[i].X, sparkline.Points[i].Y, sparkline.LineColor, sparkline.StrokeWidth);
+        canvas.DrawCircle(sparkline.Current.X, sparkline.Current.Y, sparkline.CurrentRadius, sparkline.LineColor);
     }
 
     private static void DrawRadialMetric(RgbaCanvas canvas, RadialMetricCard card) {

--- a/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.cs
+++ b/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using ChartForgeX.Core;
@@ -138,23 +139,124 @@ public sealed class SvgVisualBlockRenderer {
         var theme = options.Theme;
         var content = VisualBlockRendering.ContentRect(options);
         var statusColor = VisualBlockRendering.StatusColor(theme, card.Status);
+        var hasAction = card.ActionLabel.Length > 0;
+        var footerHeight = hasAction ? Math.Min(46, Math.Max(36, options.Size.Height * 0.24)) : 0;
+        var footerY = options.Size.Height - footerHeight;
+        var detailBottom = hasAction ? footerY - 12 : options.Size.Height - options.Padding.Bottom;
+        var labelX = content.X;
+        var labelWidth = content.Width;
+        var valueYOffset = 0.0;
         if (card.Status != VisualStatus.None) writer.StartElement("rect").Attribute("data-cfx-role", "metric-status-bar").Attribute("x", 0).Attribute("y", 0).Attribute("width", 7).Attribute("height", options.Size.Height).Attribute("fill", statusColor.ToCss()).EndEmptyElement().Line();
         if (card.Icon != VisualIcon.None || card.Symbol.Length > 0) {
             var badgeColor = card.Status == VisualStatus.None ? VisualBlockRendering.PaletteAt(theme, 0) : statusColor;
             var badgeRadius = Math.Min(24, Math.Max(15, options.Size.Height * 0.11));
-            var cx = options.Size.Width - options.Padding.Right - badgeRadius;
+            var leftBadge = card.BadgePlacement == MetricCardBadgePlacement.TopLeft;
+            var cx = leftBadge ? content.X + badgeRadius : options.Size.Width - options.Padding.Right - badgeRadius;
             var cy = options.Padding.Top + badgeRadius;
-            writer.StartElement("circle").Attribute("data-cfx-role", "metric-symbol-badge").Attribute("cx", cx).Attribute("cy", cy).Attribute("r", badgeRadius).Attribute("fill", badgeColor.WithAlpha(48).ToCss()).Attribute("stroke", badgeColor.ToCss()).EndEmptyElement().Line();
+            if (leftBadge) {
+                labelX = cx + badgeRadius + 12;
+                labelWidth = Math.Max(1, content.X + content.Width - labelX);
+                valueYOffset = Math.Max(8, badgeRadius * 0.55);
+            }
+
+            writer.StartElement("circle").Attribute("data-cfx-role", "metric-symbol-badge").Attribute("data-cfx-placement", leftBadge ? "top-left" : "top-right").Attribute("cx", cx).Attribute("cy", cy).Attribute("r", badgeRadius).Attribute("fill", badgeColor.WithAlpha(48).ToCss()).Attribute("stroke", badgeColor.ToCss()).EndEmptyElement().Line();
             if (card.Icon != VisualIcon.None) WriteIcon(writer, card.Icon, cx, cy, badgeRadius * 0.62, badgeColor);
             else writer.StartElement("text").Attribute("data-cfx-role", "metric-symbol").Attribute("x", cx).Attribute("y", cy + Math.Max(10, badgeRadius * 0.46) / 3.0).Attribute("text-anchor", "middle").Attribute("fill", badgeColor.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", Math.Max(10, badgeRadius * 0.46)).Attribute("font-weight", "850").Text(VisualBlockRendering.FitText(card.Symbol, Math.Max(10, badgeRadius * 0.46), badgeRadius * 1.45)).EndElement().Line();
         }
 
         var labelSize = Math.Max(11, theme.SubtitleFontSize);
-        var valueSize = Math.Min(54, Math.Max(26, options.Size.Height * 0.22));
-        writer.StartElement("text").Attribute("data-cfx-role", "metric-label").Attribute("x", content.X).Attribute("y", content.Y + labelSize).Attribute("fill", theme.MutedText.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", labelSize).Attribute("font-weight", "700").Text(VisualBlockRendering.FitText(card.Label, labelSize, content.Width)).EndElement().Line();
-        writer.StartElement("text").Attribute("data-cfx-role", "metric-value").Attribute("x", content.X).Attribute("y", content.Y + labelSize + valueSize + 14).Attribute("fill", theme.Text.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", valueSize).Attribute("font-weight", "850").Text(VisualBlockRendering.FitText(card.Value, valueSize, content.Width)).EndElement().Line();
-        if (card.Trend.Length > 0) writer.StartElement("text").Attribute("data-cfx-role", "metric-trend").Attribute("x", content.X).Attribute("y", options.Size.Height - options.Padding.Bottom - 18).Attribute("fill", statusColor.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", theme.SubtitleFontSize).Attribute("font-weight", "700").Text(VisualBlockRendering.FitText(card.Trend, theme.SubtitleFontSize, content.Width)).EndElement().Line();
-        if (card.Caption.Length > 0) writer.StartElement("text").Attribute("data-cfx-role", "metric-caption").Attribute("x", content.X).Attribute("y", options.Size.Height - options.Padding.Bottom).Attribute("fill", theme.MutedText.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", Math.Max(10, theme.SubtitleFontSize - 1)).Text(VisualBlockRendering.FitText(card.Caption, Math.Max(10, theme.SubtitleFontSize - 1), content.Width)).EndElement().Line();
+        var baseValueSize = Math.Min(54, Math.Max(26, options.Size.Height * 0.22));
+        var hasMicroVisual = card.MiniBars.Count > 0 || card.MiniSparkline.Count > 0;
+        var microWidth = hasMicroVisual ? Math.Min(112, Math.Max(58, content.Width * 0.32)) : 0;
+        var microHeight = Math.Min(56, Math.Max(34, options.Size.Height * 0.24));
+        var valueWidth = hasMicroVisual ? Math.Max(1, content.Width - microWidth - 18) : content.Width;
+        var valueSize = MetricValueFontSize(card.Value, baseValueSize, valueWidth);
+        writer.StartElement("text").Attribute("data-cfx-role", "metric-label").Attribute("x", labelX).Attribute("y", content.Y + labelSize).Attribute("fill", theme.MutedText.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", labelSize).Attribute("font-weight", "700").Text(VisualBlockRendering.FitText(card.Label, labelSize, labelWidth)).EndElement().Line();
+        writer.StartElement("text").Attribute("data-cfx-role", "metric-value").Attribute("x", content.X).Attribute("y", content.Y + labelSize + valueSize + 14 + valueYOffset).Attribute("fill", theme.Text.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", valueSize).Attribute("font-weight", "850").Text(VisualBlockRendering.FitText(card.Value, valueSize, valueWidth)).EndElement().Line();
+        if (card.MiniSparkline.Count > 0) RenderMetricMiniSparkline(writer, card, content.X + content.Width - microWidth, content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset, microWidth, microHeight);
+        else if (card.MiniBars.Count > 0) RenderMetricMiniBars(writer, card, content.X + content.Width - microWidth, content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset, microWidth, microHeight);
+        RenderMetricDetail(writer, card, detailBottom, content.X, content.Width);
+        if (hasAction) RenderMetricAction(writer, card, footerY, footerHeight, content.X, content.Width);
+    }
+
+    private static void RenderMetricDetail(SvgMarkupWriter writer, MetricCard card, double bottom, double x, double width) {
+        var theme = card.Options.Theme;
+        var statusColor = VisualBlockRendering.StatusColor(theme, card.Status);
+        var trendSize = Math.Max(10, theme.SubtitleFontSize);
+        var captionSize = Math.Max(10, theme.SubtitleFontSize - 1);
+        var baseline = bottom - (card.Trend.Length > 0 && card.Caption.Length > 0 ? 5 : 0);
+        if (card.Trend.Length > 0) {
+            var trendWidth = Math.Min(width * 0.42, VisualBlockRendering.EstimateTextWidth(card.Trend, trendSize) + 10);
+            writer.StartElement("text").Attribute("data-cfx-role", "metric-trend").Attribute("x", x).Attribute("y", baseline).Attribute("fill", statusColor.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", trendSize).Attribute("font-weight", "700").Text(VisualBlockRendering.FitText(card.Trend, trendSize, trendWidth)).EndElement().Line();
+            if (card.Caption.Length > 0) writer.StartElement("text").Attribute("data-cfx-role", "metric-caption").Attribute("x", x + trendWidth + 5).Attribute("y", baseline).Attribute("fill", theme.MutedText.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", captionSize).Text(VisualBlockRendering.FitText(card.Caption, captionSize, Math.Max(1, width - trendWidth - 5))).EndElement().Line();
+        } else if (card.Caption.Length > 0) {
+            writer.StartElement("text").Attribute("data-cfx-role", "metric-caption").Attribute("x", x).Attribute("y", baseline).Attribute("fill", theme.MutedText.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", captionSize).Text(VisualBlockRendering.FitText(card.Caption, captionSize, width)).EndElement().Line();
+        }
+    }
+
+    private static void RenderMetricAction(SvgMarkupWriter writer, MetricCard card, double footerY, double footerHeight, double x, double width) {
+        var theme = card.Options.Theme;
+        writer.StartElement("line").Attribute("data-cfx-role", "metric-action-divider").Attribute("x1", 0).Attribute("y1", footerY).Attribute("x2", card.Options.Size.Width).Attribute("y2", footerY).Attribute("stroke", theme.PlotBorder.ToCss()).EndEmptyElement().Line();
+        var fontSize = Math.Max(10, theme.SubtitleFontSize);
+        var symbolWidth = Math.Min(24, VisualBlockRendering.EstimateTextWidth(card.ActionSymbol, fontSize) + 6);
+        var baseline = footerY + footerHeight * 0.64;
+        if (card.ActionUrl.Length > 0) writer.StartElement("a").Attribute("data-cfx-role", "metric-action-link").Attribute("href", card.ActionUrl).Attribute("target", "_top").EndStartElement().Line();
+        writer.StartElement("text").Attribute("data-cfx-role", "metric-action-label").Attribute("x", x).Attribute("y", baseline).Attribute("fill", theme.MutedText.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", fontSize).Text(VisualBlockRendering.FitText(card.ActionLabel, fontSize, Math.Max(1, width - symbolWidth - 8))).EndElement().Line();
+        writer.StartElement("text").Attribute("data-cfx-role", "metric-action-symbol").Attribute("x", x + width).Attribute("y", baseline).Attribute("text-anchor", "end").Attribute("fill", theme.Text.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", fontSize).Attribute("font-weight", "700").Text(VisualBlockRendering.FitText(card.ActionSymbol, fontSize, symbolWidth)).EndElement().Line();
+        if (card.ActionUrl.Length > 0) writer.EndElement().Line();
+    }
+
+    private static void RenderMetricMiniBars(SvgMarkupWriter writer, MetricCard card, double x, double y, double width, double height) {
+        var bounds = VisualBlockRendering.MiniBarBounds(card);
+        var bars = VisualBlockRendering.CreateMiniBars(card, x, y, width, height);
+        writer.StartElement("g").Attribute("data-cfx-role", "metric-mini-bars").Attribute("data-cfx-min", bounds.Minimum).Attribute("data-cfx-max", bounds.Maximum).EndStartElement().Line();
+        foreach (var bar in bars) {
+            writer.StartElement("rect")
+                .Attribute("data-cfx-role", bar.Highlighted ? "metric-mini-bar-highlight" : "metric-mini-bar")
+                .Attribute("data-cfx-index", bar.Index)
+                .Attribute("data-cfx-value", bar.Value)
+                .Attribute("x", bar.X)
+                .Attribute("y", bar.Y)
+                .Attribute("width", bar.Width)
+                .Attribute("height", bar.Height)
+                .Attribute("rx", bar.Radius)
+                .Attribute("fill", bar.Color.ToCss());
+            writer.EndEmptyElement().Line();
+        }
+
+        writer.EndElement().Line();
+    }
+
+    private static double MetricValueFontSize(string value, double requestedSize, double maxWidth) {
+        var estimatedWidth = VisualBlockRendering.EstimateTextWidth(value, requestedSize);
+        if (estimatedWidth <= maxWidth) return requestedSize;
+        return Math.Max(22, Math.Floor(requestedSize * maxWidth / Math.Max(1, estimatedWidth)));
+    }
+
+    private static void RenderMetricMiniSparkline(SvgMarkupWriter writer, MetricCard card, double x, double y, double width, double height) {
+        var bounds = VisualBlockRendering.MiniSparklineBounds(card);
+        var sparkline = VisualBlockRendering.CreateMiniSparkline(card, x, y, width, height);
+
+        writer.StartElement("g").Attribute("data-cfx-role", "metric-mini-sparkline").Attribute("data-cfx-min", bounds.Minimum).Attribute("data-cfx-max", bounds.Maximum).EndStartElement().Line();
+        writer.StartElement("polygon")
+            .Attribute("data-cfx-role", "metric-mini-sparkline-fill")
+            .Attribute("points", SparklinePoints(sparkline.Area))
+            .Attribute("fill", sparkline.FillColor.ToCss())
+            .EndEmptyElement()
+            .Line();
+        writer.StartElement("polyline")
+            .Attribute("data-cfx-role", "metric-mini-sparkline-line")
+            .Attribute("points", SparklinePoints(sparkline.Points))
+            .Attribute("fill", "none")
+            .Attribute("stroke", sparkline.LineColor.ToCss())
+            .Attribute("stroke-width", sparkline.StrokeWidth)
+            .Attribute("stroke-linecap", "round")
+            .Attribute("stroke-linejoin", "round")
+            .EndEmptyElement()
+            .Line();
+        var last = sparkline.Current;
+        writer.StartElement("circle").Attribute("data-cfx-role", "metric-mini-sparkline-current").Attribute("cx", last.X).Attribute("cy", last.Y).Attribute("r", sparkline.CurrentRadius).Attribute("fill", sparkline.LineColor.ToCss()).EndEmptyElement().Line();
+        writer.EndElement().Line();
     }
 
     private static void RenderRadialMetric(SvgMarkupWriter writer, RadialMetricCard card) {
@@ -229,6 +331,14 @@ public sealed class SvgVisualBlockRenderer {
         else if (alignment == VisualTextAlignment.Right) { anchor = "end"; textX = x + width; }
         writer.StartElement("text").Attribute("data-cfx-role", "visual-text").Attribute("x", textX).Attribute("y", y).Attribute("text-anchor", anchor).Attribute("fill", color.ToCss()).Attribute("font-family", fontFamily).Attribute("font-size", fontSize).Attribute("font-weight", weight).Text(fitted).EndElement().Line();
     }
+
+    private static string SparklinePoints(IReadOnlyList<ChartPoint> points) {
+        var values = new string[points.Count];
+        for (var i = 0; i < points.Count; i++) values[i] = FormatPoint(points[i].X, points[i].Y);
+        return string.Join(" ", values);
+    }
+
+    private static string FormatPoint(double x, double y) => x.ToString("0.###", CultureInfo.InvariantCulture) + "," + y.ToString("0.###", CultureInfo.InvariantCulture);
 
     private static double[] ColumnWidths(ChartTable table, double totalWidth) {
         var widths = new double[table.Columns.Count];

--- a/ChartForgeX/VisualBlocks/VisualBlockModels.cs
+++ b/ChartForgeX/VisualBlocks/VisualBlockModels.cs
@@ -78,6 +78,16 @@ public enum VisualIcon {
 }
 
 /// <summary>
+/// Badge placement used by metric visual blocks.
+/// </summary>
+public enum MetricCardBadgePlacement {
+    /// <summary>Place the badge in the upper-right corner.</summary>
+    TopRight,
+    /// <summary>Place the badge before the label in the upper-left corner.</summary>
+    TopLeft
+}
+
+/// <summary>
 /// Shared renderer-independent options for visual blocks.
 /// </summary>
 public sealed class VisualBlockOptions {
@@ -486,83 +496,6 @@ public sealed class ChartListItem {
 }
 
 /// <summary>
-/// A compact KPI or metric card visual block.
-/// </summary>
-public sealed class MetricCard : VisualBlock<MetricCard> {
-    private string _label = string.Empty;
-    private string _value = string.Empty;
-    private string _caption = string.Empty;
-    private string _trend = string.Empty;
-    private string _symbol = string.Empty;
-    private VisualIcon _icon;
-    private VisualStatus _status;
-
-    /// <summary>Gets or sets the metric label.</summary>
-    public string Label { get => _label; set => _label = value ?? throw new ArgumentNullException(nameof(value)); }
-
-    /// <summary>Gets or sets the metric value.</summary>
-    public string Value { get => _value; set => _value = value ?? throw new ArgumentNullException(nameof(value)); }
-
-    /// <summary>Gets or sets optional supporting text.</summary>
-    public string Caption { get => _caption; set => _caption = value ?? throw new ArgumentNullException(nameof(value)); }
-
-    /// <summary>Gets or sets optional trend text.</summary>
-    public string Trend { get => _trend; set => _trend = value ?? throw new ArgumentNullException(nameof(value)); }
-
-    /// <summary>Gets or sets an optional compact symbol rendered as a badge.</summary>
-    public string Symbol { get => _symbol; set => _symbol = value ?? throw new ArgumentNullException(nameof(value)); }
-
-    /// <summary>Gets or sets an optional built-in icon rendered as a badge.</summary>
-    public VisualIcon Icon {
-        get => _icon;
-        set {
-            VisualBlockGuards.EnumDefined(value, nameof(value));
-            _icon = value;
-        }
-    }
-
-    /// <summary>Gets or sets the metric status.</summary>
-    public VisualStatus Status {
-        get => _status;
-        set {
-            VisualBlockGuards.EnumDefined(value, nameof(value));
-            _status = value;
-        }
-    }
-
-    /// <summary>Gets a concise accessibility label.</summary>
-    public override string AccessibleName => Label.Length == 0 ? base.AccessibleName : Label;
-
-    /// <summary>Creates a new metric card.</summary>
-    public static MetricCard Create() => new();
-
-    /// <summary>Sets the primary metric label and value.</summary>
-    public MetricCard WithMetric(string label, object? value, string? format = null) {
-        Label = label ?? throw new ArgumentNullException(nameof(label));
-        Value = ChartTableCell.FromValue(value, format).Text;
-        return this;
-    }
-
-    /// <summary>Sets optional supporting text.</summary>
-    public MetricCard WithCaption(string caption) { Caption = caption ?? throw new ArgumentNullException(nameof(caption)); return this; }
-
-    /// <summary>Sets optional trend text.</summary>
-    public MetricCard WithTrend(string trend) { Trend = trend ?? throw new ArgumentNullException(nameof(trend)); return this; }
-
-    /// <summary>Sets an optional compact symbol rendered as a badge.</summary>
-    public MetricCard WithSymbol(string symbol) { Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol)); return this; }
-
-    /// <summary>Sets an optional built-in icon rendered as a badge.</summary>
-    public MetricCard WithIcon(VisualIcon icon) { Icon = icon; return this; }
-
-    /// <summary>Sets the metric status.</summary>
-    public MetricCard WithStatus(VisualStatus status) {
-        Status = status;
-        return this;
-    }
-}
-
-/// <summary>
 /// A KPI card with one or more radial progress layers around a central metric.
 /// </summary>
 public sealed class RadialMetricCard : VisualBlock<RadialMetricCard> {
@@ -692,6 +625,27 @@ public sealed class VisualGrid {
 
     /// <summary>Creates a new visual grid.</summary>
     public static VisualGrid Create() => new();
+
+    /// <summary>Creates a metric-card strip using the standard compact section layout.</summary>
+    public static VisualGrid CreateMetricStrip(string title, IEnumerable<MetricCard> cards, int columns = 4, int panelWidth = 320, int panelHeight = 176) {
+        if (title == null) throw new ArgumentNullException(nameof(title));
+        if (cards == null) throw new ArgumentNullException(nameof(cards));
+        var grid = Create()
+            .WithTitle(title)
+            .WithColumns(columns)
+            .WithPanelSize(panelWidth, panelHeight)
+            .WithGap(16)
+            .WithPadding(24);
+        var count = 0;
+        foreach (var card in cards) {
+            if (card == null) throw new ArgumentException("Metric strips cannot contain null cards.", nameof(cards));
+            grid.Add(card);
+            count++;
+        }
+
+        if (count == 0) throw new ArgumentException("Metric strips require at least one metric card.", nameof(cards));
+        return grid;
+    }
 
     /// <summary>Sets the grid title.</summary>
     public VisualGrid WithTitle(string title) { Title = title ?? throw new ArgumentNullException(nameof(title)); return this; }

--- a/ChartForgeX/VisualBlocks/VisualBlockRendering.cs
+++ b/ChartForgeX/VisualBlocks/VisualBlockRendering.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using ChartForgeX.Core;
 using ChartForgeX.Primitives;
+using ChartForgeX.Rendering;
 using ChartForgeX.Themes;
 
 namespace ChartForgeX.VisualBlocks;
@@ -24,6 +26,12 @@ internal static class VisualBlockRendering {
             if (card.Label.Length == 0) throw new InvalidOperationException("Metric cards must define a label.");
             if (card.Value.Length == 0) throw new InvalidOperationException("Metric cards must define a value.");
             if (card.Symbol.Length > 12) throw new InvalidOperationException("Metric card symbols must be twelve characters or fewer.");
+            if (card.ActionLabel.Length > 48) throw new InvalidOperationException("Metric card action labels must be forty-eight characters or fewer.");
+            if (card.ActionSymbol.Length > 4) throw new InvalidOperationException("Metric card action symbols must be four characters or fewer.");
+            if (card.ActionUrl.Length > 0 && !IsSafeActionUrl(card.ActionUrl)) throw new InvalidOperationException("Metric card action URLs must be relative URLs, http(s), or mailto links.");
+            if (card.MiniBarMinimum.HasValue && card.MiniBarMaximum.HasValue && card.MiniBarMaximum.Value <= card.MiniBarMinimum.Value) throw new InvalidOperationException("Metric card mini bar maximum must be greater than minimum.");
+            if (card.MiniBarHighlightIndex.HasValue && card.MiniBarHighlightIndex.Value >= card.MiniBars.Count) throw new InvalidOperationException("Metric card mini bar highlight index must reference an existing mini bar.");
+            if (card.MiniSparklineMinimum.HasValue && card.MiniSparklineMaximum.HasValue && card.MiniSparklineMaximum.Value <= card.MiniSparklineMinimum.Value) throw new InvalidOperationException("Metric card mini sparkline maximum must be greater than minimum.");
             return;
         }
 
@@ -118,9 +126,91 @@ internal static class VisualBlockRendering {
 
     public static ChartColor CardBackground(VisualBlockOptions options) => options.Theme.CardBackground;
 
+    public static (double Minimum, double Maximum) MiniBarBounds(MetricCard card) {
+        return ValueBounds(card.MiniBars, card.MiniBarMinimum, card.MiniBarMaximum, includeZero: true);
+    }
+
+    public static int MiniBarHighlightIndex(MetricCard card) => card.MiniBarHighlightIndex ?? card.MiniBars.Count - 1;
+
+    public static (double Minimum, double Maximum) MiniSparklineBounds(MetricCard card) {
+        return ValueBounds(card.MiniSparkline, card.MiniSparklineMinimum, card.MiniSparklineMaximum, includeZero: false);
+    }
+
+    public static VisualMiniBar[] CreateMiniBars(MetricCard card, double x, double y, double width, double height) {
+        var theme = card.Options.Theme;
+        var bounds = MiniBarBounds(card);
+        var highlight = MiniBarHighlightIndex(card);
+        var count = card.MiniBars.Count;
+        var gap = count > 5 ? ChartVisualPrimitives.MiniBarDenseGap : ChartVisualPrimitives.MiniBarGap;
+        var barWidth = Math.Max(ChartVisualPrimitives.MiniBarMinWidth, (width - gap * Math.Max(0, count - 1)) / count);
+        var activeColor = card.MiniBarColor ?? (card.Status == VisualStatus.None ? PaletteAt(theme, 0) : StatusColor(theme, card.Status));
+        var mutedColor = card.MiniBarMutedColor ?? theme.MutedText.WithAlpha(85);
+        var bars = new VisualMiniBar[count];
+        for (var i = 0; i < count; i++) {
+            var value = card.MiniBars[i];
+            var ratio = Math.Max(0, Math.Min(1, (value - bounds.Minimum) / (bounds.Maximum - bounds.Minimum)));
+            var barHeight = Math.Max(ChartVisualPrimitives.MiniBarMinHeight, height * ratio);
+            var currentX = x + i * (barWidth + gap);
+            var currentY = y + height - barHeight;
+            var highlighted = i == highlight;
+            var color = highlighted ? activeColor : mutedColor.WithAlpha((byte)Math.Min(255, Math.Round(mutedColor.A * ChartVisualPrimitives.MiniBarMutedOpacity)));
+            bars[i] = new VisualMiniBar(i, value, currentX, currentY, barWidth, barHeight, Math.Min(ChartVisualPrimitives.MiniBarRadiusMax, barWidth * 0.45), color, highlighted);
+        }
+
+        return bars;
+    }
+
+    public static VisualMiniSparkline CreateMiniSparkline(MetricCard card, double x, double y, double width, double height) {
+        var theme = card.Options.Theme;
+        var bounds = MiniSparklineBounds(card);
+        var color = card.MiniSparklineColor ?? (card.Status == VisualStatus.None ? PaletteAt(theme, 0) : StatusColor(theme, card.Status));
+        var fillColor = card.MiniSparklineFillColor ?? color.WithAlpha((byte)Math.Round(255 * ChartVisualPrimitives.MiniSparklineFillOpacity));
+        var points = new ChartPoint[card.MiniSparkline.Count];
+        var step = width / Math.Max(1, card.MiniSparkline.Count - 1);
+        for (var i = 0; i < card.MiniSparkline.Count; i++) {
+            var ratio = Math.Max(0, Math.Min(1, (card.MiniSparkline[i] - bounds.Minimum) / (bounds.Maximum - bounds.Minimum)));
+            points[i] = new ChartPoint(x + i * step, y + height - ratio * height);
+        }
+
+        var area = new ChartPoint[points.Length + 2];
+        area[0] = new ChartPoint(points[0].X, y + height);
+        for (var i = 0; i < points.Length; i++) area[i + 1] = points[i];
+        area[area.Length - 1] = new ChartPoint(points[points.Length - 1].X, y + height);
+        return new VisualMiniSparkline(points, area, color, fillColor, ChartVisualPrimitives.MiniSparklineStrokeWidth, ChartVisualPrimitives.MiniSparklineCurrentRadius);
+    }
+
+    private static bool IsSafeActionUrl(string value) {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        var text = value.Trim();
+        if (text.StartsWith("#", StringComparison.Ordinal) || text.StartsWith("/", StringComparison.Ordinal) || text.StartsWith("./", StringComparison.Ordinal) || text.StartsWith("../", StringComparison.Ordinal)) return true;
+        if (!Uri.TryCreate(text, UriKind.Absolute, out var uri)) return false;
+        return string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(uri.Scheme, Uri.UriSchemeMailto, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool EqualsAny(string text, params string[] values) {
         foreach (var value in values) if (string.Equals(text, value, StringComparison.OrdinalIgnoreCase)) return true;
         return false;
+    }
+
+    private static double Minimum(IReadOnlyList<double> values) {
+        var minimum = double.PositiveInfinity;
+        foreach (var value in values) minimum = Math.Min(minimum, value);
+        return minimum;
+    }
+
+    private static double Maximum(IReadOnlyList<double> values) {
+        var maximum = double.NegativeInfinity;
+        foreach (var value in values) maximum = Math.Max(maximum, value);
+        return maximum;
+    }
+
+    private static (double Minimum, double Maximum) ValueBounds(IReadOnlyList<double> values, double? configuredMinimum, double? configuredMaximum, bool includeZero) {
+        var minimum = configuredMinimum ?? (includeZero ? Math.Min(0, Minimum(values)) : Minimum(values));
+        var maximum = configuredMaximum ?? (includeZero ? Math.Max(0, Maximum(values)) : Maximum(values));
+        if (maximum <= minimum) maximum = minimum + 1;
+        return (minimum, maximum);
     }
 
     private static void Add(ref uint hash, string value) {

--- a/ChartForgeX/VisualBlocks/VisualMicroVisualPrimitives.cs
+++ b/ChartForgeX/VisualBlocks/VisualMicroVisualPrimitives.cs
@@ -1,0 +1,60 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.VisualBlocks;
+
+internal readonly struct VisualMiniBar {
+    public VisualMiniBar(int index, double value, double x, double y, double width, double height, double radius, ChartColor color, bool highlighted) {
+        Index = index;
+        Value = value;
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+        Radius = radius;
+        Color = color;
+        Highlighted = highlighted;
+    }
+
+    public int Index { get; }
+
+    public double Value { get; }
+
+    public double X { get; }
+
+    public double Y { get; }
+
+    public double Width { get; }
+
+    public double Height { get; }
+
+    public double Radius { get; }
+
+    public ChartColor Color { get; }
+
+    public bool Highlighted { get; }
+}
+
+internal readonly struct VisualMiniSparkline {
+    public VisualMiniSparkline(ChartPoint[] points, ChartPoint[] area, ChartColor lineColor, ChartColor fillColor, double strokeWidth, double currentRadius) {
+        Points = points;
+        Area = area;
+        LineColor = lineColor;
+        FillColor = fillColor;
+        StrokeWidth = strokeWidth;
+        CurrentRadius = currentRadius;
+    }
+
+    public ChartPoint[] Points { get; }
+
+    public ChartPoint[] Area { get; }
+
+    public ChartColor LineColor { get; }
+
+    public ChartColor FillColor { get; }
+
+    public double StrokeWidth { get; }
+
+    public double CurrentRadius { get; }
+
+    public ChartPoint Current => Points[Points.Length - 1];
+}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Already in place:
 Still open before calling the library future-complete:
 
 - Finish the remaining string/raw SVG cleanup outside topology. Topology body composition now stays in the SVG element tree, but grid embeds scoped child SVG as raw markup, and some map/chart renderers still use targeted `StringBuilder` paths.
-- Broaden visual blocks based on real consumers: richer table/list formatting, icons, status palettes, and infographic snippets without becoming a spreadsheet or arbitrary HTML renderer.
+- Broaden visual blocks based on real consumers: richer table/list formatting, icons, status palettes, metric-card micro bars/sparklines, and infographic snippets without becoming a spreadsheet or arbitrary HTML renderer.
 - Keep dashboard shells in host projects. ChartForgeX should emit reusable visual fragments and data hooks; HtmlForgeX/TestimoX should own panels, filters, inspectors, tables, and collected product data.
 - Promote topology/geographic examples into formal visual baselines only after dense routing and geographic layout polish are stable enough for numeric baseline thresholds.
 
@@ -171,19 +171,42 @@ var drives = ChartTable.Create()
 var card = MetricCard.Create()
     .WithMetric("Patch compliance", 0.94, "P0")
     .WithTrend("+4 pp")
-    .WithStatus(VisualStatus.Positive);
+    .WithSymbol("OK")
+    .WithBadgePlacement(MetricCardBadgePlacement.TopLeft)
+    .WithStatus(VisualStatus.Positive)
+    .WithAction("View details", url: "#patch-compliance")
+    .WithMiniBars(new[] { 82d, 86d, 88d, 91d, 94d }, maximum: 100);
+
+var latency = MetricCard.Create()
+    .WithMetric("Latency", "18 ms")
+    .WithTrend("-12 ms")
+    .WithStatus(VisualStatus.Info)
+    .WithAction("Open samples", url: "#latency")
+    .WithMiniSparkline(new[] { 42d, 36d, 31d, 28d, 24d, 18d });
 
 var snapshot = VisualGrid.Create()
     .WithTitle("System Snapshot")
     .WithColumns(2)
     .Add(chart)
     .Add(drives)
-    .Add(card, columnSpan: 2);
+    .Add(card)
+    .Add(latency);
 
 snapshot.SaveSvg("snapshot.svg");
 snapshot.SaveHtml("snapshot.html");
 snapshot.SavePng("snapshot.png");
 ```
+
+For PowerBGInfo-style KPI rows, `VisualGrid.CreateMetricStrip(...)` applies the standard compact card-section sizing:
+
+```csharp
+var endpoint = VisualGrid.CreateMetricStrip("Endpoint Snapshot", new[] {
+    MetricCard.Create().WithMetric("CPU Load", "38%").WithSymbol("CPU").WithBadgePlacement(MetricCardBadgePlacement.TopLeft).WithAction("View details", url: "#cpu-load").WithMiniSparkline(new[] { 52d, 48d, 44d, 41d, 38d }),
+    MetricCard.Create().WithMetric("Memory Used", "71%").WithAction("View details").WithMiniBars(new[] { 55d, 59d, 63d, 68d, 71d }, maximum: 100)
+});
+```
+
+Metric-card mini bars and sparklines share internal geometry/styling primitives across SVG and PNG renderers. That keeps future line/bar polish reusable instead of making the card visuals a separate second implementation.
 
 ChartForgeX validates chart data before rendering so invalid report payloads fail close to the caller instead of producing partial markup or malformed PNGs. Public APIs reject non-finite numbers, invalid enum values, empty required data sets, malformed specialized series, negative proportional values, cyclic Sankey flows, and tree data with multiple roots or parents. HTML fragments and grids scope child SVG IDs per render, so repeated or identical charts can be safely embedded on the same page. When embedding raw SVG strings yourself, pass a stable scope such as `chart.ToSvg("panel-a")` or `grid.ToSvg("report-a")` to keep element IDs unique without giving up deterministic output.
 

--- a/docs/visual-blocks.md
+++ b/docs/visual-blocks.md
@@ -6,7 +6,7 @@ Current visual-block primitives:
 
 - `ChartTable` for structured rows, columns, headers, alignment, formattable values, row striping, status columns, conditional row/cell colors, dense mode, transparent backgrounds, and SVG/PNG/HTML export.
 - `ChartList` for bullets, numbered lists, key/value rows, checklists, status lists, and compact inventory summaries.
-- `MetricCard` for one KPI with label, value, trend, status, and optional comparison/supporting text.
+- `MetricCard` for one KPI with label, value, trend, status, optional comparison/supporting text, footer action text, and embedded mini bars or sparklines for compact history/current-state cards.
 - `VisualGrid` for composing charts and visual blocks side by side without forcing non-chart content into `ChartGrid`.
 
 The first API is intentionally generic and bounded:
@@ -43,10 +43,49 @@ table.SaveHtml("drives.html");
 table.SavePng("drives.png");
 ```
 
+Metric cards can carry a short micro bar history without becoming a full chart:
+
+```csharp
+var cpu = MetricCard.Create()
+    .WithMetric("CPU Load", "38%")
+    .WithTrend("-6%")
+    .WithCaption("5 minute trend")
+    .WithSymbol("CPU")
+    .WithBadgePlacement(MetricCardBadgePlacement.TopLeft)
+    .WithStatus(VisualStatus.Positive)
+    .WithAction("View details", url: "#cpu-load")
+    .WithMiniBars(new[] { 48d, 52d, 44d, 41d, 38d }, maximum: 100);
+```
+
+Use a mini sparkline when the shape of recent movement matters more than discrete columns:
+
+```csharp
+var latency = MetricCard.Create()
+    .WithMetric("Latency", "18 ms")
+    .WithTrend("-12 ms")
+    .WithCaption("last samples")
+    .WithStatus(VisualStatus.Info)
+    .WithAction("Open samples", url: "#latency")
+    .WithMiniSparkline(new[] { 42d, 36d, 31d, 28d, 24d, 18d });
+```
+
+Metric strips provide a reusable section preset for PowerBGInfo-style card rows:
+
+```csharp
+var section = VisualGrid.CreateMetricStrip("Endpoint Snapshot", new[] {
+    MetricCard.Create().WithMetric("CPU Load", "38%").WithSymbol("CPU").WithBadgePlacement(MetricCardBadgePlacement.TopLeft).WithAction("View details", url: "#cpu-load").WithMiniSparkline(new[] { 52d, 48d, 44d, 41d, 38d }),
+    MetricCard.Create().WithMetric("Memory Used", "71%").WithAction("View details").WithMiniBars(new[] { 55d, 59d, 63d, 68d, 71d }, maximum: 100)
+});
+```
+
+`WithAction(...)` is still static-renderer friendly. SVG/HTML outputs render safe relative, `http(s)`, and `mailto` action URLs when one is supplied; PNG keeps the same visual affordance without embedding a link.
+
+The mini bar and mini sparkline geometry is shared by the SVG and PNG visual-block renderers, so improvements to compact line/bar polish can be applied once instead of redoing each output format separately.
+
 Next extension points should be driven by real PowerBGInfo, ImagePlayground, email, Word, and wallpaper scenarios:
 
 - richer table/list style presets
 - optional small icon symbols for status cells and list markers
 - reusable status palettes
-- compact infographic snippets that are still data-driven blocks, not arbitrary markup
+- compact infographic snippets that reuse shared primitive layout/styling, not arbitrary markup
 - more examples and visual-baseline candidates once layouts stabilize


### PR DESCRIPTION
## Summary
- Adds reusable `MetricCard` visual blocks with mini bars, mini sparklines, badge placement, footer actions, and safe SVG/HTML action links.
- Adds shared internal mini visual primitives so compact bar/sparkline geometry and styling are reused by SVG and PNG renderers.
- Adds dark PowerBGInfo and light report-summary metric strip examples, refreshed visual baselines, tests, and documentation.

## Validation
- `dotnet test .\ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Release`
- `.\Build.ps1 -UpdateVisualBaseline -SkipPack`
- `dotnet build-server shutdown`
- `dotnet build .\ChartForgeX.sln -c Release --no-restore -m:1 -nr:false /p:UseSharedCompilation=false`
- `dotnet test .\ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Release --no-build --no-restore`
- `dotnet run --project .\ChartForgeX.Examples\ChartForgeX.Examples.csproj -c Release --no-build`
- SVG/PNG comparison manifest: 81 chart pairs, 81 dimension matches, 81 healthy SVGs, 81 healthy PNGs, 0 warnings
- `git diff --check`

## Notes
- A plain `.\Build.ps1 -SkipPack` retry hit a stale `dotnet` build-server/restore process on this machine and exited without a useful diagnostic after the stuck process was cleared. The same build, test, example, and visual-comparison path was rerun explicitly after `dotnet build-server shutdown` and passed.
