### PR TITLE
Ignore local tooling outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ artifacts/
 /.claude/
 /.playwright-mcp/
 /*.png
-/Website/
+Website/_reports/
+Website/_site/
+Website/_temp/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ obj/
 *.suo
 TestResults/
 artifacts/
-Website/_reports/
-Website/_site/
-Website/_temp/
+/.claude/
+/.playwright-mcp/
+/*.png
+/Website/


### PR DESCRIPTION
## Summary
- ignore local assistant/browser artifact folders
- ignore root-level generated PNG exports
- ignore the local Website workspace used during site experiments

## Validation
- git check-ignore verifies the local artifact paths are ignored