### PR TITLE
Add wellness dashboard visual blocks

### DIFF
--- a/ChartForgeX.Examples/ExampleProgramOptions.cs
+++ b/ChartForgeX.Examples/ExampleProgramOptions.cs
@@ -25,6 +25,13 @@ internal static class ExampleProgramOptions {
             return true;
         }
 
+        if (HasArg(args, "--wellness-only")) {
+            WellnessDashboardExamples.Write(output, pngOutputScale);
+            GalleryWriter.Write(output);
+            Console.WriteLine("Generated wellness files in: " + output);
+            return true;
+        }
+
         if (HasArg(args, "--dashboard-shipment-only")) {
             DashboardPatternExamples.WriteShipmentActivityPanel(output, pngOutputScale);
             Console.WriteLine("Generated dashboard shipment panel in: " + output);

--- a/ChartForgeX.Examples/GalleryWriter.Catalog.cs
+++ b/ChartForgeX.Examples/GalleryWriter.Catalog.cs
@@ -68,7 +68,8 @@ public static partial class GalleryWriter {
             "Composed mobile-style health and nutrition cards plus generic layered radial primitives.",
             "wellness-layered-radial-progress",
             "wellness-weight-data-gauge",
-            "wellness-calories-intake-dashboard"),
+            "wellness-calories-intake-dashboard",
+            "wellness-weekly-progress-dashboard"),
         new(
             "Dashboard Patterns",
             "Reusable KPI cards, progress rows, honeycomb utilization, ticketing analytics, MRR trend cards, and composed dashboard grids.",

--- a/ChartForgeX.Examples/WellnessDashboardExamples.cs
+++ b/ChartForgeX.Examples/WellnessDashboardExamples.cs
@@ -23,6 +23,7 @@ internal static class WellnessDashboardExamples {
         SavePowerBgInfoStatsSection(output, (int)pngOutputScale);
         SaveReportMetricStrip(output, (int)pngOutputScale);
         SaveTransparentReportMetricStrip(output, (int)pngOutputScale);
+        SaveWeeklyProgressDashboard(output, (int)pngOutputScale);
     }
 
     private static void SaveLayeredRadial(string output, ChartPngOutputScale pngOutputScale) {
@@ -267,6 +268,117 @@ internal static class WellnessDashboardExamples {
         grid.SaveSvg(Path.Combine(output, "transparent-report-summary-metric-strip.svg"));
         grid.SaveHtml(Path.Combine(output, "transparent-report-summary-metric-strip.html"));
         grid.SavePng(Path.Combine(output, "transparent-report-summary-metric-strip.png"));
+    }
+
+    private static void SaveWeeklyProgressDashboard(string output, int outputScale) {
+        var theme = WellnessTheme()
+            .WithSurfaceColors(ChartColor.FromHex("#F6F7FA"), ChartColor.FromHex("#FFFFFF"), ChartColor.FromHex("#FFFFFF"), ChartColor.FromHex("#F0F2F6"), ChartColor.FromHex("#E4E7EF"))
+            .WithPalette("#0F83F7", "#FF7A1A", "#E72CEB", "#52C7E9", "#C98A52")
+            .WithCornerRadius(28, 18)
+            .WithShadowOpacity(0.055);
+        var coolActivityTheme = WellnessTheme()
+            .WithSurfaceColors(ChartColor.FromHex("#F6F7FA"), ChartColor.FromHex("#F8FBFF"), ChartColor.FromHex("#FFFFFF"), ChartColor.FromHex("#E9F3FF"), ChartColor.FromHex("#E0EBF7"))
+            .WithPalette("#0F83F7", "#FF7A1A", "#E72CEB", "#52C7E9", "#C98A52")
+            .WithCornerRadius(28, 18)
+            .WithShadowOpacity(0.055);
+        var warmTheme = WellnessTheme()
+            .WithSurfaceColors(ChartColor.FromHex("#F6F7FA"), ChartColor.FromHex("#FFF9F3"), ChartColor.FromHex("#FFF9F3"), ChartColor.FromHex("#F2E7DA"), ChartColor.FromHex("#F0E6DA"))
+            .WithPalette("#FF7A1A", "#0F83F7", "#E72CEB", "#52C7E9", "#C98A52")
+            .WithCornerRadius(28, 18)
+            .WithShadowOpacity(0.055);
+        var blue = ChartColor.FromHex("#0F83F7");
+        var orange = ChartColor.FromHex("#FF7A1A");
+
+        var week = DateStripBlock.Create()
+            .WithSize(760, 158)
+            .WithTheme(theme)
+            .WithPadding(18)
+            .WithHeader("May 9, 2026")
+            .WithNavigation(false)
+            .AddItem("s", "9", selected: true, color: blue)
+            .AddItem("s", "10")
+            .AddItem("m", "10")
+            .AddItem("t", "12")
+            .AddItem("w", "13")
+            .AddItem("t", "14")
+            .AddItem("f", "15");
+
+        var water = MetricCard.Create()
+            .WithSize(360, 140)
+            .WithTheme(theme)
+            .WithIcon(VisualIcon.Droplet)
+            .WithBadgePlacement(MetricCardBadgePlacement.TopLeft)
+            .WithMicroVisualSurface(MetricCardMicroVisualSurface.Inset)
+            .WithMetric("Litres of water", "4.5", unit: "Litres");
+
+        var calories = MetricCard.Create()
+            .WithSize(360, 140)
+            .WithTheme(warmTheme)
+            .WithIcon(VisualIcon.Flame)
+            .WithBadgePlacement(MetricCardBadgePlacement.TopLeft)
+            .WithMicroVisualSurface(MetricCardMicroVisualSurface.Inset)
+            .WithMetric("Calories", "2.3k", unit: "Kcal");
+
+        var running = MetricCard.Create()
+            .WithSize(360, 300)
+            .WithTheme(coolActivityTheme)
+            .WithMetric("Running", "30 mins")
+            .WithMiniSparkline(new[] { 18d, 30d, 34d, 25d, 28d, 43d, 45d, 44d, 48d }, minimum: 0, maximum: 62, color: blue)
+            .WithSecondaryMiniSparkline(new[] { 15d, 27d, 31d, 23d, 25d, 40d, 42d, 41d, 45d }, blue.WithAlpha(210))
+            .WithMiniSparklineStyle(MetricCardSparklineStyle.Line)
+            .WithMicroVisualPlacement(MetricCardMicroVisualPlacement.Hero)
+            .WithMicroVisualSurface(MetricCardMicroVisualSurface.Inset)
+            .WithCaption("7-day trend");
+
+        var cycling = MetricCard.Create()
+            .WithSize(360, 300)
+            .WithTheme(warmTheme)
+            .WithMetric("Cycling", "40 mins")
+            .WithMiniSparkline(new[] { 16d, 25d, 28d, 21d, 22d, 35d, 38d, 37d, 42d }, minimum: 0, maximum: 62, color: orange)
+            .WithSecondaryMiniSparkline(new[] { 13d, 22d, 25d, 18d, 19d, 32d, 35d, 34d, 39d }, orange.WithAlpha(210))
+            .WithMiniSparklineStyle(MetricCardSparklineStyle.Line)
+            .WithMicroVisualPlacement(MetricCardMicroVisualPlacement.Hero)
+            .WithMicroVisualSurface(MetricCardMicroVisualSurface.Inset)
+            .WithCaption("7-day trend");
+
+        var goalsHeader = SectionHeaderBlock.Create()
+            .WithTitle("Today's Goals")
+            .WithSize(760, 44)
+            .WithTheme(theme)
+            .WithPadding(0, 4, 0, 0)
+            .WithTransparentBackground()
+            .WithCard(false);
+
+        var friends = EntityStripBlock.Create()
+            .WithTitle("Duel with friends")
+            .WithSize(760, 144)
+            .WithTheme(theme)
+            .WithPadding(18)
+            .AddItem("Karrem", color: blue)
+            .AddItem("Peter", color: orange)
+            .AddItem("Pasel", color: ChartColor.FromHex("#E72CEB"))
+            .AddItem("Libura", color: ChartColor.FromHex("#52C7E9"))
+            .AddItem("Hakem", color: ChartColor.FromHex("#C98A52"));
+
+        var grid = VisualGrid.Create()
+            .WithTitle("Your Weekly Progress")
+            .WithColumns(2)
+            .WithAdaptiveRowHeights()
+            .WithGap(20)
+            .WithPadding(30)
+            .WithTheme(theme)
+            .WithPngOutputScale(outputScale)
+            .Add(week, columnSpan: 2)
+            .Add(water)
+            .Add(calories)
+            .Add(goalsHeader, columnSpan: 2)
+            .Add(running)
+            .Add(cycling)
+            .Add(friends, columnSpan: 2);
+
+        grid.SaveSvg(Path.Combine(output, "wellness-weekly-progress-dashboard.svg"));
+        grid.SaveHtml(Path.Combine(output, "wellness-weekly-progress-dashboard.html"));
+        grid.SavePng(Path.Combine(output, "wellness-weekly-progress-dashboard.png"));
     }
 
     private static ChartTheme WellnessTheme() => ChartTheme.Minimal()

--- a/ChartForgeX.Examples/visual-baseline.json
+++ b/ChartForgeX.Examples/visual-baseline.json
@@ -1746,6 +1746,22 @@
       }
     },
     {
+      "name": "wellness-weekly-progress-dashboard",
+      "width": 820,
+      "height": 1002,
+      "svg": {
+        "minVisualNodes": 128,
+        "maxClippedTextNodes": 0,
+        "maxNearEdgeTextNodes": 1
+      },
+      "png": {
+        "outputScale": 2,
+        "minVisiblePixels": 3286560,
+        "minDistinctColors": 2048,
+        "maxEdgeInkPixels": 0
+      }
+    },
+    {
       "name": "wellness-weight-data-gauge",
       "width": 560,
       "height": 420,

--- a/ChartForgeX.Tests/SmokeTests/VisualBlockTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualBlockTests.cs
@@ -94,6 +94,17 @@ internal static partial class SmokeTests {
         Assert(symbolMetricSvg.Contains("dominant-baseline=\"central\"", StringComparison.Ordinal), "MetricCard symbols should be vertically centered inside their badge.");
         Assert(symbolMetric.ToPng().Length > 64, "MetricCard symbol badges should render in PNG output.");
 
+        var valueSurfaceMetric = MetricCard.Create()
+            .WithMetric("Litres of water", "4.5", unit: "Litres")
+            .WithIcon(VisualIcon.Droplet)
+            .WithMicroVisualSurface(MetricCardMicroVisualSurface.Inset)
+            .WithSize(300, 140);
+        var valueSurfaceSvg = valueSurfaceMetric.ToSvg("visual-block-metric-value-surface");
+        Assert(valueSurfaceSvg.Contains("data-cfx-role=\"metric-value-surface\"", StringComparison.Ordinal), "MetricCard should render compact metric value surfaces.");
+        Assert(valueSurfaceSvg.Contains("data-cfx-role=\"metric-value-surface-badge\"", StringComparison.Ordinal), "MetricCard value surfaces should keep icons inside the value tray.");
+        Assert(valueSurfaceSvg.Contains("data-cfx-role=\"metric-unit\"", StringComparison.Ordinal), "MetricCard should render optional metric units separately from emphasized values.");
+        Assert(valueSurfaceMetric.ToPng().Length > 64, "MetricCard compact value surfaces should render PNG output.");
+
         var sparkMetric = MetricCard.Create()
             .WithMetric("Network", "842 Mbps")
             .WithStatus(VisualStatus.Info)
@@ -103,6 +114,21 @@ internal static partial class SmokeTests {
         Assert(sparkSvg.Contains("data-cfx-role=\"metric-mini-sparkline-current\"", StringComparison.Ordinal), "MetricCard sparklines should mark the current value.");
         Assert(sparkSvg.Contains("842 Mbps", StringComparison.Ordinal), "MetricCard should shrink long values enough to fit beside micro visuals.");
         Assert(sparkMetric.ToPng().Length > 64, "MetricCard sparkline should render PNG output.");
+
+        var heroSparkMetric = MetricCard.Create()
+            .WithMetric("Running", "30 mins")
+            .WithMiniSparkline(new[] { 18d, 30d, 34d, 25d, 28d, 43d, 45d, 44d, 48d })
+            .WithSecondaryMiniSparkline(new[] { 15d, 27d, 31d, 23d, 25d, 40d, 42d, 41d, 45d })
+            .WithMiniSparklineStyle(MetricCardSparklineStyle.Line)
+            .WithMicroVisualPlacement(MetricCardMicroVisualPlacement.Hero)
+            .WithMicroVisualSurface(MetricCardMicroVisualSurface.Inset)
+            .WithSize(360, 300);
+        var heroSparkSvg = heroSparkMetric.ToSvg("visual-block-metric-hero-sparkline");
+        Assert(heroSparkSvg.Contains("data-cfx-role=\"metric-micro-surface\"", StringComparison.Ordinal), "MetricCard hero mini visuals should support an inset surface.");
+        Assert(heroSparkSvg.Contains("data-cfx-style=\"line\"", StringComparison.Ordinal), "MetricCard should render line-style sparklines without area fill.");
+        Assert(heroSparkSvg.Contains("data-cfx-role=\"metric-mini-sparkline-secondary\"", StringComparison.Ordinal), "MetricCard should render a true secondary sparkline series.");
+        Assert(heroSparkSvg.Contains("data-cfx-role=\"metric-mini-sparkline-start\"", StringComparison.Ordinal), "MetricCard line-style sparklines should mark the starting value.");
+        Assert(heroSparkMetric.ToPng().Length > 64, "MetricCard hero line sparkline should render PNG output.");
 
         var radialMetric = RadialMetricCard.Create()
             .WithMetric("Capacity left", "42%")
@@ -192,6 +218,47 @@ internal static partial class SmokeTests {
         Assert(heatmapSvg.Contains("16 appointments", StringComparison.Ordinal), "HeatmapInsightCard should render insight details.");
         Assert(heatmap.ToHtmlFragment().Contains("chartforgex-visual-block", StringComparison.Ordinal), "HeatmapInsightCard should render an embeddable HTML fragment.");
         Assert(heatmap.ToPng().Length > 64, "HeatmapInsightCard should render PNG output.");
+
+        var dateStrip = DateStripBlock.Create()
+            .WithHeader("May 9, 2026")
+            .WithTheme(ChartTheme.ReportLight())
+            .WithSize(620, 150)
+            .AddItem("S", "9", selected: true, color: ChartColor.FromHex("#0F83F7"))
+            .AddItem("M", "10")
+            .AddItem("T", "11");
+        var dateStripSvg = dateStrip.ToSvg("visual-block-date-strip");
+        Assert(dateStripSvg.Contains("data-cfx-role=\"date-strip-block\"", StringComparison.Ordinal), "DateStripBlock should render a public block role.");
+        Assert(dateStripSvg.Contains("data-cfx-role=\"date-strip-header\"", StringComparison.Ordinal), "DateStripBlock should render optional header chrome.");
+        Assert(dateStripSvg.Contains("data-cfx-role=\"date-strip-item\"", StringComparison.Ordinal), "DateStripBlock should render date items.");
+        Assert(dateStripSvg.Contains("data-cfx-selected=\"true\"", StringComparison.Ordinal), "DateStripBlock should preserve selected item metadata.");
+        Assert(dateStrip.ToHtmlFragment().Contains("chartforgex-visual-block", StringComparison.Ordinal), "DateStripBlock should render an embeddable HTML fragment.");
+        Assert(dateStrip.ToPng().Length > 64, "DateStripBlock should render PNG output.");
+
+        var entityStrip = EntityStripBlock.Create()
+            .WithTitle("Duel with friends")
+            .WithAction("New")
+            .WithTheme(ChartTheme.ReportLight())
+            .WithSize(620, 150)
+            .AddItem("Karrem", color: ChartColor.FromHex("#0F83F7"))
+            .AddItem("Peter", avatarText: "P", color: ChartColor.FromHex("#FF7A1A"));
+        var entityStripSvg = entityStrip.ToSvg("visual-block-entity-strip");
+        Assert(entityStripSvg.Contains("data-cfx-role=\"entity-strip-block\"", StringComparison.Ordinal), "EntityStripBlock should render a public block role.");
+        Assert(entityStripSvg.Contains("data-cfx-role=\"entity-strip-avatar\"", StringComparison.Ordinal), "EntityStripBlock should render avatar slots.");
+        Assert(entityStripSvg.Contains("data-cfx-icon=\"person\"", StringComparison.Ordinal), "EntityStripBlock should reuse built-in person icons when avatar text is not configured.");
+        Assert(entityStrip.ToHtmlFragment().Contains("chartforgex-visual-block", StringComparison.Ordinal), "EntityStripBlock should render an embeddable HTML fragment.");
+        Assert(entityStrip.ToPng().Length > 64, "EntityStripBlock should render PNG output.");
+
+        var sectionHeader = SectionHeaderBlock.Create()
+            .WithTitle("Today's Goals")
+            .WithAction("See all")
+            .WithTheme(ChartTheme.ReportLight())
+            .WithSize(620, 48)
+            .WithCard(false)
+            .WithTransparentBackground();
+        var sectionHeaderSvg = sectionHeader.ToSvg("visual-block-section-header");
+        Assert(sectionHeaderSvg.Contains("data-cfx-role=\"section-header-title\"", StringComparison.Ordinal), "SectionHeaderBlock should render a public title role.");
+        Assert(sectionHeaderSvg.Contains("data-cfx-role=\"section-header-action\"", StringComparison.Ordinal), "SectionHeaderBlock should render optional trailing actions.");
+        Assert(sectionHeader.ToPng().Length > 64, "SectionHeaderBlock should render PNG output.");
 
         var workload = WorkloadListBlock.Create()
             .WithTitle("Today Staff Workload")
@@ -367,6 +434,19 @@ internal static partial class SmokeTests {
         Assert(autoHtml.Contains("--cfx-visual-grid-panel-height:260px", StringComparison.Ordinal), "Auto-sized VisualGrid HTML should emit the computed max panel height used by SVG/PNG layout.");
         Assert(autoHtml.Contains(".chartforgex-visual-grid-panel svg{width:auto;height:auto", StringComparison.Ordinal), "Auto-sized VisualGrid HTML should preserve child SVG intrinsic sizes.");
         Assert(!autoHtml.Contains("chartforgex-visual-grid has-fixed-panels", StringComparison.Ordinal), "Auto-sized VisualGrid HTML should not force fixed-panel child scaling.");
+
+        var adaptiveGrid = VisualGrid.Create()
+            .WithColumns(2)
+            .WithGap(20)
+            .WithAdaptiveRowHeights()
+            .Add(SectionHeaderBlock.Create().WithTitle("Today's Goals").WithSize(760, 44).WithCard(false).WithTransparentBackground(), columnSpan: 2)
+            .Add(MetricCard.Create().WithMetric("Short", 1).WithSize(360, 140))
+            .Add(MetricCard.Create().WithMetric("Tall", 2).WithSize(360, 300));
+        var adaptiveSvg = adaptiveGrid.ToSvg("visual-grid-adaptive-rows");
+        var adaptiveHtml = adaptiveGrid.ToHtmlFragment();
+        Assert(adaptiveSvg.Contains("data-cfx-role=\"section-header-title\"", StringComparison.Ordinal), "Adaptive VisualGrid rows should compose natural section headers.");
+        Assert(adaptiveHtml.Contains("--cfx-visual-grid-panel-height:auto", StringComparison.Ordinal), "Adaptive VisualGrid HTML should let natural row heights drive layout.");
+        Assert(adaptiveGrid.ToPng().Length > 64, "Adaptive VisualGrid rows should render PNG output.");
     }
 
     private static void VisualBlocksRejectInvalidInputsCloseToCaller() {
@@ -395,6 +475,10 @@ internal static partial class SmokeTests {
         AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().Status = (VisualStatus)999, "MetricCard should reject unknown status values.");
         AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().Icon = (VisualIcon)999, "MetricCard should reject unknown icon values.");
         AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().BadgePlacement = (MetricCardBadgePlacement)999, "MetricCard should reject unknown badge placements.");
+        AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().MicroVisualPlacement = (MetricCardMicroVisualPlacement)999, "MetricCard should reject unknown micro visual placements.");
+        AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().MiniSparklineStyle = (MetricCardSparklineStyle)999, "MetricCard should reject unknown mini sparkline styles.");
+        AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().MicroVisualSurface = (MetricCardMicroVisualSurface)999, "MetricCard should reject unknown micro visual surfaces.");
+        AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1, unit: new string('x', 25)).ToSvg(), "MetricCard units should stay compact.");
         AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithAction(new string('x', 49)).ToSvg(), "MetricCard action labels should stay compact.");
         AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithAction("Open", "longer").ToSvg(), "MetricCard action symbols should stay compact.");
         AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithAction("Open", url: "javascript:alert(1)").ToSvg(), "MetricCard action URLs should reject scriptable URLs.");
@@ -405,6 +489,7 @@ internal static partial class SmokeTests {
         AssertThrows<ArgumentException>(() => MetricCard.Create().WithMiniSparkline(new[] { 1d }), "MetricCard mini sparklines should require at least two values.");
         AssertThrows<ArgumentOutOfRangeException>(() => MetricCard.Create().WithMiniSparkline(new[] { 1d, double.PositiveInfinity }), "MetricCard mini sparklines should reject non-finite values.");
         AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithMiniSparkline(new[] { 1d, 2d }, minimum: 3, maximum: 2).ToSvg(), "MetricCard mini sparklines should require maximum greater than minimum.");
+        AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Bad", 1).WithMiniSparkline(new[] { 1d, 2d }).WithSecondaryMiniSparkline(new[] { 1d, 2d, 3d }).ToSvg(), "MetricCard secondary mini sparklines should match the primary count.");
         AssertThrows<InvalidOperationException>(() => MetricCard.Create().WithMetric("Missing", null).ToSvg(), "MetricCard should require a visible value.");
         AssertThrows<InvalidOperationException>(() => RadialMetricCard.Create().WithMetric("Missing", "1").ToSvg(), "RadialMetricCard should require at least one layer.");
         AssertThrows<InvalidOperationException>(() => RadialMetricCard.Create().AddLayer("Bad", 1, configure: _ => null!).ToSvg(), "RadialMetricCard should reject null fluent layer configuration results.");
@@ -430,6 +515,16 @@ internal static partial class SmokeTests {
         AssertThrows<InvalidOperationException>(() => HeatmapInsightCard.Create().ToSvg(), "HeatmapInsightCard should require columns and rows.");
         AssertThrows<InvalidOperationException>(() => HeatmapInsightCard.Create().WithColumns("A", "B").AddRow("Bad", 1).ToSvg(), "HeatmapInsightCard rows should match the column count.");
         AssertThrows<InvalidOperationException>(() => HeatmapInsightCard.Create().WithColumns("A").WithColorKey(2, 1).AddRow("Bad", 1).ToSvg(), "HeatmapInsightCard should require a valid color key range.");
+        AssertThrows<InvalidOperationException>(() => DateStripBlock.Create().ToSvg(), "DateStripBlock should require items.");
+        AssertThrows<InvalidOperationException>(() => DateStripBlock.Create().AddItem("", "1").ToSvg(), "DateStripBlock should require item labels.");
+        AssertThrows<InvalidOperationException>(() => DateStripBlock.Create().AddItem("Monday and too long", "1").ToSvg(), "DateStripBlock item labels should stay compact.");
+        AssertThrows<InvalidOperationException>(() => EntityStripBlock.Create().ToSvg(), "EntityStripBlock should require items.");
+        AssertThrows<InvalidOperationException>(() => EntityStripBlock.Create().AddItem("", "A").ToSvg(), "EntityStripBlock should require item labels.");
+        AssertThrows<InvalidOperationException>(() => EntityStripBlock.Create().AddItem("Bad", "TOOLONG").ToSvg(), "EntityStripBlock avatar text should stay compact.");
+        AssertThrows<InvalidOperationException>(() => EntityStripBlock.Create().AddItem("Bad").WithAction("Open", url: "javascript:alert(1)").ToSvg(), "EntityStripBlock action URLs should reject scriptable URLs.");
+        AssertThrows<InvalidOperationException>(() => SectionHeaderBlock.Create().ToSvg(), "SectionHeaderBlock should require a title.");
+        AssertThrows<InvalidOperationException>(() => SectionHeaderBlock.Create().WithTitle("Bad").WithAction(new string('x', 49)).ToSvg(), "SectionHeaderBlock action labels should stay compact.");
+        AssertThrows<InvalidOperationException>(() => SectionHeaderBlock.Create().WithTitle("Bad").WithAction("Open", url: "javascript:alert(1)").ToSvg(), "SectionHeaderBlock action URLs should reject scriptable URLs.");
         AssertThrows<InvalidOperationException>(() => WorkloadListBlock.Create().ToSvg(), "WorkloadListBlock should require rows.");
         AssertThrows<InvalidOperationException>(() => WorkloadListBlock.Create().AddPerson("", "Role", 1).ToSvg(), "WorkloadListBlock should require row labels.");
         AssertThrows<InvalidOperationException>(() => WorkloadListBlock.Create().AddPerson("Bad", "Role", -1).ToSvg(), "WorkloadListBlock should reject negative values.");

--- a/ChartForgeX.Tests/SmokeTests/VisualBlockTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualBlockTests.cs
@@ -105,6 +105,27 @@ internal static partial class SmokeTests {
         Assert(valueSurfaceSvg.Contains("data-cfx-role=\"metric-unit\"", StringComparison.Ordinal), "MetricCard should render optional metric units separately from emphasized values.");
         Assert(valueSurfaceMetric.ToPng().Length > 64, "MetricCard compact value surfaces should render PNG output.");
 
+        var narrowValueSurfaceMetric = MetricCard.Create()
+            .WithMetric("Energy", "123456789", unit: "kilocalories-per-day")
+            .WithMicroVisualSurface(MetricCardMicroVisualSurface.Inset)
+            .WithSize(210, 140);
+        var narrowValueSurfaceSvg = narrowValueSurfaceMetric.ToSvg("visual-block-metric-narrow-value-surface");
+        Assert(narrowValueSurfaceSvg.Contains("data-cfx-role=\"metric-unit\"", StringComparison.Ordinal), "MetricCard narrow value surfaces should still render unit text.");
+        Assert(!narrowValueSurfaceSvg.Contains("kilocalories-per-day", StringComparison.Ordinal) && narrowValueSurfaceSvg.Contains("...", StringComparison.Ordinal), "MetricCard value surfaces should fit unit text to the remaining inset width.");
+        Assert(narrowValueSurfaceMetric.ToPng().Length > 64, "MetricCard narrow value surfaces should render PNG output.");
+
+        var compactValueSurfaceMetric = MetricCard.Create()
+            .WithMetric("Compact", "123", unit: "kilocalories-per-day")
+            .WithMicroVisualSurface(MetricCardMicroVisualSurface.Inset)
+            .WithSize(210, 90);
+        var compactValueSurfaceSvg = compactValueSurfaceMetric.ToSvg("visual-block-metric-compact-value-surface");
+        var compactValueSurface = System.Text.RegularExpressions.Regex.Match(compactValueSurfaceSvg, "data-cfx-role=\"metric-value-surface\"[^>]*y=\"([^\"]+)\"[^>]*height=\"([^\"]+)\"");
+        Assert(compactValueSurface.Success, "MetricCard compact inset values should render a measurable value surface.");
+        var compactValueSurfaceY = double.Parse(compactValueSurface.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+        var compactValueSurfaceHeight = double.Parse(compactValueSurface.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
+        Assert(compactValueSurfaceY + compactValueSurfaceHeight <= 90, "MetricCard compact inset value surfaces should stay within the card bounds.");
+        Assert(compactValueSurfaceMetric.ToPng().Length > 64, "MetricCard compact inset values should render PNG output.");
+
         var sparkMetric = MetricCard.Create()
             .WithMetric("Network", "842 Mbps")
             .WithStatus(VisualStatus.Info)
@@ -114,6 +135,15 @@ internal static partial class SmokeTests {
         Assert(sparkSvg.Contains("data-cfx-role=\"metric-mini-sparkline-current\"", StringComparison.Ordinal), "MetricCard sparklines should mark the current value.");
         Assert(sparkSvg.Contains("842 Mbps", StringComparison.Ordinal), "MetricCard should shrink long values enough to fit beside micro visuals.");
         Assert(sparkMetric.ToPng().Length > 64, "MetricCard sparkline should render PNG output.");
+
+        var areaSparkMetric = MetricCard.Create()
+            .WithMetric("Hydration", "4.5 L")
+            .WithMiniSparkline(new[] { 1d, 2d, 3d })
+            .WithSecondaryMiniSparkline(new[] { 100d, 120d, 140d });
+        var areaSparkSvg = areaSparkMetric.ToSvg("visual-block-metric-area-sparkline");
+        Assert(areaSparkSvg.Contains("data-cfx-style=\"area\"", StringComparison.Ordinal), "MetricCard should keep the default filled area sparkline style.");
+        Assert(areaSparkSvg.Contains("data-cfx-max=\"3\"", StringComparison.Ordinal), "Area-style MetricCard sparklines should derive bounds from the visible primary series only.");
+        Assert(!areaSparkSvg.Contains("data-cfx-role=\"metric-mini-sparkline-secondary\"", StringComparison.Ordinal), "Area-style MetricCard sparklines should not render hidden secondary series.");
 
         var heroSparkMetric = MetricCard.Create()
             .WithMetric("Running", "30 mins")
@@ -129,6 +159,30 @@ internal static partial class SmokeTests {
         Assert(heroSparkSvg.Contains("data-cfx-role=\"metric-mini-sparkline-secondary\"", StringComparison.Ordinal), "MetricCard should render a true secondary sparkline series.");
         Assert(heroSparkSvg.Contains("data-cfx-role=\"metric-mini-sparkline-start\"", StringComparison.Ordinal), "MetricCard line-style sparklines should mark the starting value.");
         Assert(heroSparkMetric.ToPng().Length > 64, "MetricCard hero line sparkline should render PNG output.");
+
+        var compactHeroSparkMetric = MetricCard.Create()
+            .WithMetric("Compact", "10")
+            .WithMiniSparkline(new[] { 2d, 5d, 3d, 8d })
+            .WithMicroVisualPlacement(MetricCardMicroVisualPlacement.Hero)
+            .WithMicroVisualSurface(MetricCardMicroVisualSurface.Inset)
+            .AddDetail("Ready", "84%")
+            .WithSize(260, 140);
+        var compactHeroSparkSvg = compactHeroSparkMetric.ToSvg("visual-block-metric-compact-hero-sparkline");
+        var compactSurface = System.Text.RegularExpressions.Regex.Match(compactHeroSparkSvg, "data-cfx-role=\"metric-micro-surface\"[^>]*y=\"([^\"]+)\"[^>]*height=\"([^\"]+)\"");
+        Assert(compactSurface.Success, "MetricCard compact hero inset sparklines should render a measurable inset surface.");
+        var compactSurfaceY = double.Parse(compactSurface.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+        var compactSurfaceHeight = double.Parse(compactSurface.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
+        Assert(compactSurfaceY + compactSurfaceHeight <= 140, "MetricCard compact hero inset surfaces should stay within the card bounds.");
+        Assert(!compactHeroSparkSvg.Contains("data-cfx-role=\"metric-detail\"", StringComparison.Ordinal), "MetricCard compact hero sparklines should skip detail pills when there is no non-overlapping space.");
+        Assert(compactHeroSparkMetric.ToPng().Length > 64, "MetricCard compact hero sparkline should render PNG output.");
+
+        var retainedSparklineStyleMetric = MetricCard.Create()
+            .WithMetric("Style", "1")
+            .WithMiniSparkline(new[] { 1d, 2d })
+            .WithMiniSparklineStyle(MetricCardSparklineStyle.Line)
+            .WithoutMiniSparkline()
+            .WithMiniSparkline(new[] { 2d, 4d });
+        Assert(retainedSparklineStyleMetric.ToSvg("visual-block-metric-retained-sparkline-style").Contains("data-cfx-style=\"line\"", StringComparison.Ordinal), "MetricCard should preserve configured sparkline style after clearing and replacing sparkline data.");
 
         var radialMetric = RadialMetricCard.Create()
             .WithMetric("Capacity left", "42%")
@@ -234,6 +288,16 @@ internal static partial class SmokeTests {
         Assert(dateStrip.ToHtmlFragment().Contains("chartforgex-visual-block", StringComparison.Ordinal), "DateStripBlock should render an embeddable HTML fragment.");
         Assert(dateStrip.ToPng().Length > 64, "DateStripBlock should render PNG output.");
 
+        var navOnlyDateStrip = DateStripBlock.Create()
+            .WithNavigation()
+            .WithTheme(ChartTheme.ReportLight())
+            .WithSize(620, 150)
+            .AddItem("S", "9", selected: true, color: ChartColor.FromHex("#0F83F7"))
+            .AddItem("M", "10");
+        var navOnlyDateStripSvg = navOnlyDateStrip.ToSvg("visual-block-date-strip-nav-only");
+        Assert(navOnlyDateStripSvg.Contains("data-cfx-role=\"date-strip-nav\"", StringComparison.Ordinal), "DateStripBlock navigation should render even when no header text is configured.");
+        Assert(navOnlyDateStrip.ToPng().Length > 64, "DateStripBlock navigation-only headers should render PNG output.");
+
         var entityStrip = EntityStripBlock.Create()
             .WithTitle("Duel with friends")
             .WithAction("New")
@@ -248,9 +312,19 @@ internal static partial class SmokeTests {
         Assert(entityStrip.ToHtmlFragment().Contains("chartforgex-visual-block", StringComparison.Ordinal), "EntityStripBlock should render an embeddable HTML fragment.");
         Assert(entityStrip.ToPng().Length > 64, "EntityStripBlock should render PNG output.");
 
+        var actionOnlyEntityStrip = EntityStripBlock.Create()
+            .WithAction("Open", url: "#friends")
+            .WithTheme(ChartTheme.ReportLight())
+            .WithSize(620, 150)
+            .AddItem("Karrem", color: ChartColor.FromHex("#0F83F7"))
+            .AddItem("Peter", avatarText: "P", color: ChartColor.FromHex("#FF7A1A"));
+        var actionOnlyEntityStripSvg = actionOnlyEntityStrip.ToSvg("visual-block-entity-strip-action-only");
+        Assert(actionOnlyEntityStripSvg.Contains("data-cfx-role=\"entity-strip-action-link\"", StringComparison.Ordinal) && actionOnlyEntityStripSvg.Contains("href=\"#friends\"", StringComparison.Ordinal), "EntityStripBlock should render linked actions even when no title is configured.");
+        Assert(actionOnlyEntityStrip.ToPng().Length > 64, "EntityStripBlock action-only headers should render PNG output.");
+
         var sectionHeader = SectionHeaderBlock.Create()
             .WithTitle("Today's Goals")
-            .WithAction("See all")
+            .WithAction("See all", url: "#goals")
             .WithTheme(ChartTheme.ReportLight())
             .WithSize(620, 48)
             .WithCard(false)
@@ -258,6 +332,7 @@ internal static partial class SmokeTests {
         var sectionHeaderSvg = sectionHeader.ToSvg("visual-block-section-header");
         Assert(sectionHeaderSvg.Contains("data-cfx-role=\"section-header-title\"", StringComparison.Ordinal), "SectionHeaderBlock should render a public title role.");
         Assert(sectionHeaderSvg.Contains("data-cfx-role=\"section-header-action\"", StringComparison.Ordinal), "SectionHeaderBlock should render optional trailing actions.");
+        Assert(sectionHeaderSvg.Contains("data-cfx-role=\"section-header-action-link\"", StringComparison.Ordinal) && sectionHeaderSvg.Contains("href=\"#goals\"", StringComparison.Ordinal), "SectionHeaderBlock should render safe linked actions in SVG/HTML outputs.");
         Assert(sectionHeader.ToPng().Length > 64, "SectionHeaderBlock should render PNG output.");
 
         var workload = WorkloadListBlock.Create()

--- a/ChartForgeX/VisualBlocks/DashboardStripBlocks.cs
+++ b/ChartForgeX/VisualBlocks/DashboardStripBlocks.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.VisualBlocks;
+
+/// <summary>
+/// A compact horizontal date or period selector strip for dashboards and report snapshots.
+/// </summary>
+public sealed class DateStripBlock : VisualBlock<DateStripBlock> {
+    private readonly List<DateStripItem> _items = new();
+    private string _header = string.Empty;
+    private string _previousSymbol = "<";
+    private string _nextSymbol = ">";
+
+    /// <summary>Gets date strip items.</summary>
+    public IReadOnlyList<DateStripItem> Items => _items;
+
+    /// <summary>Gets or sets the header text rendered above the strip.</summary>
+    public string Header { get => _header; set => _header = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets whether previous and next controls are rendered.</summary>
+    public bool ShowNavigation { get; set; }
+
+    /// <summary>Gets or sets the previous control symbol.</summary>
+    public string PreviousSymbol { get => _previousSymbol; set => _previousSymbol = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets the next control symbol.</summary>
+    public string NextSymbol { get => _nextSymbol; set => _nextSymbol = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Creates a new date strip block.</summary>
+    public static DateStripBlock Create() => new();
+
+    /// <summary>Sets the header text rendered above the strip.</summary>
+    public DateStripBlock WithHeader(string header) { Header = header ?? throw new ArgumentNullException(nameof(header)); return this; }
+
+    /// <summary>Sets whether previous and next controls are rendered.</summary>
+    public DateStripBlock WithNavigation(bool enabled = true) { ShowNavigation = enabled; return this; }
+
+    /// <summary>Sets previous and next control symbols.</summary>
+    public DateStripBlock WithNavigationSymbols(string previous, string next) {
+        PreviousSymbol = previous ?? throw new ArgumentNullException(nameof(previous));
+        NextSymbol = next ?? throw new ArgumentNullException(nameof(next));
+        return this;
+    }
+
+    /// <summary>Adds a date item.</summary>
+    public DateStripBlock AddItem(string label, string value, bool selected = false, ChartColor? color = null) {
+        _items.Add(new DateStripItem(label, value) { Selected = selected, Color = color });
+        return this;
+    }
+}
+
+/// <summary>
+/// Describes one item in a date strip.
+/// </summary>
+public sealed class DateStripItem {
+    private string _label;
+    private string _value;
+
+    /// <summary>Initializes a date strip item.</summary>
+    public DateStripItem(string label, string value) {
+        _label = label ?? throw new ArgumentNullException(nameof(label));
+        _value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>Gets or sets the upper label, such as a weekday initial.</summary>
+    public string Label { get => _label; set => _label = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets the lower value, such as a day number.</summary>
+    public string Value { get => _value; set => _value = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets whether the item is selected.</summary>
+    public bool Selected { get; set; }
+
+    /// <summary>Gets or sets an optional item accent color.</summary>
+    public ChartColor? Color { get; set; }
+}
+
+/// <summary>
+/// A compact horizontal entity strip for people, systems, teams, or owners.
+/// </summary>
+public sealed class EntityStripBlock : VisualBlock<EntityStripBlock> {
+    private readonly List<EntityStripItem> _items = new();
+    private string _actionLabel = string.Empty;
+    private string _actionSymbol = "+";
+    private string _actionUrl = string.Empty;
+
+    /// <summary>Gets entity strip items.</summary>
+    public IReadOnlyList<EntityStripItem> Items => _items;
+
+    /// <summary>Gets or sets optional action text.</summary>
+    public string ActionLabel { get => _actionLabel; set => _actionLabel = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets optional action symbol.</summary>
+    public string ActionSymbol { get => _actionSymbol; set => _actionSymbol = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets an optional URL for the action in SVG/HTML outputs.</summary>
+    public string ActionUrl { get => _actionUrl; set => _actionUrl = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Creates a new entity strip block.</summary>
+    public static EntityStripBlock Create() => new();
+
+    /// <summary>Adds one entity item.</summary>
+    public EntityStripBlock AddItem(string label, string? avatarText = null, ChartColor? color = null, VisualStatus status = VisualStatus.None) {
+        _items.Add(new EntityStripItem(label, avatarText) { Color = color, Status = status });
+        return this;
+    }
+
+    /// <summary>Sets optional action text rendered in the strip header.</summary>
+    public EntityStripBlock WithAction(string label, string? symbol = null, string? url = null) {
+        ActionLabel = label ?? throw new ArgumentNullException(nameof(label));
+        ActionSymbol = symbol ?? "+";
+        ActionUrl = url ?? string.Empty;
+        return this;
+    }
+}
+
+/// <summary>
+/// Describes one entity in an entity strip.
+/// </summary>
+public sealed class EntityStripItem {
+    private string _label;
+    private string _avatarText;
+    private VisualStatus _status;
+
+    /// <summary>Initializes an entity strip item.</summary>
+    public EntityStripItem(string label, string? avatarText = null) {
+        _label = label ?? throw new ArgumentNullException(nameof(label));
+        _avatarText = avatarText ?? string.Empty;
+    }
+
+    /// <summary>Gets or sets the entity label.</summary>
+    public string Label { get => _label; set => _label = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets optional avatar text.</summary>
+    public string AvatarText { get => _avatarText; set => _avatarText = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets an optional accent color.</summary>
+    public ChartColor? Color { get; set; }
+
+    /// <summary>Gets or sets an optional semantic status.</summary>
+    public VisualStatus Status {
+        get => _status;
+        set {
+            VisualBlockGuards.EnumDefined(value, nameof(value));
+            _status = value;
+        }
+    }
+}
+
+/// <summary>
+/// A compact dashboard section header for separating groups inside visual grids.
+/// </summary>
+public sealed class SectionHeaderBlock : VisualBlock<SectionHeaderBlock> {
+    private string _actionLabel = string.Empty;
+    private string _actionSymbol = string.Empty;
+    private string _actionUrl = string.Empty;
+
+    /// <summary>Gets or sets optional action text.</summary>
+    public string ActionLabel { get => _actionLabel; set => _actionLabel = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets optional action symbol.</summary>
+    public string ActionSymbol { get => _actionSymbol; set => _actionSymbol = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets an optional URL for the action in SVG/HTML outputs.</summary>
+    public string ActionUrl { get => _actionUrl; set => _actionUrl = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Creates a new section header block.</summary>
+    public static SectionHeaderBlock Create() => new();
+
+    /// <summary>Sets optional action text rendered on the trailing side.</summary>
+    public SectionHeaderBlock WithAction(string label, string? symbol = null, string? url = null) {
+        ActionLabel = label ?? throw new ArgumentNullException(nameof(label));
+        ActionSymbol = symbol ?? string.Empty;
+        ActionUrl = url ?? string.Empty;
+        return this;
+    }
+}

--- a/ChartForgeX/VisualBlocks/HtmlVisualGridRenderer.cs
+++ b/ChartForgeX/VisualBlocks/HtmlVisualGridRenderer.cs
@@ -120,7 +120,9 @@ public sealed class HtmlVisualGridRenderer {
         sb.Append(";--cfx-visual-grid-gap:").Append(grid.Gap.ToString(CultureInfo.InvariantCulture)).Append("px");
         sb.Append(";--cfx-visual-grid-padding:").Append(grid.Padding.ToString(CultureInfo.InvariantCulture)).Append("px");
         sb.Append(";--cfx-visual-grid-panel-width:").Append(layout.PanelWidth.ToString(CultureInfo.InvariantCulture)).Append("px");
-        sb.Append(";--cfx-visual-grid-panel-height:").Append(layout.PanelHeight.ToString(CultureInfo.InvariantCulture)).Append("px");
+        sb.Append(";--cfx-visual-grid-panel-height:");
+        if (!grid.PanelSize.HasValue && grid.AdaptiveRowHeights) sb.Append("auto");
+        else sb.Append(layout.PanelHeight.ToString(CultureInfo.InvariantCulture)).Append("px");
 
         return sb.ToString();
     }

--- a/ChartForgeX/VisualBlocks/MetricCard.cs
+++ b/ChartForgeX/VisualBlocks/MetricCard.cs
@@ -11,8 +11,10 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
     private readonly List<MetricCardDetail> _details = new();
     private readonly List<double> _miniBars = new();
     private readonly List<double> _miniSparkline = new();
+    private readonly List<double> _secondaryMiniSparkline = new();
     private string _label = string.Empty;
     private string _value = string.Empty;
+    private string _unit = string.Empty;
     private string _caption = string.Empty;
     private string _trend = string.Empty;
     private string _symbol = string.Empty;
@@ -27,12 +29,18 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
     private VisualIcon _icon;
     private VisualStatus _status;
     private MetricCardBadgePlacement _badgePlacement;
+    private MetricCardMicroVisualPlacement _microVisualPlacement;
+    private MetricCardSparklineStyle _miniSparklineStyle;
+    private MetricCardMicroVisualSurface _microVisualSurface;
 
     /// <summary>Gets compact bar values rendered inside the metric card.</summary>
     public IReadOnlyList<double> MiniBars => _miniBars;
 
     /// <summary>Gets compact sparkline values rendered inside the metric card.</summary>
     public IReadOnlyList<double> MiniSparkline => _miniSparkline;
+
+    /// <summary>Gets optional secondary sparkline values rendered beside the primary sparkline.</summary>
+    public IReadOnlyList<double> SecondaryMiniSparkline => _secondaryMiniSparkline;
 
     /// <summary>Gets compact supporting detail rows rendered inside the card.</summary>
     public IReadOnlyList<MetricCardDetail> Details => _details;
@@ -42,6 +50,9 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
 
     /// <summary>Gets or sets the metric value.</summary>
     public string Value { get => _value; set => _value = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets an optional metric unit rendered beside the value.</summary>
+    public string Unit { get => _unit; set => _unit = value ?? throw new ArgumentNullException(nameof(value)); }
 
     /// <summary>Gets or sets optional supporting text.</summary>
     public string Caption { get => _caption; set => _caption = value ?? throw new ArgumentNullException(nameof(value)); }
@@ -118,6 +129,18 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
     /// <summary>Gets or sets the optional fill color under the mini sparkline.</summary>
     public ChartColor? MiniSparklineFillColor { get; set; }
 
+    /// <summary>Gets or sets the optional stroke color for the secondary mini sparkline.</summary>
+    public ChartColor? SecondaryMiniSparklineColor { get; set; }
+
+    /// <summary>Gets or sets the mini sparkline presentation style.</summary>
+    public MetricCardSparklineStyle MiniSparklineStyle {
+        get => _miniSparklineStyle;
+        set {
+            VisualBlockGuards.EnumDefined(value, nameof(value));
+            _miniSparklineStyle = value;
+        }
+    }
+
     /// <summary>Gets or sets an optional built-in icon rendered as a badge.</summary>
     public VisualIcon Icon {
         get => _icon;
@@ -145,6 +168,24 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
         }
     }
 
+    /// <summary>Gets or sets where compact mini charts are rendered inside the metric card.</summary>
+    public MetricCardMicroVisualPlacement MicroVisualPlacement {
+        get => _microVisualPlacement;
+        set {
+            VisualBlockGuards.EnumDefined(value, nameof(value));
+            _microVisualPlacement = value;
+        }
+    }
+
+    /// <summary>Gets or sets the optional surface treatment for the mini visual.</summary>
+    public MetricCardMicroVisualSurface MicroVisualSurface {
+        get => _microVisualSurface;
+        set {
+            VisualBlockGuards.EnumDefined(value, nameof(value));
+            _microVisualSurface = value;
+        }
+    }
+
     /// <summary>Gets a concise accessibility label.</summary>
     public override string AccessibleName => Label.Length == 0 ? base.AccessibleName : Label;
 
@@ -152,11 +193,15 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
     public static MetricCard Create() => new();
 
     /// <summary>Sets the primary metric label and value.</summary>
-    public MetricCard WithMetric(string label, object? value, string? format = null) {
+    public MetricCard WithMetric(string label, object? value, string? format = null, string? unit = null) {
         Label = label ?? throw new ArgumentNullException(nameof(label));
         Value = ChartTableCell.FromValue(value, format).Text;
+        Unit = unit ?? string.Empty;
         return this;
     }
+
+    /// <summary>Sets an optional metric unit rendered beside the value.</summary>
+    public MetricCard WithUnit(string unit) { Unit = unit ?? throw new ArgumentNullException(nameof(unit)); return this; }
 
     /// <summary>Sets optional supporting text.</summary>
     public MetricCard WithCaption(string caption) { Caption = caption ?? throw new ArgumentNullException(nameof(caption)); return this; }
@@ -243,10 +288,13 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
     /// <summary>Clears compact sparkline values from the metric card.</summary>
     public MetricCard WithoutMiniSparkline() {
         _miniSparkline.Clear();
+        _secondaryMiniSparkline.Clear();
         MiniSparklineMinimum = null;
         MiniSparklineMaximum = null;
         MiniSparklineColor = null;
         MiniSparklineFillColor = null;
+        SecondaryMiniSparklineColor = null;
+        MiniSparklineStyle = MetricCardSparklineStyle.Area;
         return this;
     }
 
@@ -259,6 +307,38 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
     /// <summary>Sets the badge placement when an icon or symbol is configured.</summary>
     public MetricCard WithBadgePlacement(MetricCardBadgePlacement placement) {
         BadgePlacement = placement;
+        return this;
+    }
+
+    /// <summary>Sets where compact mini charts are rendered inside the metric card.</summary>
+    public MetricCard WithMicroVisualPlacement(MetricCardMicroVisualPlacement placement) {
+        MicroVisualPlacement = placement;
+        return this;
+    }
+
+    /// <summary>Sets the mini sparkline presentation style.</summary>
+    public MetricCard WithMiniSparklineStyle(MetricCardSparklineStyle style) {
+        MiniSparklineStyle = style;
+        return this;
+    }
+
+    /// <summary>Replaces optional secondary sparkline values rendered with the primary sparkline.</summary>
+    public MetricCard WithSecondaryMiniSparkline(IEnumerable<double> values, ChartColor? color = null) {
+        if (values == null) throw new ArgumentNullException(nameof(values));
+        _secondaryMiniSparkline.Clear();
+        foreach (var value in values) {
+            if (!IsFinite(value)) throw new ArgumentOutOfRangeException(nameof(values), value, "Secondary mini sparkline values must be finite.");
+            _secondaryMiniSparkline.Add(value);
+        }
+
+        if (_secondaryMiniSparkline.Count < 2) throw new ArgumentException("Metric card secondary mini sparklines require at least two values.", nameof(values));
+        SecondaryMiniSparklineColor = color;
+        return this;
+    }
+
+    /// <summary>Sets the optional surface treatment for compact mini visuals.</summary>
+    public MetricCard WithMicroVisualSurface(MetricCardMicroVisualSurface surface) {
+        MicroVisualSurface = surface;
         return this;
     }
 

--- a/ChartForgeX/VisualBlocks/MetricCard.cs
+++ b/ChartForgeX/VisualBlocks/MetricCard.cs
@@ -277,6 +277,7 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
         }
 
         if (_miniSparkline.Count < 2) throw new ArgumentException("Metric card mini sparklines require at least two values.", nameof(values));
+        if (_secondaryMiniSparkline.Count > 0 && _secondaryMiniSparkline.Count != _miniSparkline.Count) throw new InvalidOperationException("Metric card secondary mini sparklines must match the primary sparkline count.");
         MiniSparklineMinimum = minimum;
         MiniSparklineMaximum = maximum;
         MiniSparklineColor = color;
@@ -294,7 +295,6 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
         MiniSparklineColor = null;
         MiniSparklineFillColor = null;
         SecondaryMiniSparklineColor = null;
-        MiniSparklineStyle = MetricCardSparklineStyle.Area;
         return this;
     }
 
@@ -332,6 +332,7 @@ public sealed class MetricCard : VisualBlock<MetricCard> {
         }
 
         if (_secondaryMiniSparkline.Count < 2) throw new ArgumentException("Metric card secondary mini sparklines require at least two values.", nameof(values));
+        if (_miniSparkline.Count > 0 && _secondaryMiniSparkline.Count != _miniSparkline.Count) throw new InvalidOperationException("Metric card secondary mini sparklines must match the primary sparkline count.");
         SecondaryMiniSparklineColor = color;
         return this;
     }

--- a/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.Icons.cs
+++ b/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.Icons.cs
@@ -1,0 +1,87 @@
+using System;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Raster;
+
+namespace ChartForgeX.VisualBlocks;
+
+public sealed partial class PngVisualBlockRenderer {
+    private static void DrawIcon(RgbaCanvas canvas, VisualIcon icon, double x, double y, double size, ChartColor color) {
+        var stroke = Math.Max(1.6, size * 0.16);
+        if (icon == VisualIcon.ForkKnife) {
+            canvas.DrawLine(x - size * 0.42, y - size * 0.54, x - size * 0.42, y + size * 0.48, color, stroke);
+            canvas.DrawLine(x - size * 0.66, y - size * 0.56, x - size * 0.66, y - size * 0.12, color, stroke);
+            canvas.DrawLine(x - size * 0.42, y - size * 0.56, x - size * 0.42, y - size * 0.12, color, stroke);
+            canvas.DrawLine(x - size * 0.18, y - size * 0.56, x - size * 0.18, y - size * 0.12, color, stroke);
+            canvas.DrawLine(x + size * 0.34, y + size * 0.48, x + size * 0.34, y - size * 0.52, color, stroke);
+            canvas.DrawArc(x + size * 0.48, y - size * 0.22, size * 0.25, -Math.PI / 2, Math.PI / 2, color, stroke);
+            return;
+        }
+
+        if (icon == VisualIcon.Flame) {
+            canvas.FillPolygon(new[] {
+                new ChartPoint(x, y + size * 0.70),
+                new ChartPoint(x - size * 0.43, y + size * 0.36),
+                new ChartPoint(x - size * 0.48, y - size * 0.12),
+                new ChartPoint(x - size * 0.10, y - size * 0.78),
+                new ChartPoint(x + size * 0.10, y - size * 0.30),
+                new ChartPoint(x + size * 0.46, y - size * 0.72),
+                new ChartPoint(x + size * 0.56, y - size * 0.12),
+                new ChartPoint(x + size * 0.43, y + size * 0.36)
+            }, color);
+            return;
+        }
+
+        if (icon == VisualIcon.Droplet) {
+            canvas.FillPolygon(new[] {
+                new ChartPoint(x, y - size * 0.92),
+                new ChartPoint(x - size * 0.28, y - size * 0.56),
+                new ChartPoint(x - size * 0.52, y - size * 0.12),
+                new ChartPoint(x - size * 0.58, y + size * 0.24),
+                new ChartPoint(x - size * 0.45, y + size * 0.64),
+                new ChartPoint(x - size * 0.16, y + size * 0.90),
+                new ChartPoint(x, y + size * 0.98),
+                new ChartPoint(x + size * 0.16, y + size * 0.90),
+                new ChartPoint(x + size * 0.45, y + size * 0.64),
+                new ChartPoint(x + size * 0.58, y + size * 0.24),
+                new ChartPoint(x + size * 0.52, y - size * 0.12),
+                new ChartPoint(x + size * 0.28, y - size * 0.56)
+            }, color);
+            return;
+        }
+
+        if (icon == VisualIcon.Runner) {
+            canvas.DrawCircleOutline(x + size * 0.12, y - size * 0.70, size * 0.16, color, stroke);
+            canvas.DrawLine(x + size * 0.02, y - size * 0.42, x - size * 0.18, y - size * 0.02, color, stroke);
+            canvas.DrawLine(x - size * 0.18, y - size * 0.02, x + size * 0.10, y + size * 0.16, color, stroke);
+            canvas.DrawLine(x, y - size * 0.34, x + size * 0.40, y - size * 0.18, color, stroke);
+            canvas.DrawLine(x - size * 0.18, y - size * 0.02, x - size * 0.50, y + size * 0.36, color, stroke);
+            canvas.DrawLine(x + size * 0.10, y + size * 0.16, x + size * 0.48, y + size * 0.50, color, stroke);
+            return;
+        }
+
+        if (icon == VisualIcon.Bicycle) {
+            canvas.DrawCircleOutline(x - size * 0.50, y + size * 0.34, size * 0.28, color, stroke);
+            canvas.DrawCircleOutline(x + size * 0.50, y + size * 0.34, size * 0.28, color, stroke);
+            canvas.DrawLine(x - size * 0.50, y + size * 0.34, x - size * 0.12, y - size * 0.12, color, stroke);
+            canvas.DrawLine(x - size * 0.12, y - size * 0.12, x + size * 0.18, y + size * 0.34, color, stroke);
+            canvas.DrawLine(x + size * 0.18, y + size * 0.34, x - size * 0.50, y + size * 0.34, color, stroke);
+            canvas.DrawLine(x - size * 0.12, y - size * 0.12, x + size * 0.46, y - size * 0.12, color, stroke);
+            canvas.DrawLine(x + size * 0.46, y - size * 0.12, x + size * 0.50, y + size * 0.34, color, stroke);
+            canvas.DrawLine(x - size * 0.02, y - size * 0.28, x - size * 0.24, y - size * 0.28, color, stroke);
+            return;
+        }
+
+        if (icon == VisualIcon.Person) {
+            canvas.DrawCircle(x, y - size * 0.36, size * 0.28, color);
+            canvas.FillRoundedRect(x - size * 0.58, y + size * 0.18, size * 1.16, size * 0.55, size * 0.26, color);
+            return;
+        }
+
+        canvas.DrawLine(x - size * 0.52, y - size * 0.32, x + size * 0.10, y - size * 0.92, color, stroke);
+        canvas.DrawLine(x + size * 0.10, y - size * 0.92, x, y - size * 0.26, color, stroke);
+        canvas.DrawLine(x, y - size * 0.26, x + size * 0.58, y - size * 0.08, color, stroke);
+        canvas.DrawLine(x + size * 0.58, y - size * 0.08, x - size * 0.20, y + size * 0.82, color, stroke);
+        canvas.DrawLine(x - size * 0.20, y + size * 0.82, x - size * 0.04, y + size * 0.08, color, stroke);
+    }
+}

--- a/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.MetricValue.cs
+++ b/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.MetricValue.cs
@@ -1,0 +1,60 @@
+using System;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Raster;
+using ChartForgeX.Rendering;
+
+namespace ChartForgeX.VisualBlocks;
+
+public sealed partial class PngVisualBlockRenderer {
+    private static void DrawMetricValueSurface(RgbaCanvas canvas, MetricCard card, ChartRect content, double detailBottom, double labelSize, double valueSize, double valueWidth, ChartColor statusColor) {
+        var theme = card.Options.Theme;
+        var y = content.Y + labelSize + 18;
+        var height = Math.Max(54, detailBottom - y - 4);
+        var radius = Math.Min(20, Math.Max(14, theme.PlotCornerRadius + 7));
+        canvas.FillRoundedRectVerticalGradient(content.X, y, content.Width, height, radius, ChartSurfacePolish.GradientTop(theme.PlotBackground), ChartSurfacePolish.GradientBottom(theme.CardBackground));
+        canvas.StrokeRoundedRect(content.X, y, content.Width, height, radius, theme.PlotBorder.WithAlpha(140), 1);
+        var badgeColor = card.Status == VisualStatus.None ? VisualBlockRendering.PaletteAt(theme, 0) : statusColor;
+        var hasBadge = card.Icon != VisualIcon.None || card.Symbol.Length > 0;
+        var valueX = content.X + 22;
+        if (hasBadge) {
+            var badgeRadius = Math.Min(24, Math.Max(17, height * 0.30));
+            var cx = content.X + 28 + badgeRadius;
+            var cy = y + height / 2;
+            canvas.DrawCircle(cx, cy, badgeRadius, badgeColor.WithAlpha(36));
+            canvas.DrawCircleOutline(cx, cy, badgeRadius, theme.PlotBorder.WithAlpha(155), 1);
+            if (card.Icon != VisualIcon.None) DrawIcon(canvas, card.Icon, cx, cy, badgeRadius * 0.62, badgeColor);
+            else {
+                var symbolMaxWidth = badgeRadius * 1.62;
+                var symbolSize = MetricSymbolFontSize(card.Symbol, Math.Max(10, badgeRadius * 0.46), symbolMaxWidth);
+                DrawCenteredTextMiddle(canvas, card.Symbol, cx, cy, symbolSize, ChartColorMath.TextOnBackground(badgeColor), true, symbolMaxWidth);
+            }
+
+            valueX = cx + badgeRadius + 24;
+        }
+
+        DrawMetricValueText(canvas, card, valueX, y + (height - valueSize) * 0.52, valueSize, valueWidth, theme.Text, theme.MutedText);
+    }
+
+    private static void DrawMetricValueText(RgbaCanvas canvas, MetricCard card, double x, double y, double valueSize, double maxWidth, ChartColor valueColor, ChartColor unitColor) {
+        var unitSize = MetricUnitFontSize(valueSize);
+        var gap = card.Unit.Length == 0 ? 0 : Math.Max(6, valueSize * 0.14);
+        var unitWidth = card.Unit.Length == 0 ? 0 : RgbaCanvas.MeasureTextWidth(card.Unit, unitSize, null);
+        var valueWidth = Math.Max(1, maxWidth - unitWidth - gap);
+        var fittedValue = FitText(card.Value, valueSize, valueWidth);
+        canvas.DrawTextEmphasized(x, y, fittedValue, valueColor, valueSize);
+        if (card.Unit.Length == 0) return;
+        var valueTextWidth = RgbaCanvas.MeasureTextEmphasizedWidth(fittedValue, valueSize, null);
+        canvas.DrawText(x + valueTextWidth + gap, y + valueSize * 0.42, FitText(card.Unit, unitSize, unitWidth), unitColor, unitSize);
+    }
+
+    private static double MetricValueFontSize(MetricCard card, double requestedSize, double maxWidth) {
+        var unitSize = MetricUnitFontSize(requestedSize);
+        var measuredWidth = RgbaCanvas.MeasureTextEmphasizedWidth(card.Value, requestedSize, null);
+        if (card.Unit.Length > 0) measuredWidth += Math.Max(6, requestedSize * 0.14) + RgbaCanvas.MeasureTextWidth(card.Unit, unitSize, null);
+        if (measuredWidth <= maxWidth) return requestedSize;
+        return Math.Max(22, Math.Floor(requestedSize * maxWidth / Math.Max(1, measuredWidth)));
+    }
+
+    private static double MetricUnitFontSize(double valueSize) => Math.Max(13, Math.Min(24, valueSize * 0.42));
+}

--- a/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.MetricValue.cs
+++ b/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.MetricValue.cs
@@ -10,7 +10,7 @@ public sealed partial class PngVisualBlockRenderer {
     private static void DrawMetricValueSurface(RgbaCanvas canvas, MetricCard card, ChartRect content, double detailBottom, double labelSize, double valueSize, double valueWidth, ChartColor statusColor) {
         var theme = card.Options.Theme;
         var y = content.Y + labelSize + 18;
-        var height = Math.Max(54, detailBottom - y - 4);
+        var height = Math.Max(1, detailBottom - y - 4);
         var radius = Math.Min(20, Math.Max(14, theme.PlotCornerRadius + 7));
         canvas.FillRoundedRectVerticalGradient(content.X, y, content.Width, height, radius, ChartSurfacePolish.GradientTop(theme.PlotBackground), ChartSurfacePolish.GradientBottom(theme.CardBackground));
         canvas.StrokeRoundedRect(content.X, y, content.Width, height, radius, theme.PlotBorder.WithAlpha(140), 1);
@@ -33,18 +33,20 @@ public sealed partial class PngVisualBlockRenderer {
             valueX = cx + badgeRadius + 24;
         }
 
-        DrawMetricValueText(canvas, card, valueX, y + (height - valueSize) * 0.52, valueSize, valueWidth, theme.Text, theme.MutedText);
+        var surfaceValueWidth = Math.Max(1, Math.Min(valueWidth, content.X + content.Width - valueX - 22));
+        DrawMetricValueText(canvas, card, valueX, y + (height - valueSize) * 0.52, valueSize, surfaceValueWidth, theme.Text, theme.MutedText);
     }
 
     private static void DrawMetricValueText(RgbaCanvas canvas, MetricCard card, double x, double y, double valueSize, double maxWidth, ChartColor valueColor, ChartColor unitColor) {
         var unitSize = MetricUnitFontSize(valueSize);
         var gap = card.Unit.Length == 0 ? 0 : Math.Max(6, valueSize * 0.14);
-        var unitWidth = card.Unit.Length == 0 ? 0 : RgbaCanvas.MeasureTextWidth(card.Unit, unitSize, null);
-        var valueWidth = Math.Max(1, maxWidth - unitWidth - gap);
+        var desiredUnitWidth = card.Unit.Length == 0 ? 0 : RgbaCanvas.MeasureTextWidth(card.Unit, unitSize, null);
+        var valueWidth = Math.Max(1, maxWidth - desiredUnitWidth - gap);
         var fittedValue = FitText(card.Value, valueSize, valueWidth);
         canvas.DrawTextEmphasized(x, y, fittedValue, valueColor, valueSize);
         if (card.Unit.Length == 0) return;
         var valueTextWidth = RgbaCanvas.MeasureTextEmphasizedWidth(fittedValue, valueSize, null);
+        var unitWidth = Math.Max(1, maxWidth - valueTextWidth - gap);
         canvas.DrawText(x + valueTextWidth + gap, y + valueSize * 0.42, FitText(card.Unit, unitSize, unitWidth), unitColor, unitSize);
     }
 

--- a/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.Strips.cs
+++ b/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.Strips.cs
@@ -14,13 +14,16 @@ public sealed partial class PngVisualBlockRenderer {
         var y = content.Y;
         DrawHeading(canvas, block, ref y, content.X, content.Width);
         var navReserve = block.ShowNavigation ? 72.0 : 0;
-        if (block.Header.Length > 0) {
-            canvas.FillRoundedRect(content.X, y + 3, 22, 22, 6, theme.Text.WithAlpha(24));
-            canvas.StrokeRoundedRect(content.X, y + 3, 22, 22, 6, theme.Text.WithAlpha(85));
-            canvas.DrawLine(content.X + 5, y + 9, content.X + 17, y + 9, theme.Text, 1.4);
-            canvas.DrawCircle(content.X + 8, y + 15, 1.5, theme.Text);
-            canvas.DrawCircle(content.X + 14, y + 15, 1.5, theme.Text);
-            DrawAlignedText(canvas, block.Header, content.X + 32, y + 7, Math.Max(1, content.Width - 32 - navReserve), VisualTextAlignment.Left, theme.Text, Math.Max(13, theme.SubtitleFontSize + 1), true);
+        if (block.Header.Length > 0 || block.ShowNavigation) {
+            if (block.Header.Length > 0) {
+                canvas.FillRoundedRect(content.X, y + 3, 22, 22, 6, theme.Text.WithAlpha(24));
+                canvas.StrokeRoundedRect(content.X, y + 3, 22, 22, 6, theme.Text.WithAlpha(85));
+                canvas.DrawLine(content.X + 5, y + 9, content.X + 17, y + 9, theme.Text, 1.4);
+                canvas.DrawCircle(content.X + 8, y + 15, 1.5, theme.Text);
+                canvas.DrawCircle(content.X + 14, y + 15, 1.5, theme.Text);
+                DrawAlignedText(canvas, block.Header, content.X + 32, y + 7, Math.Max(1, content.Width - 32 - navReserve), VisualTextAlignment.Left, theme.Text, Math.Max(13, theme.SubtitleFontSize + 1), true);
+            }
+
             if (block.ShowNavigation) {
                 DrawDateNavButton(canvas, block.PreviousSymbol, content.X + content.Width - 66, y + 2, 28, theme, muted: true);
                 DrawDateNavButton(canvas, block.NextSymbol, content.X + content.Width - 30, y + 2, 28, theme, muted: false);
@@ -67,9 +70,9 @@ public sealed partial class PngVisualBlockRenderer {
         var content = VisualBlockRendering.ContentRect(options);
         var y = content.Y;
         var actionWidth = block.ActionLabel.Length == 0 ? 0 : Math.Min(120, RgbaCanvas.MeasureTextEmphasizedWidth(block.ActionSymbol + " " + block.ActionLabel, theme.SubtitleFontSize + 1, null) + 12);
-        if (block.Title.Length > 0) {
+        if (block.Title.Length > 0 || block.ActionLabel.Length > 0) {
             var titleSize = Math.Max(14, Math.Min(theme.TitleFontSize, theme.SubtitleFontSize + 8));
-            DrawAlignedText(canvas, block.Title, content.X, y, Math.Max(1, content.Width - actionWidth - 10), VisualTextAlignment.Left, theme.Text, titleSize, true);
+            if (block.Title.Length > 0) DrawAlignedText(canvas, block.Title, content.X, y, Math.Max(1, content.Width - actionWidth - 10), VisualTextAlignment.Left, theme.Text, titleSize, true);
             if (block.ActionLabel.Length > 0) DrawAlignedText(canvas, block.ActionSymbol + " " + block.ActionLabel, content.X + content.Width - actionWidth, y + 1, actionWidth, VisualTextAlignment.Right, VisualBlockRendering.PaletteAt(theme, 0), Math.Max(12, theme.SubtitleFontSize + 1), true);
             y += titleSize + 14;
         }

--- a/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.Strips.cs
+++ b/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.Strips.cs
@@ -1,0 +1,111 @@
+using System;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Raster;
+using ChartForgeX.Rendering;
+
+namespace ChartForgeX.VisualBlocks;
+
+public sealed partial class PngVisualBlockRenderer {
+    private static void DrawDateStrip(RgbaCanvas canvas, DateStripBlock block) {
+        var options = block.Options;
+        var theme = options.Theme;
+        var content = VisualBlockRendering.ContentRect(options);
+        var y = content.Y;
+        DrawHeading(canvas, block, ref y, content.X, content.Width);
+        var navReserve = block.ShowNavigation ? 72.0 : 0;
+        if (block.Header.Length > 0) {
+            canvas.FillRoundedRect(content.X, y + 3, 22, 22, 6, theme.Text.WithAlpha(24));
+            canvas.StrokeRoundedRect(content.X, y + 3, 22, 22, 6, theme.Text.WithAlpha(85));
+            canvas.DrawLine(content.X + 5, y + 9, content.X + 17, y + 9, theme.Text, 1.4);
+            canvas.DrawCircle(content.X + 8, y + 15, 1.5, theme.Text);
+            canvas.DrawCircle(content.X + 14, y + 15, 1.5, theme.Text);
+            DrawAlignedText(canvas, block.Header, content.X + 32, y + 7, Math.Max(1, content.Width - 32 - navReserve), VisualTextAlignment.Left, theme.Text, Math.Max(13, theme.SubtitleFontSize + 1), true);
+            if (block.ShowNavigation) {
+                DrawDateNavButton(canvas, block.PreviousSymbol, content.X + content.Width - 66, y + 2, 28, theme, muted: true);
+                DrawDateNavButton(canvas, block.NextSymbol, content.X + content.Width - 30, y + 2, 28, theme, muted: false);
+            }
+
+            y += 36;
+        }
+
+        var stripHeight = Math.Max(50, options.Size.Height - options.Padding.Bottom - y);
+        canvas.FillRoundedRect(content.X, y, content.Width, stripHeight, Math.Min(18, Math.Max(8, theme.PlotCornerRadius + 6)), theme.PlotBackground.WithAlpha(150));
+        canvas.StrokeRoundedRect(content.X, y, content.Width, stripHeight, Math.Min(18, Math.Max(8, theme.PlotCornerRadius + 6)), theme.PlotBorder.WithAlpha(130), 1);
+        var innerX = content.X + 12;
+        var innerY = y + 10;
+        var innerWidth = Math.Max(1, content.Width - 24);
+        var innerHeight = Math.Max(1, stripHeight - 20);
+        var cellWidth = innerWidth / block.Items.Count;
+        var pillWidth = Math.Min(54, Math.Max(42, cellWidth * 0.68));
+        for (var i = 0; i < block.Items.Count; i++) {
+            var item = block.Items[i];
+            var cellX = innerX + i * cellWidth;
+            var x = cellX + (cellWidth - pillWidth) / 2;
+            var accent = item.Color ?? VisualBlockRendering.PaletteAt(theme, 0);
+            var textColor = theme.Text;
+            var valueTextColor = item.Selected ? ChartColorMath.TextOnBackground(accent) : theme.Text;
+            var itemRadius = Math.Min(24, pillWidth * 0.48);
+            canvas.FillRoundedRect(x, innerY, pillWidth, innerHeight, itemRadius, item.Selected ? theme.CardBackground.WithAlpha(230) : theme.CardBackground.WithAlpha(160));
+            canvas.StrokeRoundedRect(x, innerY, pillWidth, innerHeight, itemRadius, item.Selected ? theme.CardBorder.WithAlpha(95) : theme.CardBorder.WithAlpha(70), 1);
+            DrawAlignedText(canvas, item.Label, x, innerY + 7, pillWidth, VisualTextAlignment.Center, item.Selected ? textColor : theme.MutedText, Math.Max(10, theme.SubtitleFontSize - 1), true);
+            canvas.DrawCircle(x + pillWidth / 2, innerY + innerHeight - 18, 17, item.Selected ? accent : theme.Background.WithAlpha(170));
+            canvas.DrawCircleOutline(x + pillWidth / 2, innerY + innerHeight - 18, 17, item.Selected ? ChartColor.White.WithAlpha(130) : theme.CardBorder.WithAlpha(70), 1);
+            DrawAlignedText(canvas, item.Value, x, innerY + innerHeight - 24, pillWidth, VisualTextAlignment.Center, valueTextColor, Math.Max(11, theme.SubtitleFontSize), true);
+        }
+    }
+
+    private static void DrawDateNavButton(RgbaCanvas canvas, string symbol, double x, double y, double size, ChartForgeX.Themes.ChartTheme theme, bool muted) {
+        canvas.DrawCircle(x + size / 2, y + size / 2, size / 2, muted ? ChartColor.White.WithAlpha(150) : ChartColor.White);
+        canvas.DrawCircleOutline(x + size / 2, y + size / 2, size / 2, theme.CardBorder.WithAlpha(90), 1);
+        DrawAlignedText(canvas, symbol, x, y + 6, size, VisualTextAlignment.Center, muted ? theme.MutedText : theme.Text, 15, true);
+    }
+
+    private static void DrawEntityStrip(RgbaCanvas canvas, EntityStripBlock block) {
+        var options = block.Options;
+        var theme = options.Theme;
+        var content = VisualBlockRendering.ContentRect(options);
+        var y = content.Y;
+        var actionWidth = block.ActionLabel.Length == 0 ? 0 : Math.Min(120, RgbaCanvas.MeasureTextEmphasizedWidth(block.ActionSymbol + " " + block.ActionLabel, theme.SubtitleFontSize + 1, null) + 12);
+        if (block.Title.Length > 0) {
+            var titleSize = Math.Max(14, Math.Min(theme.TitleFontSize, theme.SubtitleFontSize + 8));
+            DrawAlignedText(canvas, block.Title, content.X, y, Math.Max(1, content.Width - actionWidth - 10), VisualTextAlignment.Left, theme.Text, titleSize, true);
+            if (block.ActionLabel.Length > 0) DrawAlignedText(canvas, block.ActionSymbol + " " + block.ActionLabel, content.X + content.Width - actionWidth, y + 1, actionWidth, VisualTextAlignment.Right, VisualBlockRendering.PaletteAt(theme, 0), Math.Max(12, theme.SubtitleFontSize + 1), true);
+            y += titleSize + 14;
+        }
+
+        if (block.Subtitle.Length > 0) {
+            DrawAlignedText(canvas, block.Subtitle, content.X, y, content.Width, VisualTextAlignment.Left, theme.MutedText, theme.SubtitleFontSize, false);
+            y += theme.SubtitleFontSize + 12;
+        }
+
+        var stripHeight = Math.Max(56, options.Size.Height - options.Padding.Bottom - y);
+        canvas.FillRoundedRect(content.X, y, content.Width, stripHeight, Math.Min(18, Math.Max(8, theme.PlotCornerRadius + 6)), theme.PlotBackground.WithAlpha(150));
+        canvas.StrokeRoundedRect(content.X, y, content.Width, stripHeight, Math.Min(18, Math.Max(8, theme.PlotCornerRadius + 6)), theme.PlotBorder.WithAlpha(130), 1);
+        var cellWidth = Math.Max(1, (content.Width - 20) / block.Items.Count);
+        var avatarRadius = Math.Min(22, Math.Max(16, cellWidth * 0.18));
+        var startX = content.X + 10;
+        for (var i = 0; i < block.Items.Count; i++) {
+            var item = block.Items[i];
+            var x = startX + i * cellWidth;
+            var centerX = x + cellWidth / 2;
+            var color = item.Color ?? (item.Status == VisualStatus.None ? VisualBlockRendering.PaletteAt(theme, i) : VisualBlockRendering.StatusColor(theme, item.Status));
+            canvas.DrawCircle(centerX, y + 28, avatarRadius, color.WithAlpha(45));
+            canvas.DrawCircleOutline(centerX, y + 28, avatarRadius, color.WithAlpha(115), 1);
+            if (item.AvatarText.Length > 0) DrawAlignedText(canvas, item.AvatarText, centerX - avatarRadius, y + 28 - Math.Max(9, theme.SubtitleFontSize - 2) * 0.45, avatarRadius * 2, VisualTextAlignment.Center, color, Math.Max(9, theme.SubtitleFontSize - 2), true);
+            else DrawIcon(canvas, VisualIcon.Person, centerX, y + 28, avatarRadius * 0.56, color);
+            DrawAlignedText(canvas, item.Label, x, y + stripHeight - 24, cellWidth, VisualTextAlignment.Center, theme.Text, Math.Max(10, theme.SubtitleFontSize), false);
+        }
+    }
+
+    private static void DrawSectionHeader(RgbaCanvas canvas, SectionHeaderBlock block) {
+        var theme = block.Options.Theme;
+        var content = VisualBlockRendering.ContentRect(block.Options);
+        var titleSize = Math.Max(16, Math.Min(theme.TitleFontSize, theme.SubtitleFontSize + 10));
+        var actionText = block.ActionLabel.Length == 0 ? string.Empty : (block.ActionSymbol.Length == 0 ? block.ActionLabel : block.ActionSymbol + " " + block.ActionLabel);
+        var actionWidth = actionText.Length == 0 ? 0 : Math.Min(150, RgbaCanvas.MeasureTextEmphasizedWidth(actionText, Math.Max(12, theme.SubtitleFontSize + 1), null) + 12);
+        var y = content.Y + (content.Height - titleSize) * 0.48;
+        DrawAlignedText(canvas, block.Title, content.X, y, Math.Max(1, content.Width - actionWidth - 12), VisualTextAlignment.Left, theme.Text, titleSize, true);
+        if (actionText.Length > 0) DrawAlignedText(canvas, actionText, content.X + content.Width - actionWidth, y + 1, actionWidth, VisualTextAlignment.Right, VisualBlockRendering.PaletteAt(theme, 0), Math.Max(12, theme.SubtitleFontSize + 1), true);
+    }
+}

--- a/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.cs
+++ b/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.cs
@@ -35,6 +35,9 @@ public sealed partial class PngVisualBlockRenderer {
         else if (block is CompositionStatusCard compositionCard) DrawCompositionStatus(canvas, compositionCard);
         else if (block is DistributionStripCard distributionCard) DrawDistributionStripCard(canvas, distributionCard);
         else if (block is HeatmapInsightCard heatmapCard) DrawHeatmapInsightCard(canvas, heatmapCard);
+        else if (block is DateStripBlock dateStrip) DrawDateStrip(canvas, dateStrip);
+        else if (block is EntityStripBlock entityStrip) DrawEntityStrip(canvas, entityStrip);
+        else if (block is SectionHeaderBlock sectionHeader) DrawSectionHeader(canvas, sectionHeader);
         else if (block is WorkloadListBlock workloadBlock) DrawWorkloadList(canvas, workloadBlock);
         else if (block is ActivityTimelineBlock activityBlock) DrawActivityTimeline(canvas, activityBlock);
         else if (block is ScheduleTimelineBlock scheduleBlock) DrawScheduleTimeline(canvas, scheduleBlock);
@@ -132,6 +135,9 @@ public sealed partial class PngVisualBlockRenderer {
         var footerHeight = hasAction ? Math.Min(46, Math.Max(36, options.Size.Height * 0.24)) : 0;
         var footerY = options.Size.Height - footerHeight;
         var detailBottom = hasAction ? footerY - 12 : options.Size.Height - options.Padding.Bottom;
+        var hasMicroVisual = card.MiniBars.Count > 0 || card.MiniSparkline.Count > 0;
+        var heroMicroVisual = hasMicroVisual && card.MicroVisualPlacement == MetricCardMicroVisualPlacement.Hero;
+        var valueInsetSurface = !hasMicroVisual && card.MicroVisualSurface == MetricCardMicroVisualSurface.Inset;
         var labelX = content.X;
         var labelWidth = content.Width;
         var valueYOffset = 0.0;
@@ -143,7 +149,7 @@ public sealed partial class PngVisualBlockRenderer {
             else canvas.FillRect(0, 0, ChartVisualPrimitives.MetricStatusBarWidth, options.Size.Height, statusColor);
         }
 
-        if (card.Icon != VisualIcon.None || card.Symbol.Length > 0) {
+        if (!valueInsetSurface && (card.Icon != VisualIcon.None || card.Symbol.Length > 0)) {
             var badgeColor = card.Status == VisualStatus.None ? VisualBlockRendering.PaletteAt(theme, 0) : statusColor;
             var badgeRadius = Math.Min(24, Math.Max(15, options.Size.Height * 0.11));
             var leftBadge = card.BadgePlacement == MetricCardBadgePlacement.TopLeft;
@@ -167,15 +173,32 @@ public sealed partial class PngVisualBlockRenderer {
 
         var labelSize = Math.Max(11, theme.SubtitleFontSize);
         var baseValueSize = Math.Min(54, Math.Max(26, options.Size.Height * 0.22));
-        var hasMicroVisual = card.MiniBars.Count > 0 || card.MiniSparkline.Count > 0;
-        var microWidth = hasMicroVisual ? Math.Min(112, Math.Max(58, content.Width * 0.32)) : 0;
-        var microHeight = Math.Min(56, Math.Max(34, options.Size.Height * 0.24));
+        var microWidth = hasMicroVisual ? heroMicroVisual ? Math.Max(92, content.Width - 48) : Math.Min(112, Math.Max(58, content.Width * 0.32)) : 0;
+        var microHeight = heroMicroVisual ? Math.Min(66, Math.Max(50, options.Size.Height * 0.30)) : Math.Min(56, Math.Max(34, options.Size.Height * 0.24));
         var valueWidth = hasMicroVisual ? Math.Max(1, content.Width - microWidth - 18) : content.Width;
-        var valueSize = MetricValueFontSize(card.Value, baseValueSize, valueWidth);
+        if (heroMicroVisual) valueWidth = content.Width;
+        if (valueInsetSurface && (card.Icon != VisualIcon.None || card.Symbol.Length > 0)) valueWidth = Math.Max(1, content.Width - 106);
+        var valueSize = MetricValueFontSize(card, baseValueSize, valueWidth);
         canvas.DrawTextEmphasized(labelX, content.Y, FitText(card.Label, labelSize, labelWidth), theme.MutedText, labelSize);
-        canvas.DrawTextEmphasized(content.X, content.Y + labelSize + 18 + valueYOffset, FitText(card.Value, valueSize, valueWidth), theme.Text, valueSize);
-        if (card.MiniSparkline.Count > 0) DrawMetricMiniSparkline(canvas, card, content.X + content.Width - microWidth, content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset, microWidth, microHeight);
-        else if (card.MiniBars.Count > 0) DrawMetricMiniBars(canvas, card, content.X + content.Width - microWidth, content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset, microWidth, microHeight);
+        if (valueInsetSurface) DrawMetricValueSurface(canvas, card, content, detailBottom, labelSize, valueSize, valueWidth, statusColor);
+        else DrawMetricValueText(canvas, card, content.X, content.Y + labelSize + 18 + valueYOffset, valueSize, valueWidth, theme.Text, theme.MutedText);
+        var microX = heroMicroVisual ? content.X + 24 : content.X + content.Width - microWidth;
+        var microY = heroMicroVisual ? content.Y + Math.Max(66, options.Size.Height * 0.36) : content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset;
+        if (heroMicroVisual && card.MicroVisualSurface == MetricCardMicroVisualSurface.Inset) {
+            var surfaceX = content.X;
+            var surfaceY = microY - 18;
+            var surfaceWidth = content.Width;
+            var surfaceHeight = Math.Max(88, detailBottom - surfaceY - 24);
+            canvas.FillRoundedRectVerticalGradient(surfaceX, surfaceY, surfaceWidth, surfaceHeight, Math.Min(18, theme.PlotCornerRadius + 6), ChartSurfacePolish.GradientTop(theme.PlotBackground.WithAlpha(170)), ChartSurfacePolish.GradientBottom(theme.PlotBackground.WithAlpha(170)));
+            canvas.StrokeRoundedRect(surfaceX, surfaceY, surfaceWidth, surfaceHeight, Math.Min(18, theme.PlotCornerRadius + 6), theme.PlotBorder.WithAlpha(125), 1);
+            microX = surfaceX + 28;
+            microY = surfaceY + 32;
+            microWidth = Math.Max(1, surfaceWidth - 56);
+            microHeight = Math.Max(34, surfaceHeight - 58);
+        }
+
+        if (card.MiniSparkline.Count > 0) DrawMetricMiniSparkline(canvas, card, microX, microY, microWidth, microHeight);
+        else if (card.MiniBars.Count > 0) DrawMetricMiniBars(canvas, card, microX, microY, microWidth, microHeight);
         var detailsTop = content.Y + labelSize + valueSize + 24 + valueYOffset;
         DrawMetricDetails(canvas, card, content, detailsTop, detailBottom);
         DrawMetricDetail(canvas, card, detailBottom, content.X, content.Width);
@@ -213,12 +236,6 @@ public sealed partial class PngVisualBlockRenderer {
         }
     }
 
-    private static double MetricValueFontSize(string value, double requestedSize, double maxWidth) {
-        var measuredWidth = RgbaCanvas.MeasureTextEmphasizedWidth(value, requestedSize, null);
-        if (measuredWidth <= maxWidth) return requestedSize;
-        return Math.Max(22, Math.Floor(requestedSize * maxWidth / Math.Max(1, measuredWidth)));
-    }
-
     private static double MetricSymbolFontSize(string value, double requestedSize, double maxWidth) {
         var fontSize = requestedSize;
         while (fontSize > 7.5 && RgbaCanvas.MeasureTextEmphasizedWidth(value, fontSize, null) > maxWidth) fontSize -= 0.5;
@@ -227,8 +244,16 @@ public sealed partial class PngVisualBlockRenderer {
 
     private static void DrawMetricMiniSparkline(RgbaCanvas canvas, MetricCard card, double x, double y, double width, double height) {
         var sparkline = VisualBlockRendering.CreateMiniSparkline(card, x, y, width, height);
-        canvas.FillPolygon(sparkline.Area, sparkline.FillColor);
-        for (var i = 1; i < sparkline.Points.Length; i++) canvas.DrawLine(sparkline.Points[i - 1].X, sparkline.Points[i - 1].Y, sparkline.Points[i].X, sparkline.Points[i].Y, sparkline.LineColor, sparkline.StrokeWidth);
+        var points = card.MiniSparklineStyle == MetricCardSparklineStyle.Line ? VisualBlockRendering.SmoothMiniSparklinePoints(sparkline) : sparkline.Points;
+        if (card.MiniSparklineStyle == MetricCardSparklineStyle.Area) canvas.FillPolygon(sparkline.Area, sparkline.FillColor);
+        else if (card.SecondaryMiniSparkline.Count > 0) {
+            var secondary = VisualBlockRendering.CreateSecondaryMiniSparkline(card, x, y + 6, width, height);
+            var secondaryPoints = VisualBlockRendering.SmoothMiniSparklinePoints(secondary);
+            for (var i = 1; i < secondaryPoints.Count; i++) canvas.DrawLine(secondaryPoints[i - 1].X, secondaryPoints[i - 1].Y, secondaryPoints[i].X, secondaryPoints[i].Y, secondary.LineColor, Math.Max(1.8, secondary.StrokeWidth * 0.72));
+        }
+
+        for (var i = 1; i < points.Count; i++) canvas.DrawLine(points[i - 1].X, points[i - 1].Y, points[i].X, points[i].Y, sparkline.LineColor, sparkline.StrokeWidth);
+        if (card.MiniSparklineStyle == MetricCardSparklineStyle.Line) canvas.DrawCircle(sparkline.Points[0].X, sparkline.Points[0].Y, sparkline.CurrentRadius * 0.82, sparkline.LineColor);
         canvas.DrawCircle(sparkline.Current.X, sparkline.Current.Y, sparkline.CurrentRadius, sparkline.LineColor);
     }
 
@@ -658,35 +683,6 @@ public sealed partial class PngVisualBlockRenderer {
             var angle = start + (end - start) * i / (layer.SeparatorCount + 1);
             canvas.DrawLine(cx + Math.Cos(angle) * inner, cy + Math.Sin(angle) * inner, cx + Math.Cos(angle) * outer, cy + Math.Sin(angle) * outer, separator, layer.SeparatorStrokeWidth);
         }
-    }
-
-    private static void DrawIcon(RgbaCanvas canvas, VisualIcon icon, double x, double y, double size, ChartColor color) {
-        var stroke = Math.Max(1.6, size * 0.16);
-        if (icon == VisualIcon.ForkKnife) {
-            canvas.DrawLine(x - size * 0.42, y - size * 0.54, x - size * 0.42, y + size * 0.48, color, stroke);
-            canvas.DrawLine(x - size * 0.66, y - size * 0.56, x - size * 0.66, y - size * 0.12, color, stroke);
-            canvas.DrawLine(x - size * 0.42, y - size * 0.56, x - size * 0.42, y - size * 0.12, color, stroke);
-            canvas.DrawLine(x - size * 0.18, y - size * 0.56, x - size * 0.18, y - size * 0.12, color, stroke);
-            canvas.DrawLine(x + size * 0.34, y + size * 0.48, x + size * 0.34, y - size * 0.52, color, stroke);
-            canvas.DrawArc(x + size * 0.48, y - size * 0.22, size * 0.25, -Math.PI / 2, Math.PI / 2, color, stroke);
-            return;
-        }
-
-        if (icon == VisualIcon.Flame) {
-            canvas.DrawLine(x, y + size * 0.62, x - size * 0.42, y + size * 0.10, color, stroke);
-            canvas.DrawLine(x - size * 0.42, y + size * 0.10, x - size * 0.08, y - size * 0.82, color, stroke);
-            canvas.DrawLine(x - size * 0.08, y - size * 0.82, x + size * 0.22, y - size * 0.22, color, stroke);
-            canvas.DrawLine(x + size * 0.22, y - size * 0.22, x + size * 0.54, y - size * 0.78, color, stroke);
-            canvas.DrawLine(x + size * 0.54, y - size * 0.78, x + size * 0.72, y + size * 0.18, color, stroke);
-            canvas.DrawLine(x + size * 0.72, y + size * 0.18, x, y + size * 0.62, color, stroke);
-            return;
-        }
-
-        canvas.DrawLine(x - size * 0.52, y - size * 0.32, x + size * 0.10, y - size * 0.92, color, stroke);
-        canvas.DrawLine(x + size * 0.10, y - size * 0.92, x, y - size * 0.26, color, stroke);
-        canvas.DrawLine(x, y - size * 0.26, x + size * 0.58, y - size * 0.08, color, stroke);
-        canvas.DrawLine(x + size * 0.58, y - size * 0.08, x - size * 0.20, y + size * 0.82, color, stroke);
-        canvas.DrawLine(x - size * 0.20, y + size * 0.82, x - size * 0.04, y + size * 0.08, color, stroke);
     }
 
     private static void DrawCenteredText(RgbaCanvas canvas, string text, double x, double y, double size, ChartColor color, bool emphasized, double? maxWidth = null) {

--- a/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.cs
+++ b/ChartForgeX/VisualBlocks/PngVisualBlockRenderer.cs
@@ -188,18 +188,19 @@ public sealed partial class PngVisualBlockRenderer {
             var surfaceX = content.X;
             var surfaceY = microY - 18;
             var surfaceWidth = content.Width;
-            var surfaceHeight = Math.Max(88, detailBottom - surfaceY - 24);
+            var availableSurfaceHeight = Math.Max(1, detailBottom - surfaceY - 4);
+            var surfaceHeight = Math.Min(Math.Max(88, detailBottom - surfaceY - 24), availableSurfaceHeight);
             canvas.FillRoundedRectVerticalGradient(surfaceX, surfaceY, surfaceWidth, surfaceHeight, Math.Min(18, theme.PlotCornerRadius + 6), ChartSurfacePolish.GradientTop(theme.PlotBackground.WithAlpha(170)), ChartSurfacePolish.GradientBottom(theme.PlotBackground.WithAlpha(170)));
             canvas.StrokeRoundedRect(surfaceX, surfaceY, surfaceWidth, surfaceHeight, Math.Min(18, theme.PlotCornerRadius + 6), theme.PlotBorder.WithAlpha(125), 1);
             microX = surfaceX + 28;
-            microY = surfaceY + 32;
+            microY = surfaceY + Math.Min(32, Math.Max(10, surfaceHeight * 0.36));
             microWidth = Math.Max(1, surfaceWidth - 56);
-            microHeight = Math.Max(34, surfaceHeight - 58);
+            microHeight = Math.Max(1, surfaceHeight - (microY - surfaceY) - 18);
         }
 
         if (card.MiniSparkline.Count > 0) DrawMetricMiniSparkline(canvas, card, microX, microY, microWidth, microHeight);
         else if (card.MiniBars.Count > 0) DrawMetricMiniBars(canvas, card, microX, microY, microWidth, microHeight);
-        var detailsTop = content.Y + labelSize + valueSize + 24 + valueYOffset;
+        var detailsTop = heroMicroVisual ? microY + microHeight + 10 : content.Y + labelSize + valueSize + 24 + valueYOffset;
         DrawMetricDetails(canvas, card, content, detailsTop, detailBottom);
         DrawMetricDetail(canvas, card, detailBottom, content.X, content.Width);
         if (hasAction) DrawMetricAction(canvas, card, footerY, footerHeight, content.X, content.Width);
@@ -247,7 +248,7 @@ public sealed partial class PngVisualBlockRenderer {
         var points = card.MiniSparklineStyle == MetricCardSparklineStyle.Line ? VisualBlockRendering.SmoothMiniSparklinePoints(sparkline) : sparkline.Points;
         if (card.MiniSparklineStyle == MetricCardSparklineStyle.Area) canvas.FillPolygon(sparkline.Area, sparkline.FillColor);
         else if (card.SecondaryMiniSparkline.Count > 0) {
-            var secondary = VisualBlockRendering.CreateSecondaryMiniSparkline(card, x, y + 6, width, height);
+            var secondary = VisualBlockRendering.CreateSecondaryMiniSparkline(card, x, y, width, height);
             var secondaryPoints = VisualBlockRendering.SmoothMiniSparklinePoints(secondary);
             for (var i = 1; i < secondaryPoints.Count; i++) canvas.DrawLine(secondaryPoints[i - 1].X, secondaryPoints[i - 1].Y, secondaryPoints[i].X, secondaryPoints[i].Y, secondary.LineColor, Math.Max(1.8, secondary.StrokeWidth * 0.72));
         }

--- a/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.Icons.cs
+++ b/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.Icons.cs
@@ -1,0 +1,80 @@
+using System;
+using ChartForgeX.Primitives;
+using ChartForgeX.Svg;
+
+namespace ChartForgeX.VisualBlocks;
+
+public sealed partial class SvgVisualBlockRenderer {
+    private static void WriteIcon(SvgMarkupWriter writer, VisualIcon icon, double x, double y, double size, ChartColor color) {
+        var stroke = Math.Max(1.6, size * 0.16);
+        if (icon == VisualIcon.ForkKnife) {
+            writer.StartElement("path")
+                .Attribute("data-cfx-role", "visual-icon")
+                .Attribute("data-cfx-icon", "fork-knife")
+                .Attribute("d", "M " + F(x - size * 0.42) + " " + F(y - size * 0.54) + " V " + F(y + size * 0.48) + " M " + F(x - size * 0.66) + " " + F(y - size * 0.56) + " V " + F(y - size * 0.12) + " M " + F(x - size * 0.42) + " " + F(y - size * 0.56) + " V " + F(y - size * 0.12) + " M " + F(x - size * 0.18) + " " + F(y - size * 0.56) + " V " + F(y - size * 0.12) + " M " + F(x - size * 0.66) + " " + F(y - size * 0.12) + " Q " + F(x - size * 0.42) + " " + F(y + size * 0.18) + " " + F(x - size * 0.18) + " " + F(y - size * 0.12) + " M " + F(x + size * 0.34) + " " + F(y + size * 0.48) + " V " + F(y - size * 0.52) + " Q " + F(x + size * 0.70) + " " + F(y - size * 0.24) + " " + F(x + size * 0.40) + " " + F(y + size * 0.04))
+                .Attribute("fill", "none")
+                .Attribute("stroke", color.ToCss())
+                .Attribute("stroke-width", stroke)
+                .Attribute("stroke-linecap", "round")
+                .Attribute("stroke-linejoin", "round")
+                .EndEmptyElement().Line();
+            return;
+        }
+
+        if (icon == VisualIcon.Flame) {
+            writer.StartElement("path")
+                .Attribute("data-cfx-role", "visual-icon")
+                .Attribute("data-cfx-icon", "flame")
+                .Attribute("d", "M " + F(x) + " " + F(y + size * 0.62) + " C " + F(x - size * 0.70) + " " + F(y + size * 0.24) + " " + F(x - size * 0.38) + " " + F(y - size * 0.46) + " " + F(x - size * 0.08) + " " + F(y - size * 0.82) + " C " + F(x + size * 0.04) + " " + F(y - size * 0.30) + " " + F(x + size * 0.52) + " " + F(y - size * 0.24) + " " + F(x + size * 0.38) + " " + F(y - size * 0.88) + " C " + F(x + size * 0.98) + " " + F(y - size * 0.30) + " " + F(x + size * 0.82) + " " + F(y + size * 0.48) + " " + F(x) + " " + F(y + size * 0.62) + " Z")
+                .Attribute("fill", color.ToCss())
+                .EndEmptyElement().Line();
+            return;
+        }
+
+        if (icon == VisualIcon.Droplet) {
+            writer.StartElement("path")
+                .Attribute("data-cfx-role", "visual-icon")
+                .Attribute("data-cfx-icon", "droplet")
+                .Attribute("d", "M " + F(x) + " " + F(y - size * 0.84) + " C " + F(x - size * 0.48) + " " + F(y - size * 0.22) + " " + F(x - size * 0.64) + " " + F(y + size * 0.10) + " " + F(x - size * 0.64) + " " + F(y + size * 0.32) + " C " + F(x - size * 0.64) + " " + F(y + size * 0.78) + " " + F(x - size * 0.30) + " " + F(y + size * 0.98) + " " + F(x) + " " + F(y + size * 0.98) + " C " + F(x + size * 0.30) + " " + F(y + size * 0.98) + " " + F(x + size * 0.64) + " " + F(y + size * 0.78) + " " + F(x + size * 0.64) + " " + F(y + size * 0.32) + " C " + F(x + size * 0.64) + " " + F(y + size * 0.10) + " " + F(x + size * 0.48) + " " + F(y - size * 0.22) + " " + F(x) + " " + F(y - size * 0.84) + " Z")
+                .Attribute("fill", color.ToCss())
+                .EndEmptyElement().Line();
+            return;
+        }
+
+        if (icon == VisualIcon.Runner) {
+            writer.StartElement("g").Attribute("data-cfx-role", "visual-icon").Attribute("data-cfx-icon", "runner").EndStartElement()
+                .StartElement("circle").Attribute("cx", x + size * 0.12).Attribute("cy", y - size * 0.70).Attribute("r", size * 0.16).Attribute("fill", "none").Attribute("stroke", color.ToCss()).Attribute("stroke-width", stroke).EndEmptyElement()
+                .StartElement("path").Attribute("d", "M " + F(x + size * 0.02) + " " + F(y - size * 0.42) + " L " + F(x - size * 0.18) + " " + F(y - size * 0.02) + " L " + F(x + size * 0.10) + " " + F(y + size * 0.16) + " M " + F(x) + " " + F(y - size * 0.34) + " L " + F(x + size * 0.40) + " " + F(y - size * 0.18) + " M " + F(x - size * 0.18) + " " + F(y - size * 0.02) + " L " + F(x - size * 0.50) + " " + F(y + size * 0.36) + " M " + F(x + size * 0.10) + " " + F(y + size * 0.16) + " L " + F(x + size * 0.48) + " " + F(y + size * 0.50)).Attribute("fill", "none").Attribute("stroke", color.ToCss()).Attribute("stroke-width", stroke).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement()
+                .EndElement().Line();
+            return;
+        }
+
+        if (icon == VisualIcon.Bicycle) {
+            writer.StartElement("g").Attribute("data-cfx-role", "visual-icon").Attribute("data-cfx-icon", "bicycle").EndStartElement()
+                .StartElement("circle").Attribute("cx", x - size * 0.50).Attribute("cy", y + size * 0.34).Attribute("r", size * 0.28).Attribute("fill", "none").Attribute("stroke", color.ToCss()).Attribute("stroke-width", stroke).EndEmptyElement()
+                .StartElement("circle").Attribute("cx", x + size * 0.50).Attribute("cy", y + size * 0.34).Attribute("r", size * 0.28).Attribute("fill", "none").Attribute("stroke", color.ToCss()).Attribute("stroke-width", stroke).EndEmptyElement()
+                .StartElement("path").Attribute("d", "M " + F(x - size * 0.50) + " " + F(y + size * 0.34) + " L " + F(x - size * 0.12) + " " + F(y - size * 0.12) + " L " + F(x + size * 0.18) + " " + F(y + size * 0.34) + " L " + F(x - size * 0.50) + " " + F(y + size * 0.34) + " M " + F(x - size * 0.12) + " " + F(y - size * 0.12) + " L " + F(x + size * 0.46) + " " + F(y - size * 0.12) + " L " + F(x + size * 0.50) + " " + F(y + size * 0.34) + " M " + F(x - size * 0.02) + " " + F(y - size * 0.28) + " L " + F(x - size * 0.24) + " " + F(y - size * 0.28)).Attribute("fill", "none").Attribute("stroke", color.ToCss()).Attribute("stroke-width", stroke).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement()
+                .EndElement().Line();
+            return;
+        }
+
+        if (icon == VisualIcon.Person) {
+            writer.StartElement("g").Attribute("data-cfx-role", "visual-icon").Attribute("data-cfx-icon", "person").EndStartElement()
+                .StartElement("circle").Attribute("cx", x).Attribute("cy", y - size * 0.36).Attribute("r", size * 0.28).Attribute("fill", color.ToCss()).EndEmptyElement()
+                .StartElement("path").Attribute("d", "M " + F(x - size * 0.60) + " " + F(y + size * 0.62) + " C " + F(x - size * 0.46) + " " + F(y + size * 0.12) + " " + F(x + size * 0.46) + " " + F(y + size * 0.12) + " " + F(x + size * 0.60) + " " + F(y + size * 0.62) + " Z").Attribute("fill", color.ToCss()).EndEmptyElement()
+                .EndElement().Line();
+            return;
+        }
+
+        writer.StartElement("path")
+            .Attribute("data-cfx-role", "visual-icon")
+            .Attribute("data-cfx-icon", "lightning")
+            .Attribute("d", "M " + F(x - size * 0.52) + " " + F(y - size * 0.32) + " L " + F(x + size * 0.10) + " " + F(y - size * 0.92) + " L " + F(x) + " " + F(y - size * 0.26) + " L " + F(x + size * 0.58) + " " + F(y - size * 0.08) + " L " + F(x - size * 0.20) + " " + F(y + size * 0.82) + " L " + F(x - size * 0.04) + " " + F(y + size * 0.08) + " Z")
+            .Attribute("fill", "none")
+            .Attribute("stroke", color.ToCss())
+            .Attribute("stroke-width", stroke)
+            .Attribute("stroke-linecap", "round")
+            .Attribute("stroke-linejoin", "round")
+            .EndEmptyElement().Line();
+    }
+}

--- a/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.MetricValue.cs
+++ b/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.MetricValue.cs
@@ -10,7 +10,7 @@ public sealed partial class SvgVisualBlockRenderer {
     private static void RenderMetricValueSurface(SvgMarkupWriter writer, MetricCard card, ChartRect content, double detailBottom, double labelSize, double valueSize, double valueWidth, ChartColor statusColor) {
         var theme = card.Options.Theme;
         var y = content.Y + labelSize + 18;
-        var height = Math.Max(54, detailBottom - y - 4);
+        var height = Math.Max(1, detailBottom - y - 4);
         var radius = Math.Min(20, Math.Max(14, theme.PlotCornerRadius + 7));
         writer.StartElement("rect").Attribute("data-cfx-role", "metric-value-surface").Attribute("x", content.X).Attribute("y", y).Attribute("width", content.Width).Attribute("height", height).Attribute("rx", radius).Attribute("fill", theme.PlotBackground.ToCss()).Attribute("stroke", theme.PlotBorder.WithAlpha(140).ToCss()).EndEmptyElement().Line();
         var badgeColor = card.Status == VisualStatus.None ? VisualBlockRendering.PaletteAt(theme, 0) : statusColor;
@@ -28,18 +28,20 @@ public sealed partial class SvgVisualBlockRenderer {
             valueX = cx + badgeRadius + 24;
         }
 
-        RenderMetricValueText(writer, card, valueX, y + height * 0.5 + valueSize * 0.34, valueSize, valueWidth, theme.Text, theme.MutedText);
+        var surfaceValueWidth = Math.Max(1, Math.Min(valueWidth, content.X + content.Width - valueX - 22));
+        RenderMetricValueText(writer, card, valueX, y + height * 0.5 + valueSize * 0.34, valueSize, surfaceValueWidth, theme.Text, theme.MutedText);
     }
 
     private static void RenderMetricValueText(SvgMarkupWriter writer, MetricCard card, double x, double y, double valueSize, double maxWidth, ChartColor valueColor, ChartColor unitColor) {
         var unitSize = MetricUnitFontSize(valueSize);
         var gap = card.Unit.Length == 0 ? 0 : Math.Max(6, valueSize * 0.14);
-        var unitWidth = card.Unit.Length == 0 ? 0 : VisualBlockRendering.EstimateTextWidth(card.Unit, unitSize);
-        var valueWidth = Math.Max(1, maxWidth - unitWidth - gap);
+        var desiredUnitWidth = card.Unit.Length == 0 ? 0 : VisualBlockRendering.EstimateTextWidth(card.Unit, unitSize);
+        var valueWidth = Math.Max(1, maxWidth - desiredUnitWidth - gap);
         var fittedValue = VisualBlockRendering.FitText(card.Value, valueSize, valueWidth);
         writer.StartElement("text").Attribute("data-cfx-role", "metric-value").Attribute("x", x).Attribute("y", y).Attribute("fill", valueColor.ToCss()).Attribute("font-family", card.Options.Theme.FontFamily).Attribute("font-size", valueSize).Attribute("font-weight", "850").Text(fittedValue).EndElement().Line();
         if (card.Unit.Length == 0) return;
         var valueTextWidth = VisualBlockRendering.EstimateTextWidth(fittedValue, valueSize);
+        var unitWidth = Math.Max(1, maxWidth - valueTextWidth - gap);
         writer.StartElement("text").Attribute("data-cfx-role", "metric-unit").Attribute("x", x + valueTextWidth + gap).Attribute("y", y).Attribute("fill", unitColor.ToCss()).Attribute("font-family", card.Options.Theme.FontFamily).Attribute("font-size", unitSize).Attribute("font-weight", "650").Text(VisualBlockRendering.FitText(card.Unit, unitSize, unitWidth)).EndElement().Line();
     }
 

--- a/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.MetricValue.cs
+++ b/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.MetricValue.cs
@@ -1,0 +1,55 @@
+using System;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Rendering;
+using ChartForgeX.Svg;
+
+namespace ChartForgeX.VisualBlocks;
+
+public sealed partial class SvgVisualBlockRenderer {
+    private static void RenderMetricValueSurface(SvgMarkupWriter writer, MetricCard card, ChartRect content, double detailBottom, double labelSize, double valueSize, double valueWidth, ChartColor statusColor) {
+        var theme = card.Options.Theme;
+        var y = content.Y + labelSize + 18;
+        var height = Math.Max(54, detailBottom - y - 4);
+        var radius = Math.Min(20, Math.Max(14, theme.PlotCornerRadius + 7));
+        writer.StartElement("rect").Attribute("data-cfx-role", "metric-value-surface").Attribute("x", content.X).Attribute("y", y).Attribute("width", content.Width).Attribute("height", height).Attribute("rx", radius).Attribute("fill", theme.PlotBackground.ToCss()).Attribute("stroke", theme.PlotBorder.WithAlpha(140).ToCss()).EndEmptyElement().Line();
+        var badgeColor = card.Status == VisualStatus.None ? VisualBlockRendering.PaletteAt(theme, 0) : statusColor;
+        var hasBadge = card.Icon != VisualIcon.None || card.Symbol.Length > 0;
+        var valueX = content.X + 22;
+        if (hasBadge) {
+            var badgeRadius = Math.Min(24, Math.Max(17, height * 0.30));
+            var cx = content.X + 28 + badgeRadius;
+            var cy = y + height / 2;
+            var symbolMaxWidth = badgeRadius * 1.62;
+            var symbolSize = VisualBlockRendering.FitFontSize(card.Symbol, symbolMaxWidth, Math.Max(10, badgeRadius * 0.46), 7.5);
+            writer.StartElement("circle").Attribute("data-cfx-role", "metric-value-surface-badge").Attribute("cx", cx).Attribute("cy", cy).Attribute("r", badgeRadius).Attribute("fill", badgeColor.WithAlpha(36).ToCss()).Attribute("stroke", theme.PlotBorder.WithAlpha(155).ToCss()).EndEmptyElement().Line();
+            if (card.Icon != VisualIcon.None) WriteIcon(writer, card.Icon, cx, cy, badgeRadius * 0.62, badgeColor);
+            else writer.StartElement("text").Attribute("data-cfx-role", "metric-symbol").Attribute("x", cx).Attribute("y", cy).Attribute("text-anchor", "middle").Attribute("dominant-baseline", "central").Attribute("alignment-baseline", "central").Attribute("fill", ChartColorMath.TextOnBackground(badgeColor).ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", symbolSize).Attribute("font-weight", "850").Text(VisualBlockRendering.FitText(card.Symbol, symbolSize, symbolMaxWidth)).EndElement().Line();
+            valueX = cx + badgeRadius + 24;
+        }
+
+        RenderMetricValueText(writer, card, valueX, y + height * 0.5 + valueSize * 0.34, valueSize, valueWidth, theme.Text, theme.MutedText);
+    }
+
+    private static void RenderMetricValueText(SvgMarkupWriter writer, MetricCard card, double x, double y, double valueSize, double maxWidth, ChartColor valueColor, ChartColor unitColor) {
+        var unitSize = MetricUnitFontSize(valueSize);
+        var gap = card.Unit.Length == 0 ? 0 : Math.Max(6, valueSize * 0.14);
+        var unitWidth = card.Unit.Length == 0 ? 0 : VisualBlockRendering.EstimateTextWidth(card.Unit, unitSize);
+        var valueWidth = Math.Max(1, maxWidth - unitWidth - gap);
+        var fittedValue = VisualBlockRendering.FitText(card.Value, valueSize, valueWidth);
+        writer.StartElement("text").Attribute("data-cfx-role", "metric-value").Attribute("x", x).Attribute("y", y).Attribute("fill", valueColor.ToCss()).Attribute("font-family", card.Options.Theme.FontFamily).Attribute("font-size", valueSize).Attribute("font-weight", "850").Text(fittedValue).EndElement().Line();
+        if (card.Unit.Length == 0) return;
+        var valueTextWidth = VisualBlockRendering.EstimateTextWidth(fittedValue, valueSize);
+        writer.StartElement("text").Attribute("data-cfx-role", "metric-unit").Attribute("x", x + valueTextWidth + gap).Attribute("y", y).Attribute("fill", unitColor.ToCss()).Attribute("font-family", card.Options.Theme.FontFamily).Attribute("font-size", unitSize).Attribute("font-weight", "650").Text(VisualBlockRendering.FitText(card.Unit, unitSize, unitWidth)).EndElement().Line();
+    }
+
+    private static double MetricValueFontSize(MetricCard card, double requestedSize, double maxWidth) {
+        var unitSize = MetricUnitFontSize(requestedSize);
+        var estimatedWidth = VisualBlockRendering.EstimateTextWidth(card.Value, requestedSize);
+        if (card.Unit.Length > 0) estimatedWidth += Math.Max(6, requestedSize * 0.14) + VisualBlockRendering.EstimateTextWidth(card.Unit, unitSize);
+        if (estimatedWidth <= maxWidth) return requestedSize;
+        return Math.Max(22, Math.Floor(requestedSize * maxWidth / Math.Max(1, estimatedWidth)));
+    }
+
+    private static double MetricUnitFontSize(double valueSize) => Math.Max(13, Math.Min(24, valueSize * 0.42));
+}

--- a/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.Strips.cs
+++ b/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.Strips.cs
@@ -13,15 +13,18 @@ public sealed partial class SvgVisualBlockRenderer {
         var content = VisualBlockRendering.ContentRect(options);
         var y = content.Y;
         RenderBlockHeading(writer, block, ref y, content.X, content.Width);
-        var headerHeight = block.Header.Length > 0 ? 36.0 : 0;
+        var headerHeight = block.Header.Length > 0 || block.ShowNavigation ? 36.0 : 0;
         var navReserve = block.ShowNavigation ? 72.0 : 0;
-        if (block.Header.Length > 0) {
+        if (block.Header.Length > 0 || block.ShowNavigation) {
             writer.StartElement("g").Attribute("data-cfx-role", "date-strip-header").EndStartElement().Line();
-            writer.StartElement("rect").Attribute("data-cfx-role", "date-strip-calendar-badge").Attribute("x", content.X).Attribute("y", y + 3).Attribute("width", 22).Attribute("height", 22).Attribute("rx", 6).Attribute("fill", theme.Text.WithAlpha(24).ToCss()).Attribute("stroke", theme.Text.WithAlpha(85).ToCss()).EndEmptyElement().Line();
-            writer.StartElement("line").Attribute("x1", content.X + 5).Attribute("y1", y + 9).Attribute("x2", content.X + 17).Attribute("y2", y + 9).Attribute("stroke", theme.Text.ToCss()).Attribute("stroke-width", 1.4).EndEmptyElement().Line();
-            writer.StartElement("circle").Attribute("cx", content.X + 8).Attribute("cy", y + 15).Attribute("r", 1.5).Attribute("fill", theme.Text.ToCss()).EndEmptyElement().Line();
-            writer.StartElement("circle").Attribute("cx", content.X + 14).Attribute("cy", y + 15).Attribute("r", 1.5).Attribute("fill", theme.Text.ToCss()).EndEmptyElement().Line();
-            WriteText(writer, block.Header, content.X + 32, y + 22, Math.Max(1, content.Width - 32 - navReserve), VisualTextAlignment.Left, theme.Text, theme.FontFamily, Math.Max(13, theme.SubtitleFontSize + 1), "750");
+            if (block.Header.Length > 0) {
+                writer.StartElement("rect").Attribute("data-cfx-role", "date-strip-calendar-badge").Attribute("x", content.X).Attribute("y", y + 3).Attribute("width", 22).Attribute("height", 22).Attribute("rx", 6).Attribute("fill", theme.Text.WithAlpha(24).ToCss()).Attribute("stroke", theme.Text.WithAlpha(85).ToCss()).EndEmptyElement().Line();
+                writer.StartElement("line").Attribute("x1", content.X + 5).Attribute("y1", y + 9).Attribute("x2", content.X + 17).Attribute("y2", y + 9).Attribute("stroke", theme.Text.ToCss()).Attribute("stroke-width", 1.4).EndEmptyElement().Line();
+                writer.StartElement("circle").Attribute("cx", content.X + 8).Attribute("cy", y + 15).Attribute("r", 1.5).Attribute("fill", theme.Text.ToCss()).EndEmptyElement().Line();
+                writer.StartElement("circle").Attribute("cx", content.X + 14).Attribute("cy", y + 15).Attribute("r", 1.5).Attribute("fill", theme.Text.ToCss()).EndEmptyElement().Line();
+                WriteText(writer, block.Header, content.X + 32, y + 22, Math.Max(1, content.Width - 32 - navReserve), VisualTextAlignment.Left, theme.Text, theme.FontFamily, Math.Max(13, theme.SubtitleFontSize + 1), "750");
+            }
+
             if (block.ShowNavigation) {
                 var navY = y + 2;
                 RenderDateNavButton(writer, block.PreviousSymbol, content.X + content.Width - 66, navY, 28, theme, muted: true);
@@ -73,10 +76,15 @@ public sealed partial class SvgVisualBlockRenderer {
         var content = VisualBlockRendering.ContentRect(options);
         var y = content.Y;
         var actionWidth = block.ActionLabel.Length == 0 ? 0 : Math.Min(120, VisualBlockRendering.EstimateTextWidth(block.ActionSymbol + " " + block.ActionLabel, theme.SubtitleFontSize + 1) + 12);
-        if (block.Title.Length > 0) {
+        if (block.Title.Length > 0 || block.ActionLabel.Length > 0) {
             var titleSize = Math.Max(14, Math.Min(theme.TitleFontSize, theme.SubtitleFontSize + 8));
-            WriteText(writer, block.Title, content.X, y + titleSize * 0.75, Math.Max(1, content.Width - actionWidth - 10), VisualTextAlignment.Left, theme.Text, theme.FontFamily, titleSize, "800");
-            if (block.ActionLabel.Length > 0) WriteText(writer, block.ActionSymbol + " " + block.ActionLabel, content.X + content.Width - actionWidth, y + titleSize * 0.75, actionWidth, VisualTextAlignment.Right, VisualBlockRendering.PaletteAt(theme, 0), theme.FontFamily, Math.Max(12, theme.SubtitleFontSize + 1), "750");
+            if (block.Title.Length > 0) WriteText(writer, block.Title, content.X, y + titleSize * 0.75, Math.Max(1, content.Width - actionWidth - 10), VisualTextAlignment.Left, theme.Text, theme.FontFamily, titleSize, "800");
+            if (block.ActionLabel.Length > 0) {
+                if (block.ActionUrl.Length > 0) writer.StartElement("a").Attribute("data-cfx-role", "entity-strip-action-link").Attribute("href", block.ActionUrl).Attribute("target", "_top").EndStartElement().Line();
+                WriteText(writer, block.ActionSymbol + " " + block.ActionLabel, content.X + content.Width - actionWidth, y + titleSize * 0.75, actionWidth, VisualTextAlignment.Right, VisualBlockRendering.PaletteAt(theme, 0), theme.FontFamily, Math.Max(12, theme.SubtitleFontSize + 1), "750");
+                if (block.ActionUrl.Length > 0) writer.EndElement().Line();
+            }
+
             y += titleSize + 14;
         }
 
@@ -115,6 +123,10 @@ public sealed partial class SvgVisualBlockRenderer {
         var actionWidth = actionText.Length == 0 ? 0 : Math.Min(150, VisualBlockRendering.EstimateTextWidth(actionText, Math.Max(12, theme.SubtitleFontSize + 1)) + 12);
         var baseline = content.Y + content.Height * 0.60;
         writer.StartElement("text").Attribute("data-cfx-role", "section-header-title").Attribute("x", content.X).Attribute("y", baseline).Attribute("fill", theme.Text.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", titleSize).Attribute("font-weight", "800").Text(VisualBlockRendering.FitText(block.Title, titleSize, Math.Max(1, content.Width - actionWidth - 12))).EndElement().Line();
-        if (actionText.Length > 0) writer.StartElement("text").Attribute("data-cfx-role", "section-header-action").Attribute("x", content.X + content.Width).Attribute("y", baseline).Attribute("text-anchor", "end").Attribute("fill", VisualBlockRendering.PaletteAt(theme, 0).ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", Math.Max(12, theme.SubtitleFontSize + 1)).Attribute("font-weight", "750").Text(VisualBlockRendering.FitText(actionText, Math.Max(12, theme.SubtitleFontSize + 1), actionWidth)).EndElement().Line();
+        if (actionText.Length > 0) {
+            if (block.ActionUrl.Length > 0) writer.StartElement("a").Attribute("data-cfx-role", "section-header-action-link").Attribute("href", block.ActionUrl).Attribute("target", "_top").EndStartElement().Line();
+            writer.StartElement("text").Attribute("data-cfx-role", "section-header-action").Attribute("x", content.X + content.Width).Attribute("y", baseline).Attribute("text-anchor", "end").Attribute("fill", VisualBlockRendering.PaletteAt(theme, 0).ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", Math.Max(12, theme.SubtitleFontSize + 1)).Attribute("font-weight", "750").Text(VisualBlockRendering.FitText(actionText, Math.Max(12, theme.SubtitleFontSize + 1), actionWidth)).EndElement().Line();
+            if (block.ActionUrl.Length > 0) writer.EndElement().Line();
+        }
     }
 }

--- a/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.Strips.cs
+++ b/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.Strips.cs
@@ -1,0 +1,120 @@
+using System;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Rendering;
+using ChartForgeX.Svg;
+
+namespace ChartForgeX.VisualBlocks;
+
+public sealed partial class SvgVisualBlockRenderer {
+    private static void RenderDateStrip(SvgMarkupWriter writer, DateStripBlock block) {
+        var options = block.Options;
+        var theme = options.Theme;
+        var content = VisualBlockRendering.ContentRect(options);
+        var y = content.Y;
+        RenderBlockHeading(writer, block, ref y, content.X, content.Width);
+        var headerHeight = block.Header.Length > 0 ? 36.0 : 0;
+        var navReserve = block.ShowNavigation ? 72.0 : 0;
+        if (block.Header.Length > 0) {
+            writer.StartElement("g").Attribute("data-cfx-role", "date-strip-header").EndStartElement().Line();
+            writer.StartElement("rect").Attribute("data-cfx-role", "date-strip-calendar-badge").Attribute("x", content.X).Attribute("y", y + 3).Attribute("width", 22).Attribute("height", 22).Attribute("rx", 6).Attribute("fill", theme.Text.WithAlpha(24).ToCss()).Attribute("stroke", theme.Text.WithAlpha(85).ToCss()).EndEmptyElement().Line();
+            writer.StartElement("line").Attribute("x1", content.X + 5).Attribute("y1", y + 9).Attribute("x2", content.X + 17).Attribute("y2", y + 9).Attribute("stroke", theme.Text.ToCss()).Attribute("stroke-width", 1.4).EndEmptyElement().Line();
+            writer.StartElement("circle").Attribute("cx", content.X + 8).Attribute("cy", y + 15).Attribute("r", 1.5).Attribute("fill", theme.Text.ToCss()).EndEmptyElement().Line();
+            writer.StartElement("circle").Attribute("cx", content.X + 14).Attribute("cy", y + 15).Attribute("r", 1.5).Attribute("fill", theme.Text.ToCss()).EndEmptyElement().Line();
+            WriteText(writer, block.Header, content.X + 32, y + 22, Math.Max(1, content.Width - 32 - navReserve), VisualTextAlignment.Left, theme.Text, theme.FontFamily, Math.Max(13, theme.SubtitleFontSize + 1), "750");
+            if (block.ShowNavigation) {
+                var navY = y + 2;
+                RenderDateNavButton(writer, block.PreviousSymbol, content.X + content.Width - 66, navY, 28, theme, muted: true);
+                RenderDateNavButton(writer, block.NextSymbol, content.X + content.Width - 30, navY, 28, theme, muted: false);
+            }
+
+            writer.EndElement().Line();
+            y += headerHeight;
+        }
+
+        var stripHeight = Math.Max(50, options.Size.Height - options.Padding.Bottom - y);
+        writer.StartElement("g").Attribute("data-cfx-role", "date-strip-block").EndStartElement().Line();
+        writer.StartElement("rect").Attribute("data-cfx-role", "date-strip-surface").Attribute("x", content.X).Attribute("y", y).Attribute("width", content.Width).Attribute("height", stripHeight).Attribute("rx", Math.Min(18, Math.Max(8, theme.PlotCornerRadius + 6))).Attribute("fill", theme.PlotBackground.WithAlpha(150).ToCss()).Attribute("stroke", theme.PlotBorder.WithAlpha(130).ToCss()).EndEmptyElement().Line();
+        var innerX = content.X + 12;
+        var innerY = y + 10;
+        var innerWidth = Math.Max(1, content.Width - 24);
+        var innerHeight = Math.Max(1, stripHeight - 20);
+        var cellWidth = innerWidth / block.Items.Count;
+        var pillWidth = Math.Min(54, Math.Max(42, cellWidth * 0.68));
+        for (var i = 0; i < block.Items.Count; i++) {
+            var item = block.Items[i];
+            var cellX = innerX + i * cellWidth;
+            var x = cellX + (cellWidth - pillWidth) / 2;
+            var accent = item.Color ?? VisualBlockRendering.PaletteAt(theme, 0);
+            var textColor = theme.Text;
+            var valueTextColor = item.Selected ? ChartColorMath.TextOnBackground(accent) : theme.Text;
+            var itemRadius = Math.Min(24, pillWidth * 0.48);
+            writer.StartElement("g").Attribute("data-cfx-role", "date-strip-item").Attribute("data-cfx-selected", item.Selected ? "true" : "false").EndStartElement().Line();
+            writer.StartElement("rect").Attribute("x", x).Attribute("y", innerY).Attribute("width", pillWidth).Attribute("height", innerHeight).Attribute("rx", itemRadius).Attribute("fill", (item.Selected ? theme.CardBackground.WithAlpha(230) : theme.CardBackground.WithAlpha(160)).ToCss()).Attribute("stroke", (item.Selected ? theme.CardBorder.WithAlpha(95) : theme.CardBorder.WithAlpha(70)).ToCss()).EndEmptyElement().Line();
+            WriteText(writer, item.Label, x, innerY + 18, pillWidth, VisualTextAlignment.Center, item.Selected ? textColor : theme.MutedText, theme.FontFamily, Math.Max(10, theme.SubtitleFontSize - 1), "800");
+            writer.StartElement("circle").Attribute("data-cfx-role", "date-strip-value-badge").Attribute("cx", x + pillWidth / 2).Attribute("cy", innerY + innerHeight - 18).Attribute("r", 17).Attribute("fill", item.Selected ? accent.ToCss() : theme.Background.WithAlpha(170).ToCss()).Attribute("stroke", item.Selected ? ChartColor.White.WithAlpha(130).ToCss() : theme.CardBorder.WithAlpha(70).ToCss()).EndEmptyElement().Line();
+            WriteText(writer, item.Value, x, innerY + innerHeight - 13, pillWidth, VisualTextAlignment.Center, valueTextColor, theme.FontFamily, Math.Max(11, theme.SubtitleFontSize), "800");
+            writer.EndElement().Line();
+        }
+
+        writer.EndElement().Line();
+    }
+
+    private static void RenderDateNavButton(SvgMarkupWriter writer, string symbol, double x, double y, double size, ChartForgeX.Themes.ChartTheme theme, bool muted) {
+        writer.StartElement("g").Attribute("data-cfx-role", "date-strip-nav").EndStartElement().Line();
+        writer.StartElement("circle").Attribute("cx", x + size / 2).Attribute("cy", y + size / 2).Attribute("r", size / 2).Attribute("fill", muted ? ChartColor.White.WithAlpha(150).ToCss() : ChartColor.White.ToCss()).Attribute("stroke", theme.CardBorder.WithAlpha(90).ToCss()).EndEmptyElement().Line();
+        WriteText(writer, symbol, x, y + size * 0.66, size, VisualTextAlignment.Center, muted ? theme.MutedText : theme.Text, theme.FontFamily, 15, "900");
+        writer.EndElement().Line();
+    }
+
+    private static void RenderEntityStrip(SvgMarkupWriter writer, EntityStripBlock block) {
+        var options = block.Options;
+        var theme = options.Theme;
+        var content = VisualBlockRendering.ContentRect(options);
+        var y = content.Y;
+        var actionWidth = block.ActionLabel.Length == 0 ? 0 : Math.Min(120, VisualBlockRendering.EstimateTextWidth(block.ActionSymbol + " " + block.ActionLabel, theme.SubtitleFontSize + 1) + 12);
+        if (block.Title.Length > 0) {
+            var titleSize = Math.Max(14, Math.Min(theme.TitleFontSize, theme.SubtitleFontSize + 8));
+            WriteText(writer, block.Title, content.X, y + titleSize * 0.75, Math.Max(1, content.Width - actionWidth - 10), VisualTextAlignment.Left, theme.Text, theme.FontFamily, titleSize, "800");
+            if (block.ActionLabel.Length > 0) WriteText(writer, block.ActionSymbol + " " + block.ActionLabel, content.X + content.Width - actionWidth, y + titleSize * 0.75, actionWidth, VisualTextAlignment.Right, VisualBlockRendering.PaletteAt(theme, 0), theme.FontFamily, Math.Max(12, theme.SubtitleFontSize + 1), "750");
+            y += titleSize + 14;
+        }
+
+        if (block.Subtitle.Length > 0) {
+            WriteText(writer, block.Subtitle, content.X, y + theme.SubtitleFontSize * 0.75, content.Width, VisualTextAlignment.Left, theme.MutedText, theme.FontFamily, theme.SubtitleFontSize, "500");
+            y += theme.SubtitleFontSize + 12;
+        }
+
+        var stripHeight = Math.Max(56, options.Size.Height - options.Padding.Bottom - y);
+        writer.StartElement("g").Attribute("data-cfx-role", "entity-strip-block").EndStartElement().Line();
+        writer.StartElement("rect").Attribute("data-cfx-role", "entity-strip-surface").Attribute("x", content.X).Attribute("y", y).Attribute("width", content.Width).Attribute("height", stripHeight).Attribute("rx", Math.Min(18, Math.Max(8, theme.PlotCornerRadius + 6))).Attribute("fill", theme.PlotBackground.WithAlpha(150).ToCss()).Attribute("stroke", theme.PlotBorder.WithAlpha(130).ToCss()).EndEmptyElement().Line();
+        var cellWidth = Math.Max(1, (content.Width - 20) / block.Items.Count);
+        var avatarRadius = Math.Min(22, Math.Max(16, cellWidth * 0.18));
+        var startX = content.X + 10;
+        for (var i = 0; i < block.Items.Count; i++) {
+            var item = block.Items[i];
+            var x = startX + i * cellWidth;
+            var centerX = x + cellWidth / 2;
+            var color = item.Color ?? (item.Status == VisualStatus.None ? VisualBlockRendering.PaletteAt(theme, i) : VisualBlockRendering.StatusColor(theme, item.Status));
+            writer.StartElement("g").Attribute("data-cfx-role", "entity-strip-item").Attribute("data-cfx-label", item.Label).EndStartElement().Line();
+            writer.StartElement("circle").Attribute("data-cfx-role", "entity-strip-avatar").Attribute("cx", centerX).Attribute("cy", y + 28).Attribute("r", avatarRadius).Attribute("fill", color.WithAlpha(45).ToCss()).Attribute("stroke", color.WithAlpha(115).ToCss()).EndEmptyElement().Line();
+            if (item.AvatarText.Length > 0) WriteText(writer, item.AvatarText, centerX - avatarRadius, y + 33, avatarRadius * 2, VisualTextAlignment.Center, color, theme.FontFamily, Math.Max(9, theme.SubtitleFontSize - 2), "850");
+            else WriteIcon(writer, VisualIcon.Person, centerX, y + 28, avatarRadius * 0.56, color);
+            WriteText(writer, item.Label, x, y + stripHeight - 11, cellWidth, VisualTextAlignment.Center, theme.Text, theme.FontFamily, Math.Max(10, theme.SubtitleFontSize), "500");
+            writer.EndElement().Line();
+        }
+
+        writer.EndElement().Line();
+    }
+
+    private static void RenderSectionHeader(SvgMarkupWriter writer, SectionHeaderBlock block) {
+        var theme = block.Options.Theme;
+        var content = VisualBlockRendering.ContentRect(block.Options);
+        var titleSize = Math.Max(16, Math.Min(theme.TitleFontSize, theme.SubtitleFontSize + 10));
+        var actionText = block.ActionLabel.Length == 0 ? string.Empty : (block.ActionSymbol.Length == 0 ? block.ActionLabel : block.ActionSymbol + " " + block.ActionLabel);
+        var actionWidth = actionText.Length == 0 ? 0 : Math.Min(150, VisualBlockRendering.EstimateTextWidth(actionText, Math.Max(12, theme.SubtitleFontSize + 1)) + 12);
+        var baseline = content.Y + content.Height * 0.60;
+        writer.StartElement("text").Attribute("data-cfx-role", "section-header-title").Attribute("x", content.X).Attribute("y", baseline).Attribute("fill", theme.Text.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", titleSize).Attribute("font-weight", "800").Text(VisualBlockRendering.FitText(block.Title, titleSize, Math.Max(1, content.Width - actionWidth - 12))).EndElement().Line();
+        if (actionText.Length > 0) writer.StartElement("text").Attribute("data-cfx-role", "section-header-action").Attribute("x", content.X + content.Width).Attribute("y", baseline).Attribute("text-anchor", "end").Attribute("fill", VisualBlockRendering.PaletteAt(theme, 0).ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", Math.Max(12, theme.SubtitleFontSize + 1)).Attribute("font-weight", "750").Text(VisualBlockRendering.FitText(actionText, Math.Max(12, theme.SubtitleFontSize + 1), actionWidth)).EndElement().Line();
+    }
+}

--- a/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.cs
+++ b/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.cs
@@ -221,17 +221,18 @@ public sealed partial class SvgVisualBlockRenderer {
             var surfaceX = content.X;
             var surfaceY = microY - 18;
             var surfaceWidth = content.Width;
-            var surfaceHeight = Math.Max(88, detailBottom - surfaceY - 24);
+            var availableSurfaceHeight = Math.Max(1, detailBottom - surfaceY - 4);
+            var surfaceHeight = Math.Min(Math.Max(88, detailBottom - surfaceY - 24), availableSurfaceHeight);
             writer.StartElement("rect").Attribute("data-cfx-role", "metric-micro-surface").Attribute("x", surfaceX).Attribute("y", surfaceY).Attribute("width", surfaceWidth).Attribute("height", surfaceHeight).Attribute("rx", Math.Min(18, theme.PlotCornerRadius + 6)).Attribute("fill", theme.PlotBackground.WithAlpha(170).ToCss()).Attribute("stroke", theme.PlotBorder.WithAlpha(125).ToCss()).EndEmptyElement().Line();
             microX = surfaceX + 28;
-            microY = surfaceY + 32;
+            microY = surfaceY + Math.Min(32, Math.Max(10, surfaceHeight * 0.36));
             microWidth = Math.Max(1, surfaceWidth - 56);
-            microHeight = Math.Max(34, surfaceHeight - 58);
+            microHeight = Math.Max(1, surfaceHeight - (microY - surfaceY) - 18);
         }
 
         if (card.MiniSparkline.Count > 0) RenderMetricMiniSparkline(writer, card, microX, microY, microWidth, microHeight);
         else if (card.MiniBars.Count > 0) RenderMetricMiniBars(writer, card, microX, microY, microWidth, microHeight);
-        var detailsTop = content.Y + labelSize + valueSize + 22 + valueYOffset;
+        var detailsTop = heroMicroVisual ? microY + microHeight + 10 : content.Y + labelSize + valueSize + 22 + valueYOffset;
         RenderMetricDetails(writer, card, content, detailsTop, detailBottom);
         RenderMetricDetail(writer, card, detailBottom, content.X, content.Width);
         if (hasAction) RenderMetricAction(writer, card, footerY, footerHeight, content.X, content.Width);
@@ -310,7 +311,7 @@ public sealed partial class SvgVisualBlockRenderer {
         } else {
             var path = SparklineSmoothPath(sparkline.Points, 0);
             if (card.SecondaryMiniSparkline.Count > 0) {
-                var secondary = VisualBlockRendering.CreateSecondaryMiniSparkline(card, x, y + 6, width, height);
+                var secondary = VisualBlockRendering.CreateSecondaryMiniSparkline(card, x, y, width, height);
                 writer.StartElement("path").Attribute("data-cfx-role", "metric-mini-sparkline-secondary").Attribute("d", SparklineSmoothPath(secondary.Points, 0)).Attribute("fill", "none").Attribute("stroke", secondary.LineColor.ToCss()).Attribute("stroke-width", Math.Max(1.8, secondary.StrokeWidth * 0.72)).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement().Line();
             }
 

--- a/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.cs
+++ b/ChartForgeX/VisualBlocks/SvgVisualBlockRenderer.cs
@@ -70,6 +70,9 @@ public sealed partial class SvgVisualBlockRenderer {
         else if (block is CompositionStatusCard compositionCard) RenderCompositionStatus(writer, compositionCard);
         else if (block is DistributionStripCard distributionCard) RenderDistributionStripCard(writer, distributionCard);
         else if (block is HeatmapInsightCard heatmapCard) RenderHeatmapInsightCard(writer, heatmapCard);
+        else if (block is DateStripBlock dateStrip) RenderDateStrip(writer, dateStrip);
+        else if (block is EntityStripBlock entityStrip) RenderEntityStrip(writer, entityStrip);
+        else if (block is SectionHeaderBlock sectionHeader) RenderSectionHeader(writer, sectionHeader);
         else if (block is WorkloadListBlock workloadBlock) RenderWorkloadList(writer, workloadBlock);
         else if (block is ActivityTimelineBlock activityBlock) RenderActivityTimeline(writer, activityBlock);
         else if (block is ScheduleTimelineBlock scheduleBlock) RenderScheduleTimeline(writer, scheduleBlock);
@@ -92,7 +95,6 @@ public sealed partial class SvgVisualBlockRenderer {
             y += 8;
         }
     }
-
     private static void RenderTable(SvgMarkupWriter writer, ChartTable table, string id) {
         var options = table.Options;
         var theme = options.Theme;
@@ -160,7 +162,6 @@ public sealed partial class SvgVisualBlockRenderer {
             y += rowHeight;
         }
     }
-
     private static void RenderMetric(SvgMarkupWriter writer, MetricCard card, string id) {
         var options = card.Options;
         var theme = options.Theme;
@@ -170,6 +171,9 @@ public sealed partial class SvgVisualBlockRenderer {
         var footerHeight = hasAction ? Math.Min(46, Math.Max(36, options.Size.Height * 0.24)) : 0;
         var footerY = options.Size.Height - footerHeight;
         var detailBottom = hasAction ? footerY - 12 : options.Size.Height - options.Padding.Bottom;
+        var hasMicroVisual = card.MiniBars.Count > 0 || card.MiniSparkline.Count > 0;
+        var heroMicroVisual = hasMicroVisual && card.MicroVisualPlacement == MetricCardMicroVisualPlacement.Hero;
+        var valueInsetSurface = !hasMicroVisual && card.MicroVisualSurface == MetricCardMicroVisualSurface.Inset;
         var labelX = content.X;
         var labelWidth = content.Width;
         var valueYOffset = 0.0;
@@ -180,7 +184,7 @@ public sealed partial class SvgVisualBlockRenderer {
             writer.EndEmptyElement().Line();
         }
 
-        if (card.Icon != VisualIcon.None || card.Symbol.Length > 0) {
+        if (!valueInsetSurface && (card.Icon != VisualIcon.None || card.Symbol.Length > 0)) {
             var badgeColor = card.Status == VisualStatus.None ? VisualBlockRendering.PaletteAt(theme, 0) : statusColor;
             var badgeRadius = Math.Min(24, Math.Max(15, options.Size.Height * 0.11));
             var leftBadge = card.BadgePlacement == MetricCardBadgePlacement.TopLeft;
@@ -202,15 +206,31 @@ public sealed partial class SvgVisualBlockRenderer {
 
         var labelSize = Math.Max(11, theme.SubtitleFontSize);
         var baseValueSize = Math.Min(54, Math.Max(26, options.Size.Height * 0.22));
-        var hasMicroVisual = card.MiniBars.Count > 0 || card.MiniSparkline.Count > 0;
-        var microWidth = hasMicroVisual ? Math.Min(112, Math.Max(58, content.Width * 0.32)) : 0;
-        var microHeight = Math.Min(56, Math.Max(34, options.Size.Height * 0.24));
+        var microWidth = hasMicroVisual ? heroMicroVisual ? Math.Max(92, content.Width - 48) : Math.Min(112, Math.Max(58, content.Width * 0.32)) : 0;
+        var microHeight = heroMicroVisual ? Math.Min(66, Math.Max(50, options.Size.Height * 0.30)) : Math.Min(56, Math.Max(34, options.Size.Height * 0.24));
         var valueWidth = hasMicroVisual ? Math.Max(1, content.Width - microWidth - 18) : content.Width;
-        var valueSize = MetricValueFontSize(card.Value, baseValueSize, valueWidth);
+        if (heroMicroVisual) valueWidth = content.Width;
+        if (valueInsetSurface && (card.Icon != VisualIcon.None || card.Symbol.Length > 0)) valueWidth = Math.Max(1, content.Width - 106);
+        var valueSize = MetricValueFontSize(card, baseValueSize, valueWidth);
         writer.StartElement("text").Attribute("data-cfx-role", "metric-label").Attribute("x", labelX).Attribute("y", content.Y + labelSize).Attribute("fill", theme.MutedText.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", labelSize).Attribute("font-weight", "700").Text(VisualBlockRendering.FitText(card.Label, labelSize, labelWidth)).EndElement().Line();
-        writer.StartElement("text").Attribute("data-cfx-role", "metric-value").Attribute("x", content.X).Attribute("y", content.Y + labelSize + valueSize + 14 + valueYOffset).Attribute("fill", theme.Text.ToCss()).Attribute("font-family", theme.FontFamily).Attribute("font-size", valueSize).Attribute("font-weight", "850").Text(VisualBlockRendering.FitText(card.Value, valueSize, valueWidth)).EndElement().Line();
-        if (card.MiniSparkline.Count > 0) RenderMetricMiniSparkline(writer, card, content.X + content.Width - microWidth, content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset, microWidth, microHeight);
-        else if (card.MiniBars.Count > 0) RenderMetricMiniBars(writer, card, content.X + content.Width - microWidth, content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset, microWidth, microHeight);
+        if (valueInsetSurface) RenderMetricValueSurface(writer, card, content, detailBottom, labelSize, valueSize, valueWidth, statusColor);
+        else RenderMetricValueText(writer, card, content.X, content.Y + labelSize + valueSize + 14 + valueYOffset, valueSize, valueWidth, theme.Text, theme.MutedText);
+        var microX = heroMicroVisual ? content.X + 24 : content.X + content.Width - microWidth;
+        var microY = heroMicroVisual ? content.Y + Math.Max(66, options.Size.Height * 0.36) : content.Y + labelSize + Math.Max(20, valueSize * 0.52) + valueYOffset;
+        if (heroMicroVisual && card.MicroVisualSurface == MetricCardMicroVisualSurface.Inset) {
+            var surfaceX = content.X;
+            var surfaceY = microY - 18;
+            var surfaceWidth = content.Width;
+            var surfaceHeight = Math.Max(88, detailBottom - surfaceY - 24);
+            writer.StartElement("rect").Attribute("data-cfx-role", "metric-micro-surface").Attribute("x", surfaceX).Attribute("y", surfaceY).Attribute("width", surfaceWidth).Attribute("height", surfaceHeight).Attribute("rx", Math.Min(18, theme.PlotCornerRadius + 6)).Attribute("fill", theme.PlotBackground.WithAlpha(170).ToCss()).Attribute("stroke", theme.PlotBorder.WithAlpha(125).ToCss()).EndEmptyElement().Line();
+            microX = surfaceX + 28;
+            microY = surfaceY + 32;
+            microWidth = Math.Max(1, surfaceWidth - 56);
+            microHeight = Math.Max(34, surfaceHeight - 58);
+        }
+
+        if (card.MiniSparkline.Count > 0) RenderMetricMiniSparkline(writer, card, microX, microY, microWidth, microHeight);
+        else if (card.MiniBars.Count > 0) RenderMetricMiniBars(writer, card, microX, microY, microWidth, microHeight);
         var detailsTop = content.Y + labelSize + valueSize + 22 + valueYOffset;
         RenderMetricDetails(writer, card, content, detailsTop, detailBottom);
         RenderMetricDetail(writer, card, detailBottom, content.X, content.Width);
@@ -265,33 +285,39 @@ public sealed partial class SvgVisualBlockRenderer {
         writer.EndElement().Line();
     }
 
-    private static double MetricValueFontSize(string value, double requestedSize, double maxWidth) {
-        var estimatedWidth = VisualBlockRendering.EstimateTextWidth(value, requestedSize);
-        if (estimatedWidth <= maxWidth) return requestedSize;
-        return Math.Max(22, Math.Floor(requestedSize * maxWidth / Math.Max(1, estimatedWidth)));
-    }
-
     private static void RenderMetricMiniSparkline(SvgMarkupWriter writer, MetricCard card, double x, double y, double width, double height) {
         var bounds = VisualBlockRendering.MiniSparklineBounds(card);
         var sparkline = VisualBlockRendering.CreateMiniSparkline(card, x, y, width, height);
 
-        writer.StartElement("g").Attribute("data-cfx-role", "metric-mini-sparkline").Attribute("data-cfx-min", bounds.Minimum).Attribute("data-cfx-max", bounds.Maximum).EndStartElement().Line();
-        writer.StartElement("polygon")
-            .Attribute("data-cfx-role", "metric-mini-sparkline-fill")
-            .Attribute("points", SparklinePoints(sparkline.Area))
-            .Attribute("fill", sparkline.FillColor.ToCss())
-            .EndEmptyElement()
-            .Line();
-        writer.StartElement("polyline")
-            .Attribute("data-cfx-role", "metric-mini-sparkline-line")
-            .Attribute("points", SparklinePoints(sparkline.Points))
-            .Attribute("fill", "none")
-            .Attribute("stroke", sparkline.LineColor.ToCss())
-            .Attribute("stroke-width", sparkline.StrokeWidth)
-            .Attribute("stroke-linecap", "round")
-            .Attribute("stroke-linejoin", "round")
-            .EndEmptyElement()
-            .Line();
+        writer.StartElement("g").Attribute("data-cfx-role", "metric-mini-sparkline").Attribute("data-cfx-style", card.MiniSparklineStyle.ToString().ToLowerInvariant()).Attribute("data-cfx-min", bounds.Minimum).Attribute("data-cfx-max", bounds.Maximum).EndStartElement().Line();
+        if (card.MiniSparklineStyle == MetricCardSparklineStyle.Area) {
+            writer.StartElement("polygon")
+                .Attribute("data-cfx-role", "metric-mini-sparkline-fill")
+                .Attribute("points", SparklinePoints(sparkline.Area))
+                .Attribute("fill", sparkline.FillColor.ToCss())
+                .EndEmptyElement()
+                .Line();
+            writer.StartElement("polyline")
+                .Attribute("data-cfx-role", "metric-mini-sparkline-line")
+                .Attribute("points", SparklinePoints(sparkline.Points))
+                .Attribute("fill", "none")
+                .Attribute("stroke", sparkline.LineColor.ToCss())
+                .Attribute("stroke-width", sparkline.StrokeWidth)
+                .Attribute("stroke-linecap", "round")
+                .Attribute("stroke-linejoin", "round")
+                .EndEmptyElement()
+                .Line();
+        } else {
+            var path = SparklineSmoothPath(sparkline.Points, 0);
+            if (card.SecondaryMiniSparkline.Count > 0) {
+                var secondary = VisualBlockRendering.CreateSecondaryMiniSparkline(card, x, y + 6, width, height);
+                writer.StartElement("path").Attribute("data-cfx-role", "metric-mini-sparkline-secondary").Attribute("d", SparklineSmoothPath(secondary.Points, 0)).Attribute("fill", "none").Attribute("stroke", secondary.LineColor.ToCss()).Attribute("stroke-width", Math.Max(1.8, secondary.StrokeWidth * 0.72)).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement().Line();
+            }
+
+            writer.StartElement("path").Attribute("data-cfx-role", "metric-mini-sparkline-line").Attribute("d", path).Attribute("fill", "none").Attribute("stroke", sparkline.LineColor.ToCss()).Attribute("stroke-width", sparkline.StrokeWidth).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement().Line();
+            writer.StartElement("circle").Attribute("data-cfx-role", "metric-mini-sparkline-start").Attribute("cx", sparkline.Points[0].X).Attribute("cy", sparkline.Points[0].Y).Attribute("r", sparkline.CurrentRadius * 0.82).Attribute("fill", sparkline.LineColor.ToCss()).EndEmptyElement().Line();
+        }
+
         var last = sparkline.Current;
         writer.StartElement("circle").Attribute("data-cfx-role", "metric-mini-sparkline-current").Attribute("cx", last.X).Attribute("cy", last.Y).Attribute("r", sparkline.CurrentRadius).Attribute("fill", sparkline.LineColor.ToCss()).EndEmptyElement().Line();
         writer.EndElement().Line();
@@ -648,6 +674,31 @@ public sealed partial class SvgVisualBlockRenderer {
         return string.Join(" ", values);
     }
 
+    private static string SparklineSmoothPath(IReadOnlyList<ChartPoint> points, double yOffset) {
+        if (points.Count == 0) return string.Empty;
+        var path = new SvgPathDataBuilder().MoveTo(points[0].X, points[0].Y + yOffset);
+        if (points.Count < 3) {
+            for (var i = 1; i < points.Count; i++) path.LineTo(points[i].X, points[i].Y + yOffset);
+            return path.Build();
+        }
+
+        for (var i = 0; i < points.Count - 1; i++) {
+            var p0 = points[Math.Max(0, i - 1)];
+            var p1 = points[i];
+            var p2 = points[i + 1];
+            var p3 = points[Math.Min(points.Count - 1, i + 2)];
+            path.CubicTo(
+                p1.X + (p2.X - p0.X) / 6,
+                p1.Y + yOffset + (p2.Y - p0.Y) / 6,
+                p2.X - (p3.X - p1.X) / 6,
+                p2.Y + yOffset - (p3.Y - p1.Y) / 6,
+                p2.X,
+                p2.Y + yOffset);
+        }
+
+        return path.Build();
+    }
+
     private static string FormatPoint(double x, double y) => x.ToString("0.###", CultureInfo.InvariantCulture) + "," + y.ToString("0.###", CultureInfo.InvariantCulture);
 
     private static double[] ColumnWidths(ChartTable table, double totalWidth) {
@@ -688,48 +739,6 @@ public sealed partial class SvgVisualBlockRenderer {
                 .Attribute("stroke-linecap", "round")
                 .EndEmptyElement().Line();
         }
-    }
-
-    private static void WriteIcon(SvgMarkupWriter writer, VisualIcon icon, double x, double y, double size, ChartColor color) {
-        var stroke = Math.Max(1.6, size * 0.16);
-        if (icon == VisualIcon.ForkKnife) {
-            writer.StartElement("path")
-                .Attribute("data-cfx-role", "visual-icon")
-                .Attribute("data-cfx-icon", "fork-knife")
-                .Attribute("d", "M " + F(x - size * 0.42) + " " + F(y - size * 0.54) + " V " + F(y + size * 0.48) + " M " + F(x - size * 0.66) + " " + F(y - size * 0.56) + " V " + F(y - size * 0.12) + " M " + F(x - size * 0.42) + " " + F(y - size * 0.56) + " V " + F(y - size * 0.12) + " M " + F(x - size * 0.18) + " " + F(y - size * 0.56) + " V " + F(y - size * 0.12) + " M " + F(x - size * 0.66) + " " + F(y - size * 0.12) + " Q " + F(x - size * 0.42) + " " + F(y + size * 0.18) + " " + F(x - size * 0.18) + " " + F(y - size * 0.12) + " M " + F(x + size * 0.34) + " " + F(y + size * 0.48) + " V " + F(y - size * 0.52) + " Q " + F(x + size * 0.70) + " " + F(y - size * 0.24) + " " + F(x + size * 0.40) + " " + F(y + size * 0.04))
-                .Attribute("fill", "none")
-                .Attribute("stroke", color.ToCss())
-                .Attribute("stroke-width", stroke)
-                .Attribute("stroke-linecap", "round")
-                .Attribute("stroke-linejoin", "round")
-                .EndEmptyElement().Line();
-            return;
-        }
-
-        if (icon == VisualIcon.Flame) {
-            writer.StartElement("path")
-                .Attribute("data-cfx-role", "visual-icon")
-                .Attribute("data-cfx-icon", "flame")
-                .Attribute("d", "M " + F(x) + " " + F(y + size * 0.62) + " C " + F(x - size * 0.70) + " " + F(y + size * 0.24) + " " + F(x - size * 0.38) + " " + F(y - size * 0.46) + " " + F(x - size * 0.08) + " " + F(y - size * 0.82) + " C " + F(x + size * 0.04) + " " + F(y - size * 0.30) + " " + F(x + size * 0.52) + " " + F(y - size * 0.24) + " " + F(x + size * 0.38) + " " + F(y - size * 0.88) + " C " + F(x + size * 0.98) + " " + F(y - size * 0.30) + " " + F(x + size * 0.82) + " " + F(y + size * 0.48) + " " + F(x) + " " + F(y + size * 0.62) + " Z")
-                .Attribute("fill", "none")
-                .Attribute("stroke", color.ToCss())
-                .Attribute("stroke-width", stroke)
-                .Attribute("stroke-linecap", "round")
-                .Attribute("stroke-linejoin", "round")
-                .EndEmptyElement().Line();
-            return;
-        }
-
-        writer.StartElement("path")
-            .Attribute("data-cfx-role", "visual-icon")
-            .Attribute("data-cfx-icon", "lightning")
-            .Attribute("d", "M " + F(x - size * 0.52) + " " + F(y - size * 0.32) + " L " + F(x + size * 0.10) + " " + F(y - size * 0.92) + " L " + F(x) + " " + F(y - size * 0.26) + " L " + F(x + size * 0.58) + " " + F(y - size * 0.08) + " L " + F(x - size * 0.20) + " " + F(y + size * 0.82) + " L " + F(x - size * 0.04) + " " + F(y + size * 0.08) + " Z")
-            .Attribute("fill", "none")
-            .Attribute("stroke", color.ToCss())
-            .Attribute("stroke-width", stroke)
-            .Attribute("stroke-linecap", "round")
-            .Attribute("stroke-linejoin", "round")
-            .EndEmptyElement().Line();
     }
 
     private static string ArcPath(double cx, double cy, double radius, double start, double end) {

--- a/ChartForgeX/VisualBlocks/VisualBlockModels.cs
+++ b/ChartForgeX/VisualBlocks/VisualBlockModels.cs
@@ -74,7 +74,15 @@ public enum VisualIcon {
     /// <summary>Heat, burn, or activity icon.</summary>
     Flame,
     /// <summary>Energy, activity, or alert icon.</summary>
-    Lightning
+    Lightning,
+    /// <summary>Water, hydration, or liquid icon.</summary>
+    Droplet,
+    /// <summary>Walking, running, or movement icon.</summary>
+    Runner,
+    /// <summary>Cycling or bike activity icon.</summary>
+    Bicycle,
+    /// <summary>Person, member, owner, or user icon.</summary>
+    Person
 }
 
 /// <summary>
@@ -85,6 +93,36 @@ public enum MetricCardBadgePlacement {
     TopRight,
     /// <summary>Place the badge before the label in the upper-left corner.</summary>
     TopLeft
+}
+
+/// <summary>
+/// Placement for metric-card mini charts.
+/// </summary>
+public enum MetricCardMicroVisualPlacement {
+    /// <summary>Render the mini chart inline beside the primary metric.</summary>
+    Inline,
+    /// <summary>Render the mini chart as a larger focus visual below the primary metric.</summary>
+    Hero
+}
+
+/// <summary>
+/// Presentation style for metric-card mini sparklines.
+/// </summary>
+public enum MetricCardSparklineStyle {
+    /// <summary>Render the sparkline as a compact area chart.</summary>
+    Area,
+    /// <summary>Render the sparkline as a stroked line without area fill.</summary>
+    Line
+}
+
+/// <summary>
+/// Optional surface treatment for metric-card mini visuals.
+/// </summary>
+public enum MetricCardMicroVisualSurface {
+    /// <summary>Render the mini visual directly on the card surface.</summary>
+    None,
+    /// <summary>Render the mini visual inside an inset plot card.</summary>
+    Inset
 }
 
 /// <summary>
@@ -580,6 +618,7 @@ public sealed class VisualGrid {
     private int _pngOutputScale = 1;
     private ChartSize? _panelSize;
     private VisualGridPanelFit _panelFit = VisualGridPanelFit.Contain;
+    private bool _adaptiveRowHeights;
     private bool _frameVisible;
 
     /// <summary>Gets or sets the grid title.</summary>
@@ -620,6 +659,9 @@ public sealed class VisualGrid {
             _panelFit = value;
         }
     }
+
+    /// <summary>Gets or sets whether rows without a fixed panel size use their natural item heights.</summary>
+    public bool AdaptiveRowHeights { get => _adaptiveRowHeights; set => _adaptiveRowHeights = value; }
 
     /// <summary>Gets or sets the optional grid theme.</summary>
     public ChartTheme? Theme { get; set; }
@@ -674,6 +716,9 @@ public sealed class VisualGrid {
 
     /// <summary>Sets how children fit fixed panels.</summary>
     public VisualGrid WithPanelFit(VisualGridPanelFit fit) { PanelFit = fit; return this; }
+
+    /// <summary>Sets whether rows without a fixed panel size use their natural item heights.</summary>
+    public VisualGrid WithAdaptiveRowHeights(bool enabled = true) { AdaptiveRowHeights = enabled; return this; }
 
     /// <summary>Sets the PNG output pixel multiplier.</summary>
     public VisualGrid WithPngOutputScale(int scale) { PngOutputScale = scale; return this; }

--- a/ChartForgeX/VisualBlocks/VisualBlockRendering.cs
+++ b/ChartForgeX/VisualBlocks/VisualBlockRendering.cs
@@ -311,7 +311,7 @@ internal static class VisualBlockRendering {
     public static int MiniBarHighlightIndex(MetricCard card) => card.MiniBarHighlightIndex ?? card.MiniBars.Count - 1;
 
     public static (double Minimum, double Maximum) MiniSparklineBounds(MetricCard card) {
-        if (card.SecondaryMiniSparkline.Count == 0) return ValueBounds(card.MiniSparkline, card.MiniSparklineMinimum, card.MiniSparklineMaximum, includeZero: false);
+        if (card.SecondaryMiniSparkline.Count == 0 || card.MiniSparklineStyle != MetricCardSparklineStyle.Line) return ValueBounds(card.MiniSparkline, card.MiniSparklineMinimum, card.MiniSparklineMaximum, includeZero: false);
         var values = new List<double>(card.MiniSparkline.Count + card.SecondaryMiniSparkline.Count);
         values.AddRange(card.MiniSparkline);
         values.AddRange(card.SecondaryMiniSparkline);

--- a/ChartForgeX/VisualBlocks/VisualBlockRendering.cs
+++ b/ChartForgeX/VisualBlocks/VisualBlockRendering.cs
@@ -33,6 +33,7 @@ internal static class VisualBlockRendering {
         if (block is MetricCard card) {
             if (card.Label.Length == 0) throw new InvalidOperationException("Metric cards must define a label.");
             if (card.Value.Length == 0) throw new InvalidOperationException("Metric cards must define a value.");
+            if (card.Unit.Length > 24) throw new InvalidOperationException("Metric card units must be twenty-four characters or fewer.");
             if (card.Symbol.Length > 12) throw new InvalidOperationException("Metric card symbols must be twelve characters or fewer.");
             foreach (var detail in card.Details) {
                 if (detail.Label.Length == 0) throw new InvalidOperationException("Metric card details must define a label.");
@@ -45,6 +46,7 @@ internal static class VisualBlockRendering {
             if (card.MiniBarMinimum.HasValue && card.MiniBarMaximum.HasValue && card.MiniBarMaximum.Value <= card.MiniBarMinimum.Value) throw new InvalidOperationException("Metric card mini bar maximum must be greater than minimum.");
             if (card.MiniBarHighlightIndex.HasValue && card.MiniBarHighlightIndex.Value >= card.MiniBars.Count) throw new InvalidOperationException("Metric card mini bar highlight index must reference an existing mini bar.");
             if (card.MiniSparklineMinimum.HasValue && card.MiniSparklineMaximum.HasValue && card.MiniSparklineMaximum.Value <= card.MiniSparklineMinimum.Value) throw new InvalidOperationException("Metric card mini sparkline maximum must be greater than minimum.");
+            if (card.SecondaryMiniSparkline.Count > 0 && card.SecondaryMiniSparkline.Count != card.MiniSparkline.Count) throw new InvalidOperationException("Metric card secondary mini sparklines must match the primary sparkline count.");
             return;
         }
 
@@ -176,6 +178,42 @@ internal static class VisualBlockRendering {
             return;
         }
 
+        if (block is DateStripBlock dateStrip) {
+            if (dateStrip.Header.Length > 64) throw new InvalidOperationException("Date strip headers must be sixty-four characters or fewer.");
+            if (dateStrip.PreviousSymbol.Length > 4) throw new InvalidOperationException("Date strip previous symbols must be four characters or fewer.");
+            if (dateStrip.NextSymbol.Length > 4) throw new InvalidOperationException("Date strip next symbols must be four characters or fewer.");
+            if (dateStrip.Items.Count == 0) throw new InvalidOperationException("Date strip blocks must contain at least one item.");
+            foreach (var item in dateStrip.Items) {
+                if (item.Label.Length == 0) throw new InvalidOperationException("Date strip items must define a label.");
+                if (item.Label.Length > 12) throw new InvalidOperationException("Date strip item labels must be twelve characters or fewer.");
+                if (item.Value.Length == 0) throw new InvalidOperationException("Date strip items must define a value.");
+                if (item.Value.Length > 16) throw new InvalidOperationException("Date strip item values must be sixteen characters or fewer.");
+            }
+
+            return;
+        }
+
+        if (block is EntityStripBlock entityStrip) {
+            if (entityStrip.Items.Count == 0) throw new InvalidOperationException("Entity strip blocks must contain at least one item.");
+            if (entityStrip.ActionLabel.Length > 48) throw new InvalidOperationException("Entity strip action labels must be forty-eight characters or fewer.");
+            if (entityStrip.ActionSymbol.Length > 4) throw new InvalidOperationException("Entity strip action symbols must be four characters or fewer.");
+            if (entityStrip.ActionUrl.Length > 0 && !IsSafeActionUrl(entityStrip.ActionUrl)) throw new InvalidOperationException("Entity strip action URLs must be relative URLs, http(s), or mailto links.");
+            foreach (var item in entityStrip.Items) {
+                if (item.Label.Length == 0) throw new InvalidOperationException("Entity strip items must define a label.");
+                if (item.AvatarText.Length > 4) throw new InvalidOperationException("Entity strip item avatar text must be four characters or fewer.");
+            }
+
+            return;
+        }
+
+        if (block is SectionHeaderBlock sectionHeader) {
+            if (sectionHeader.Title.Length == 0) throw new InvalidOperationException("Section header blocks must define a title.");
+            if (sectionHeader.ActionLabel.Length > 48) throw new InvalidOperationException("Section header action labels must be forty-eight characters or fewer.");
+            if (sectionHeader.ActionSymbol.Length > 4) throw new InvalidOperationException("Section header action symbols must be four characters or fewer.");
+            if (sectionHeader.ActionUrl.Length > 0 && !IsSafeActionUrl(sectionHeader.ActionUrl)) throw new InvalidOperationException("Section header action URLs must be relative URLs, http(s), or mailto links.");
+            return;
+        }
+
         throw new NotSupportedException("Unsupported visual block type: " + block.GetType().FullName);
     }
 
@@ -273,7 +311,11 @@ internal static class VisualBlockRendering {
     public static int MiniBarHighlightIndex(MetricCard card) => card.MiniBarHighlightIndex ?? card.MiniBars.Count - 1;
 
     public static (double Minimum, double Maximum) MiniSparklineBounds(MetricCard card) {
-        return ValueBounds(card.MiniSparkline, card.MiniSparklineMinimum, card.MiniSparklineMaximum, includeZero: false);
+        if (card.SecondaryMiniSparkline.Count == 0) return ValueBounds(card.MiniSparkline, card.MiniSparklineMinimum, card.MiniSparklineMaximum, includeZero: false);
+        var values = new List<double>(card.MiniSparkline.Count + card.SecondaryMiniSparkline.Count);
+        values.AddRange(card.MiniSparkline);
+        values.AddRange(card.SecondaryMiniSparkline);
+        return ValueBounds(values, card.MiniSparklineMinimum, card.MiniSparklineMaximum, includeZero: false);
     }
 
     public static VisualMiniBar[] CreateMiniBars(MetricCard card, double x, double y, double width, double height) {
@@ -301,14 +343,23 @@ internal static class VisualBlockRendering {
     }
 
     public static VisualMiniSparkline CreateMiniSparkline(MetricCard card, double x, double y, double width, double height) {
+        return CreateMiniSparkline(card, card.MiniSparkline, card.MiniSparklineColor, card.MiniSparklineFillColor, x, y, width, height);
+    }
+
+    public static VisualMiniSparkline CreateSecondaryMiniSparkline(MetricCard card, double x, double y, double width, double height) {
+        var color = card.SecondaryMiniSparklineColor ?? (card.MiniSparklineColor ?? PaletteAt(card.Options.Theme, 0)).WithAlpha(220);
+        return CreateMiniSparkline(card, card.SecondaryMiniSparkline, color, null, x, y, width, height);
+    }
+
+    private static VisualMiniSparkline CreateMiniSparkline(MetricCard card, IReadOnlyList<double> values, ChartColor? lineColor, ChartColor? fill, double x, double y, double width, double height) {
         var theme = card.Options.Theme;
         var bounds = MiniSparklineBounds(card);
-        var color = card.MiniSparklineColor ?? (card.Status == VisualStatus.None ? PaletteAt(theme, 0) : StatusColor(theme, card.Status));
-        var fillColor = card.MiniSparklineFillColor ?? color.WithAlpha((byte)Math.Round(255 * ChartVisualPrimitives.MiniSparklineFillOpacity));
-        var points = new ChartPoint[card.MiniSparkline.Count];
-        var step = width / Math.Max(1, card.MiniSparkline.Count - 1);
-        for (var i = 0; i < card.MiniSparkline.Count; i++) {
-            var ratio = Math.Max(0, Math.Min(1, (card.MiniSparkline[i] - bounds.Minimum) / (bounds.Maximum - bounds.Minimum)));
+        var color = lineColor ?? (card.Status == VisualStatus.None ? PaletteAt(theme, 0) : StatusColor(theme, card.Status));
+        var fillColor = fill ?? color.WithAlpha((byte)Math.Round(255 * ChartVisualPrimitives.MiniSparklineFillOpacity));
+        var points = new ChartPoint[values.Count];
+        var step = width / Math.Max(1, values.Count - 1);
+        for (var i = 0; i < values.Count; i++) {
+            var ratio = Math.Max(0, Math.Min(1, (values[i] - bounds.Minimum) / (bounds.Maximum - bounds.Minimum)));
             points[i] = new ChartPoint(x + i * step, y + height - ratio * height);
         }
 
@@ -316,7 +367,13 @@ internal static class VisualBlockRendering {
         area[0] = new ChartPoint(points[0].X, y + height);
         for (var i = 0; i < points.Length; i++) area[i + 1] = points[i];
         area[area.Length - 1] = new ChartPoint(points[points.Length - 1].X, y + height);
-        return new VisualMiniSparkline(points, area, color, fillColor, ChartVisualPrimitives.MiniSparklineStrokeWidth, ChartVisualPrimitives.MiniSparklineCurrentRadius);
+        var strokeWidth = card.MiniSparklineStyle == MetricCardSparklineStyle.Line ? 3.4 : ChartVisualPrimitives.MiniSparklineStrokeWidth;
+        var currentRadius = card.MiniSparklineStyle == MetricCardSparklineStyle.Line ? 5.2 : ChartVisualPrimitives.MiniSparklineCurrentRadius;
+        return new VisualMiniSparkline(points, area, color, fillColor, strokeWidth, currentRadius);
+    }
+
+    public static IReadOnlyList<ChartPoint> SmoothMiniSparklinePoints(VisualMiniSparkline sparkline) {
+        return ChartPathBuilder.FromPoints(sparkline.Points, ChartSeriesKind.Line, smooth: true).Flatten(5);
     }
 
     public static double CompositionTotal(CompositionStatusCard card) {

--- a/ChartForgeX/VisualBlocks/VisualGridLayout.cs
+++ b/ChartForgeX/VisualBlocks/VisualGridLayout.cs
@@ -32,29 +32,64 @@ internal sealed class VisualGridLayout {
         foreach (var item in grid.Items) {
             if (grid.PanelSize.HasValue) break;
             var size = ItemSize(item);
-            panelWidth = Math.Max(panelWidth, size.Width);
+            var columnSpan = Math.Min(item.ColumnSpan, columns);
+            panelWidth = Math.Max(panelWidth, (int)Math.Ceiling((size.Width - (columnSpan - 1) * grid.Gap) / (double)columnSpan));
             panelHeight = Math.Max(panelHeight, size.Height);
         }
 
         var theme = grid.Theme ?? ItemTheme(grid.Items[0]);
-        var headerHeight = grid.Title.Length == 0 && grid.Subtitle.Length == 0 ? 0 : Math.Max(76, (int)Math.Ceiling(theme.TitleFontSize + (grid.Subtitle.Length == 0 ? 0 : theme.SubtitleFontSize) + 37));
+        var headerHeight = grid.Title.Length == 0 && grid.Subtitle.Length == 0 ? 0 : Math.Max(54, (int)Math.Ceiling(theme.TitleFontSize + (grid.Subtitle.Length == 0 ? 0 : theme.SubtitleFontSize) + 20));
         var width = grid.Padding * 2 + columns * panelWidth + (columns - 1) * grid.Gap;
         var occupied = new List<bool[]>();
-        var cells = new List<VisualGridCell>(grid.Items.Count);
+        var placements = new List<VisualGridPlacement>(grid.Items.Count);
+        var rowHeights = new List<int>();
         foreach (var item in grid.Items) {
             var columnSpan = Math.Min(item.ColumnSpan, columns);
             var rowSpan = item.RowSpan;
             var placement = FindPlacement(occupied, columns, columnSpan, rowSpan);
             MarkOccupied(occupied, columns, placement.Row, placement.Column, columnSpan, rowSpan);
+            var defaultRowHeight = !grid.PanelSize.HasValue && grid.AdaptiveRowHeights ? 1 : panelHeight;
+            while (rowHeights.Count < placement.Row + rowSpan) rowHeights.Add(defaultRowHeight);
+            if (!grid.PanelSize.HasValue && grid.AdaptiveRowHeights) {
+                var size = ItemSize(item);
+                var naturalRowHeight = Math.Max(1, (int)Math.Ceiling((size.Height - (rowSpan - 1) * grid.Gap) / (double)rowSpan));
+                for (var row = placement.Row; row < placement.Row + rowSpan; row++) rowHeights[row] = Math.Max(rowHeights[row], naturalRowHeight);
+            }
+
+            placements.Add(new VisualGridPlacement(item, placement.Row, placement.Column, columnSpan, rowSpan));
+        }
+
+        if (!grid.PanelSize.HasValue && grid.AdaptiveRowHeights) {
+            for (var row = 0; row < rowHeights.Count; row++) {
+                var occupiedInRow = false;
+                for (var column = 0; column < columns; column++) if (occupied[row][column]) { occupiedInRow = true; break; }
+                if (!occupiedInRow) rowHeights[row] = 0;
+            }
+        }
+
+        var rowOffsets = new List<int>(rowHeights.Count);
+        var cursorY = grid.Padding + headerHeight;
+        for (var row = 0; row < rowHeights.Count; row++) {
+            rowOffsets.Add(cursorY);
+            cursorY += rowHeights[row] + grid.Gap;
+        }
+
+        var cells = new List<VisualGridCell>(grid.Items.Count);
+        foreach (var placement in placements) {
+            var item = placement.Item;
+            var columnSpan = placement.ColumnSpan;
+            var rowSpan = placement.RowSpan;
             var panelX = grid.Padding + placement.Column * (panelWidth + grid.Gap);
-            var panelY = grid.Padding + headerHeight + placement.Row * (panelHeight + grid.Gap);
+            var panelY = rowOffsets[placement.Row];
             var spannedWidth = columnSpan * panelWidth + (columnSpan - 1) * grid.Gap;
-            var spannedHeight = rowSpan * panelHeight + (rowSpan - 1) * grid.Gap;
+            var spannedHeight = SpannedRowHeight(rowHeights, placement.Row, rowSpan, grid.Gap);
             cells.Add(FitCell(item, panelX, panelY, spannedWidth, spannedHeight, grid.PanelSize.HasValue, grid.PanelFit));
         }
 
-        var rows = occupied.Count;
-        var height = grid.Padding * 2 + headerHeight + rows * panelHeight + Math.Max(0, rows - 1) * grid.Gap;
+        var rows = rowHeights.Count;
+        var contentHeight = 0;
+        for (var row = 0; row < rows; row++) contentHeight += rowHeights[row];
+        var height = grid.Padding * 2 + headerHeight + contentHeight + Math.Max(0, rows - 1) * grid.Gap;
         return new VisualGridLayout(width, height, headerHeight, panelWidth, panelHeight, cells);
     }
 
@@ -100,6 +135,28 @@ internal sealed class VisualGridLayout {
         while (occupied.Count < row + rowSpan) occupied.Add(new bool[columns]);
         for (var r = row; r < row + rowSpan; r++) for (var c = column; c < column + columnSpan; c++) occupied[r][c] = true;
     }
+
+    private static int SpannedRowHeight(IReadOnlyList<int> rowHeights, int row, int rowSpan, int gap) {
+        var height = 0;
+        for (var i = row; i < row + rowSpan; i++) height += rowHeights[i];
+        return height + Math.Max(0, rowSpan - 1) * gap;
+    }
+}
+
+internal sealed class VisualGridPlacement {
+    public VisualGridPlacement(VisualGridItem item, int row, int column, int columnSpan, int rowSpan) {
+        Item = item;
+        Row = row;
+        Column = column;
+        ColumnSpan = columnSpan;
+        RowSpan = rowSpan;
+    }
+
+    public VisualGridItem Item { get; }
+    public int Row { get; }
+    public int Column { get; }
+    public int ColumnSpan { get; }
+    public int RowSpan { get; }
 }
 
 internal sealed class VisualGridCell {

--- a/ChartForgeX/VisualBlocks/VisualGridLayout.cs
+++ b/ChartForgeX/VisualBlocks/VisualGridLayout.cs
@@ -33,12 +33,13 @@ internal sealed class VisualGridLayout {
             if (grid.PanelSize.HasValue) break;
             var size = ItemSize(item);
             var columnSpan = Math.Min(item.ColumnSpan, columns);
-            panelWidth = Math.Max(panelWidth, (int)Math.Ceiling((size.Width - (columnSpan - 1) * grid.Gap) / (double)columnSpan));
+            var itemPanelWidth = grid.AdaptiveRowHeights ? (int)Math.Ceiling((size.Width - (columnSpan - 1) * grid.Gap) / (double)columnSpan) : size.Width;
+            panelWidth = Math.Max(panelWidth, itemPanelWidth);
             panelHeight = Math.Max(panelHeight, size.Height);
         }
 
         var theme = grid.Theme ?? ItemTheme(grid.Items[0]);
-        var headerHeight = grid.Title.Length == 0 && grid.Subtitle.Length == 0 ? 0 : Math.Max(54, (int)Math.Ceiling(theme.TitleFontSize + (grid.Subtitle.Length == 0 ? 0 : theme.SubtitleFontSize) + 20));
+        var headerHeight = grid.Title.Length == 0 && grid.Subtitle.Length == 0 ? 0 : Math.Max(76, (int)Math.Ceiling(theme.TitleFontSize + (grid.Subtitle.Length == 0 ? 0 : theme.SubtitleFontSize) + 37));
         var width = grid.Padding * 2 + columns * panelWidth + (columns - 1) * grid.Gap;
         var occupied = new List<bool[]>();
         var placements = new List<VisualGridPlacement>(grid.Items.Count);


### PR DESCRIPTION
## Summary
- Adds reusable dashboard strip blocks for date selectors, entity/avatar strips, and section headers.
- Extends metric cards with inset value surfaces, separate value units, hero mini-chart placement, paired mini sparklines, and line-style mini sparklines.
- Adds adaptive row-height visual grids for dashboard layouts with natural section rhythm.
- Adds the wellness weekly progress example, gallery entry, focused `--wellness-only` example option, and smoke coverage for the new contracts.

## Validation
- `dotnet build .\ChartForgeX.sln`
- `dotnet test .\ChartForgeX.Tests\ChartForgeX.Tests.csproj --no-build`
- `dotnet run --project .\ChartForgeX.Examples\ChartForgeX.Examples.csproj --no-build -- --wellness-only`
- `git diff --check`
