### PR TITLE
Fix force layout narrow anchor bounds

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -260,6 +260,7 @@ internal static partial class SmokeTests {
         ("Topology force-directed layout treats zero-origin groups as explicit anchors", TopologyForceDirectedLayoutTreatsZeroOriginGroupsAsExplicitAnchors),
         ("Topology force-directed layout keeps size-only groups auto anchored", TopologyForceDirectedLayoutKeepsSizeOnlyGroupsAutoAnchored),
         ("Topology force-directed layout keeps weighted anchors inside narrow viewport", TopologyForceDirectedLayoutKeepsWeightedAnchorsInsideNarrowViewport),
+        ("Topology force-directed layout keeps tiny anchor particles constrained", TopologyForceDirectedLayoutKeepsTinyAnchorParticlesConstrained),
         ("Topology monitoring bundle route labels remain readable", TopologyMonitoringBundleRouteLabelsRemainReadable),
         ("Topology dense grouped layout prepares large AD site subnet fixture", TopologyDenseGroupedLayoutPreparesLargeAdSiteSubnetFixture),
         ("Topology collapsed-dot placement uses sizing column count", TopologyCollapsedDotPlacementUsesSizingColumnCount),

--- a/ChartForgeX.Tests/SmokeTests/TopologyDenseLayoutTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/TopologyDenseLayoutTests.cs
@@ -239,6 +239,31 @@ internal static partial class SmokeTests {
 
         Assert(anchorXs.All(x => x >= 24 && x <= 136), "Weighted force anchors should stay inside the actual narrow viewport bounds.");
         Assert(prepared.Groups.All(group => group.Metadata["layout.force.anchor.strategy"] == "weighted-row"), "The narrow viewport fixture should exercise the weighted-row fast path.");
+        Assert(prepared.Groups.All(group => group.X >= 24 && group.X + group.Width <= 136), "Weighted force group panels should stay inside their narrow viewport anchor spans.");
+        Assert(prepared.Groups.All(group => group.Width <= double.Parse(group.Metadata["layout.force.anchor.width"], CultureInfo.InvariantCulture) + 0.01), "Weighted force group panels should not exceed narrow anchor widths.");
+    }
+
+    private static void TopologyForceDirectedLayoutKeepsTinyAnchorParticlesConstrained() {
+        var chart = TopologyChart.Create()
+            .WithId("force-tiny-explicit-anchors")
+            .WithViewport(220, 180, 16)
+            .WithLegend(null)
+            .WithLayout(TopologyLayoutMode.ForceDirected)
+            .AddGroup("left", "Left", 60, 42, 24, 44, TopologyHealthStatus.Healthy)
+            .AddGroup("right", "Right", 136, 42, 24, 44, TopologyHealthStatus.Warning)
+            .AddAutoNode("left-node", "Left Node", TopologyNodeKind.Team, TopologyHealthStatus.Healthy, "left", width: 96, height: 48)
+            .AddAutoNode("right-node", "Right Node", TopologyNodeKind.Team, TopologyHealthStatus.Warning, "right", width: 96, height: 48);
+
+        var prepared = TopologyLayoutEngine.Prepare(chart, options: new TopologyRenderOptions { IncludeLegend = false });
+        var leftGroup = prepared.Groups.Single(group => group.Id == "left");
+        var rightGroup = prepared.Groups.Single(group => group.Id == "right");
+        var leftNode = prepared.Nodes.Single(node => node.Id == "left-node");
+        var rightNode = prepared.Nodes.Single(node => node.Id == "right-node");
+
+        Assert(Math.Abs(leftNode.X + leftNode.Width / 2 - 72) < 0.01, "Force particles should remain constrained to tiny explicit anchor centers when the node is wider than the anchor.");
+        Assert(Math.Abs(rightNode.X + rightNode.Width / 2 - 148) < 0.01, "Tiny explicit anchors should keep particles separated instead of falling back to viewport-wide clamps.");
+        Assert(leftGroup.X >= 60 && leftGroup.X + leftGroup.Width <= 84, "Tiny explicit force group panels should not exceed the left anchor span.");
+        Assert(rightGroup.X >= 136 && rightGroup.X + rightGroup.Width <= 160, "Tiny explicit force group panels should not exceed the right anchor span.");
     }
 
     private static void TopologyMonitoringBundleRouteLabelsRemainReadable() {

--- a/ChartForgeX/Topology/TopologyLayoutEngine.ForceDirected.cs
+++ b/ChartForgeX/Topology/TopologyLayoutEngine.ForceDirected.cs
@@ -461,15 +461,8 @@ internal static partial class TopologyLayoutEngine {
                 var anchorMaxX = anchor.X + anchor.Width * 0.48 - particle.Node.Width / 2;
                 var anchorMinY = anchor.Y - anchor.Height * 0.46 + particle.Node.Height / 2;
                 var anchorMaxY = anchor.Y + anchor.Height * 0.46 - particle.Node.Height / 2;
-                if (anchorMaxX >= anchorMinX) {
-                    minX = Math.Max(minX, anchorMinX);
-                    maxX = Math.Min(maxX, anchorMaxX);
-                }
-
-                if (anchorMaxY >= anchorMinY) {
-                    minY = Math.Max(minY, anchorMinY);
-                    maxY = Math.Min(maxY, anchorMaxY);
-                }
+                ApplyForceAnchorClamp(ref minX, ref maxX, anchorMinX, anchorMaxX, anchor.X);
+                ApplyForceAnchorClamp(ref minY, ref maxY, anchorMinY, anchorMaxY, anchor.Y);
             }
 
             particle.X = ClampForce(particle.X, minX, maxX);
@@ -499,10 +492,12 @@ internal static partial class TopologyLayoutEngine {
                 groupBottom = Math.Min(groupBottom, anchor.Y + anchor.Height / 2);
             }
 
-            group.X = ClampForce(minX - 34, groupLeft, Math.Max(groupLeft, groupRight - 80));
-            group.Y = ClampForce(minY - 58, groupTop, Math.Max(groupTop, groupBottom - 80));
-            group.Width = Math.Max(150, Math.Min(groupRight - group.X, maxX - minX + 68));
-            group.Height = Math.Max(118, Math.Min(groupBottom - group.Y, maxY - minY + 92));
+            var availableWidth = Math.Max(1, groupRight - groupLeft);
+            var availableHeight = Math.Max(1, groupBottom - groupTop);
+            group.Width = Math.Min(availableWidth, Math.Max(Math.Min(150, availableWidth), maxX - minX + 68));
+            group.Height = Math.Min(availableHeight, Math.Max(Math.Min(118, availableHeight), maxY - minY + 92));
+            group.X = ClampForce(minX - 34, groupLeft, Math.Max(groupLeft, groupRight - group.Width));
+            group.Y = ClampForce(minY - 58, groupTop, Math.Max(groupTop, groupBottom - group.Height));
             group.Metadata["layout.force.nodeCount"] = groupParticles.Count.ToString(CultureInfo.InvariantCulture);
         }
     }
@@ -529,5 +524,17 @@ internal static partial class TopologyLayoutEngine {
     private static double ClampForce(double value, double min, double max) {
         if (max < min) return min;
         return value < min ? min : value > max ? max : value;
+    }
+
+    private static void ApplyForceAnchorClamp(ref double min, ref double max, double anchorMin, double anchorMax, double anchorCenter) {
+        if (anchorMax >= anchorMin) {
+            min = Math.Max(min, anchorMin);
+            max = Math.Min(max, anchorMax);
+            return;
+        }
+
+        var center = ClampForce(anchorCenter, min, max);
+        min = center;
+        max = center;
     }
 }


### PR DESCRIPTION
## Summary
- Keep force-layout particles constrained to tiny group anchors even when the anchor is narrower than the rendered node.
- Clamp force-layout group panels to their available anchor/window span instead of enforcing hard minimum dimensions that can overflow.
- Add smoke coverage for narrow weighted-row anchors and tiny explicit anchors.

## Validation
- dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj --filter "FullyQualifiedName~SmokeSuiteTests"
- dotnet build ChartForgeX\ChartForgeX.csproj --no-restore
