### PR TITLE
Add Native AOT compatibility gate

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -4,6 +4,8 @@ param(
 
     [switch] $SkipExamples,
 
+    [switch] $SkipAot,
+
     [switch] $SkipPack,
 
     [switch] $UpdateVisualBaseline,
@@ -349,6 +351,66 @@ function Invoke-DotNetCommand {
     }
 }
 
+function Get-NativeAotRuntimeIdentifier {
+    $architecture = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        if ($architecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { return 'win-arm64' }
+        return 'win-x64'
+    }
+
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Linux)) {
+        if ($architecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { return 'linux-arm64' }
+        return 'linux-x64'
+    }
+
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX)) {
+        if ($architecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { return 'osx-arm64' }
+        return 'osx-x64'
+    }
+
+    throw "Native AOT smoke validation does not know the runtime identifier for $([System.Runtime.InteropServices.RuntimeInformation]::OSDescription) / $architecture."
+}
+
+function Invoke-NativeSmokeExecutable {
+    param(
+        [Parameter(Mandatory = $true)] [string] $ExecutablePath,
+        [Parameter(Mandatory = $true)] [int] $TimeoutSeconds
+    )
+
+    if (-not (Test-Path $ExecutablePath)) {
+        throw "Native AOT smoke executable was not found: $ExecutablePath"
+    }
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $ExecutablePath
+    $startInfo.WorkingDirectory = Split-Path -Parent $ExecutablePath
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $process = [System.Diagnostics.Process]::Start($startInfo)
+    $standardOutput = $process.StandardOutput.ReadToEndAsync()
+    $standardError = $process.StandardError.ReadToEndAsync()
+
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+        try {
+            $process.Kill($true)
+        } catch {
+            $process.Kill()
+        }
+
+        throw "Native AOT smoke executable timed out after $TimeoutSeconds second(s): $ExecutablePath"
+    }
+
+    if ($process.ExitCode -ne 0) {
+        $output = (($standardOutput.GetAwaiter().GetResult(), $standardError.GetAwaiter().GetResult()) -join [Environment]::NewLine).Trim()
+        if ($output.Length -gt 0) {
+            throw "Native AOT smoke executable failed with exit code $($process.ExitCode): $output"
+        }
+
+        throw "Native AOT smoke executable failed with exit code $($process.ExitCode)."
+    }
+}
+
 $ErrorActionPreference = 'Stop'
 if ($PSVersionTable.PSVersion.Major -ge 7) {
     $PSNativeCommandUseErrorActionPreference = $true
@@ -359,6 +421,7 @@ try {
     $solution = Join-Path $root 'ChartForgeX.sln'
     $tests = Join-Path $root 'ChartForgeX.Tests/ChartForgeX.Tests.csproj'
     $examples = Join-Path $root 'ChartForgeX.Examples/ChartForgeX.Examples.csproj'
+    $aotSmoke = Join-Path $root 'ChartForgeX.AotSmoke/ChartForgeX.AotSmoke.csproj'
     $library = Join-Path $root 'ChartForgeX/ChartForgeX.csproj'
     $interactivityLibrary = Join-Path $root 'ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj'
     $htmlInteractivityLibrary = Join-Path $root 'ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj'
@@ -369,6 +432,14 @@ try {
     Invoke-DotNetCommand -Arguments @('restore', '.\ChartForgeX.sln') -Description 'Solution restore' -TimeoutSeconds $DotNetCommandTimeoutSeconds
     Invoke-DotNetCommand -Arguments @('build', $solution, '-c', $Configuration, '--no-restore') -Description 'Solution build' -TimeoutSeconds $DotNetCommandTimeoutSeconds
     Invoke-DotNetCommand -Arguments @('test', $tests, '-c', $Configuration, '--no-build', '--no-restore') -Description 'Test run' -TimeoutSeconds $DotNetCommandTimeoutSeconds
+
+    if (-not $SkipAot) {
+        $nativeAotRid = Get-NativeAotRuntimeIdentifier
+        Invoke-DotNetCommand -Arguments @('publish', $aotSmoke, '-c', $Configuration, '-r', $nativeAotRid, '--self-contained', 'true') -Description 'Native AOT smoke publish' -TimeoutSeconds $DotNetCommandTimeoutSeconds
+        $nativeAotExecutableName = if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) { 'ChartForgeX.AotSmoke.exe' } else { 'ChartForgeX.AotSmoke' }
+        $nativeAotExecutable = Join-Path $root "ChartForgeX.AotSmoke/bin/$Configuration/net8.0/$nativeAotRid/publish/$nativeAotExecutableName"
+        Invoke-NativeSmokeExecutable -ExecutablePath $nativeAotExecutable -TimeoutSeconds $PackageConsumerTimeoutSeconds
+    }
 
     if (-not $SkipExamples) {
         Invoke-DotNetCommand -Arguments @('run', '--project', $examples, '-c', $Configuration, '--no-build') -Description 'Example generation' -TimeoutSeconds $DotNetCommandTimeoutSeconds

--- a/ChartForgeX.AotSmoke/ChartForgeX.AotSmoke.csproj
+++ b/ChartForgeX.AotSmoke/ChartForgeX.AotSmoke.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PublishAot>true</PublishAot>
+    <TrimMode>full</TrimMode>
+    <SelfContained>true</SelfContained>
+    <InvariantGlobalization>false</InvariantGlobalization>
+    <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <SuppressAotAnalysisWarnings>false</SuppressAotAnalysisWarnings>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2070;IL2072;IL2075;IL2090;IL2091;IL3050;IL3053</WarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ChartForgeX\ChartForgeX.csproj" Properties="TargetFramework=net8.0" />
+    <ProjectReference Include="..\ChartForgeX.Interactivity\ChartForgeX.Interactivity.csproj" Properties="TargetFramework=net8.0" />
+    <ProjectReference Include="..\ChartForgeX.Interactivity.Html\ChartForgeX.Interactivity.Html.csproj" Properties="TargetFramework=net8.0" />
+  </ItemGroup>
+</Project>

--- a/ChartForgeX.AotSmoke/Program.cs
+++ b/ChartForgeX.AotSmoke/Program.cs
@@ -1,0 +1,70 @@
+using System;
+using ChartForgeX;
+using ChartForgeX.Core;
+using ChartForgeX.Interactivity;
+using ChartForgeX.Interactivity.Html;
+using ChartForgeX.Primitives;
+using ChartForgeX.Themes;
+using ChartForgeX.Topology;
+using ChartForgeX.VisualBlocks;
+
+var chart = Chart.Create()
+    .WithTitle("AOT smoke")
+    .WithSubtitle("Static report output")
+    .WithSize(420, 240)
+    .WithTheme(ChartTheme.ReportLight())
+    .WithXAxis("Run")
+    .WithYAxis("Value")
+    .AddSmoothLine("Values", new[] { new ChartPoint(1, 2), new ChartPoint(2, 5), new ChartPoint(3, 4) })
+    .AddBar("Warnings", new[] { new ChartPoint(1, 1), new ChartPoint(2, 2), new ChartPoint(3, 1) }, ChartColor.FromRgb(249, 115, 22));
+
+AssertContains(chart.ToSvg(), "<svg", "SVG render failed.");
+AssertContains(chart.ToHtmlPage(), "<html", "HTML page render failed.");
+AssertPng(chart.ToPng(), "PNG render failed.");
+
+var grid = ChartGrid.Create()
+    .WithTitle("AOT grid")
+    .WithPanelSize(260, 180)
+    .Add(chart)
+    .Add(Chart.Create().WithSize(260, 180).WithXLabels("Ready", "Risk").AddDonut("Share", new[] { new ChartPoint(1, 72), new ChartPoint(2, 28) }));
+AssertContains(grid.ToSvg("aot-grid"), "data-cfx-role=\"grid-panel\"", "Grid SVG render failed.");
+AssertPng(grid.ToPng(), "Grid PNG render failed.");
+
+var metric = MetricCard.Create()
+    .WithMetric("Coverage", 0.982, "P1")
+    .WithIcon(VisualIcon.Lightning)
+    .WithTrend("+2.4 pp")
+    .WithStatus(VisualStatus.Positive)
+    .WithTheme(ChartTheme.ReportLight())
+    .WithSize(320, 170);
+AssertContains(metric.ToSvg("aot-metric"), "data-cfx-role=\"metric-label\"", "Metric card SVG render failed.");
+AssertPng(metric.ToPng(), "Metric card PNG render failed.");
+
+var topology = TopologyChart.Create()
+    .WithId("aot-topology")
+    .WithTitle("AOT topology")
+    .WithViewport(460, 280, 24)
+    .WithLegend(TopologyLegend.Default().AddNodeKind("Service", TopologyNodeKind.Service, symbol: "S"))
+    .AddNode("api", "API", 80, 120, TopologyNodeKind.Service, TopologyHealthStatus.Healthy, symbol: "API")
+    .AddNode("db", "DB", 280, 120, TopologyNodeKind.Database, TopologyHealthStatus.Warning, symbol: "DB")
+    .AddEdge("api-db", "api", "db", "12 ms", TopologyEdgeKind.Dependency, TopologyHealthStatus.Warning);
+AssertContains(topology.ToSvg(), "data-cfx-role=\"topology\"", "Topology SVG render failed.");
+AssertPng(topology.ToPng(), "Topology PNG render failed.");
+
+var interactive = chart.ToInteractiveHtmlPage(options => {
+    options.PageTitle = "AOT interactive";
+    options.IdScope = "aot-chart";
+    options.Interaction.Enable(ChartInteractionFeatures.Zoom | ChartInteractionFeatures.Pan | ChartInteractionFeatures.Brush | ChartInteractionFeatures.Export | ChartInteractionFeatures.SynchronizedCharts);
+});
+AssertContains(interactive, "data-cfx-export=\"png\"", "Interactive PNG export control missing.");
+AssertContains(interactive, "new CustomEvent('cfxsync'", "Interactive sync runtime missing.");
+
+static void AssertContains(string text, string expected, string message) {
+    if (!text.Contains(expected, StringComparison.Ordinal)) throw new InvalidOperationException(message);
+}
+
+static void AssertPng(byte[] bytes, string message) {
+    if (bytes.Length <= 64 || bytes[0] != 137 || bytes[1] != 80 || bytes[2] != 78 || bytes[3] != 71) {
+        throw new InvalidOperationException(message);
+    }
+}

--- a/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
+++ b/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
@@ -6,6 +6,11 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</IsAotCompatible>
+    <PublishAot Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0'">false</PublishAot>
+    <EnableTrimAnalyzer Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</EnableAotAnalyzer>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -17,7 +22,7 @@
     <Description>Self-contained HTML and SVG interaction adapter for ChartForgeX charts.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>charts;interactive;html;svg;reports;dashboard;zero-dependency</PackageTags>
+    <PackageTags>charts;interactive;html;svg;reports;dashboard;zero-dependency;aot;nativeaot;trimming</PackageTags>
     <PackageProjectUrl>https://github.com/EvotecIT/ChartForgeX</PackageProjectUrl>
     <RepositoryUrl>https://github.com/EvotecIT/ChartForgeX</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/ChartForgeX.Interactivity.Html/HtmlInteractiveAssets.cs
+++ b/ChartForgeX.Interactivity.Html/HtmlInteractiveAssets.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Reflection;
 
 namespace ChartForgeX.Interactivity.Html;
 
@@ -16,7 +15,7 @@ internal static class HtmlInteractiveAssets {
     internal static string Script => ScriptResource.Value;
 
     private static string ReadResource(string resourceName) {
-        var assembly = typeof(HtmlInteractiveAssets).GetTypeInfo().Assembly;
+        var assembly = typeof(HtmlInteractiveAssets).Assembly;
         using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null) {
             throw new InvalidOperationException("Embedded interactive HTML asset was not found: " + resourceName);

--- a/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
+++ b/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
@@ -6,6 +6,11 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</IsAotCompatible>
+    <PublishAot Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0'">false</PublishAot>
+    <EnableTrimAnalyzer Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</EnableAotAnalyzer>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -17,7 +22,7 @@
     <Description>Host-neutral interaction contracts for ChartForgeX chart renderers and adapters.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>charts;interactivity;svg;html;reports;dashboard;zero-dependency</PackageTags>
+    <PackageTags>charts;interactivity;svg;html;reports;dashboard;zero-dependency;aot;nativeaot;trimming</PackageTags>
     <PackageProjectUrl>https://github.com/EvotecIT/ChartForgeX</PackageProjectUrl>
     <RepositoryUrl>https://github.com/EvotecIT/ChartForgeX</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/ChartForgeX.Tests/SmokeTests/BuildQualityTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/BuildQualityTests.cs
@@ -19,6 +19,10 @@ internal static partial class SmokeTests {
         Assert(script.Contains("@('README.md')", StringComparison.Ordinal), "Build script should verify README package inclusion without requiring separate changelog packaging.");
         Assert(script.Contains("lib/$framework/$($packageProject.Assembly).$extension", StringComparison.Ordinal), "Build script should verify package framework assets.");
         Assert(script.Contains("ChartForgeX-package-consumer", StringComparison.Ordinal), "Build script should verify package consumption from a clean project.");
+        Assert(script.Contains("[switch] $SkipAot", StringComparison.Ordinal), "Build script should allow intentional Native AOT smoke skips for local triage.");
+        Assert(script.Contains("ChartForgeX.AotSmoke", StringComparison.Ordinal), "Build script should publish and run the Native AOT smoke app.");
+        Assert(script.Contains("Get-NativeAotRuntimeIdentifier", StringComparison.Ordinal), "Build script should resolve the current OS runtime identifier for Native AOT validation.");
+        Assert(script.Contains("Invoke-NativeSmokeExecutable", StringComparison.Ordinal), "Build script should execute the compiled Native AOT smoke binary.");
         Assert(script.Contains("globalPackagesFolder", StringComparison.Ordinal), "Build script should isolate the package consumer cache so same-version local packages are retested.");
         Assert(script.Contains("DotNetCommandTimeoutSeconds", StringComparison.Ordinal), "Build script should time-limit all dotnet validation commands.");
         Assert(script.Contains("Invoke-DotNetCommand", StringComparison.Ordinal), "Build script should route dotnet calls through one timeout-aware command runner.");

--- a/ChartForgeX.Tests/SmokeTests/RepositoryQualityTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/RepositoryQualityTests.cs
@@ -36,6 +36,10 @@ internal static partial class SmokeTests {
         Assert(HasXmlProperty(libraryProject, "GenerateDocumentationFile", "true"), "Library project should generate XML documentation.");
         var testProject = Path.Combine(root, "ChartForgeX.Tests", "ChartForgeX.Tests.csproj");
         Assert(HasXmlProperty(testProject, "IsTestProject", "true"), "Smoke suite should be discoverable by dotnet test.");
+        var aotSmokeProject = Path.Combine(root, "ChartForgeX.AotSmoke", "ChartForgeX.AotSmoke.csproj");
+        Assert(File.Exists(aotSmokeProject), "Repository should include a Native AOT consumer smoke project.");
+        Assert(HasXmlProperty(aotSmokeProject, "PublishAot", "true"), "Native AOT smoke project should publish with Native AOT enabled.");
+        Assert(HasXmlProperty(aotSmokeProject, "TrimMode", "full"), "Native AOT smoke project should use full trimming.");
 
         foreach (var packageReference in GetXmlElements(libraryProject, "PackageReference")) {
             var include = packageReference.Attribute("Include")?.Value ?? string.Empty;
@@ -216,9 +220,12 @@ internal static partial class SmokeTests {
             Path.Combine(FindRepositoryRoot(), "ChartForgeX.Interactivity.Html", "ChartForgeX.Interactivity.Html.csproj")
         }) {
             Assert(HasXmlProperty(packageProject, "PackageLicenseExpression", "MIT"), "Package should declare the MIT license: " + Path.GetRelativePath(FindRepositoryRoot(), packageProject));
+            Assert(HasXmlProperty(packageProject, "IsAotCompatible", "true"), "Modern package assets should declare AOT compatibility: " + Path.GetRelativePath(FindRepositoryRoot(), packageProject));
+            Assert(HasXmlProperty(packageProject, "EnableTrimAnalyzer", "true"), "Modern package assets should enable trim analysis: " + Path.GetRelativePath(FindRepositoryRoot(), packageProject));
+            Assert(HasXmlProperty(packageProject, "EnableAotAnalyzer", "true"), "Modern package assets should enable AOT analysis: " + Path.GetRelativePath(FindRepositoryRoot(), packageProject));
         }
         var tags = GetXmlValue(libraryProject, "PackageTags");
-        foreach (var tag in new[] { "charts", "svg", "reports", "zero-dependency" }) {
+        foreach (var tag in new[] { "charts", "svg", "reports", "zero-dependency", "aot", "nativeaot", "trimming" }) {
             Assert(tags.Contains(tag, StringComparison.OrdinalIgnoreCase), "Package tags should include " + tag + ".");
         }
     }
@@ -254,6 +261,7 @@ internal static partial class SmokeTests {
         Assert(readme.Contains("Report intent", StringComparison.Ordinal) && readme.Contains("Theme starting point", StringComparison.Ordinal) && readme.Contains("Brand kit starting point", StringComparison.Ordinal), "README should help users choose between themes and brand kits.");
         Assert(readme.Contains("## Project Status", StringComparison.Ordinal) && readme.Contains("TODO.md", StringComparison.Ordinal), "README should summarize project status without keeping internal release-boundary prose on the front page.");
         Assert(readme.Contains("## Output API", StringComparison.Ordinal) && readme.Contains("chart.Save(\"chart.svg\")", StringComparison.Ordinal) && readme.Contains("SaveRasterImage", StringComparison.Ordinal) && readme.Contains("RasterImageOptions", StringComparison.Ordinal), "README should document the export API behavior contract directly.");
+        Assert(readme.Contains("## Native AOT and Trimming", StringComparison.Ordinal) && readme.Contains("ChartForgeX.AotSmoke", StringComparison.Ordinal) && readme.Contains("Native AOT executable", StringComparison.Ordinal), "README should document AOT and trimming support as a verified release contract.");
         Assert(readme.Contains("GitHub Releases", StringComparison.Ordinal) && readme.Contains("NuGet package notes", StringComparison.Ordinal), "README should explain where release notes belong.");
         Assert(readme.Contains("WithPanelSpan", StringComparison.Ordinal) && readme.Contains("columnSpan", StringComparison.Ordinal), "README should document grid panel spans.");
         Assert(readme.Contains("ChartColor.FromHex", StringComparison.Ordinal) && readme.Contains("ChartPalettes.FromHex", StringComparison.Ordinal), "README should document pasted hex color customization.");

--- a/ChartForgeX/ChartForgeX.csproj
+++ b/ChartForgeX/ChartForgeX.csproj
@@ -6,6 +6,11 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</IsAotCompatible>
+    <PublishAot Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0'">false</PublishAot>
+    <EnableTrimAnalyzer Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">true</EnableAotAnalyzer>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -18,7 +23,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>Preview release of dependency-free SVG, HTML, PNG, BMP, PPM, and baseline TIFF chart rendering with shared raster buffers, stream/file/byte-array raster export helpers, static HTML grids and mosaic panel spans, expressive themes, dashboard presets, brand kits, font stacks, palette, role-based text, grid-header, per-series and point-level data-label styling, point callouts, per-series legend visibility, semantic series roles, pictorial symbol, pictorial Isotype, people-infographic, dashboard, and word-cloud control galleries, sunburst, pictorial, progress-bar, hexbin heatmap, reusable heatmap row models, and word cloud charts, wrapped/customizable pictorial symbols, custom donut center text/ring thickness, progress-bar, KPI ring, and legend placement controls, pasted hex palettes, shared SVG/PNG compact number formatting, scoped inline SVG IDs, and fail-fast validation for specialized chart data.</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>charts;svg;html;png;bmp;ppm;tiff;raster;reports;dashboard;zero-dependency</PackageTags>
+    <PackageTags>charts;svg;html;png;bmp;ppm;tiff;raster;reports;dashboard;zero-dependency;aot;nativeaot;trimming</PackageTags>
     <PackageProjectUrl>https://github.com/EvotecIT/ChartForgeX</PackageProjectUrl>
     <RepositoryUrl>https://github.com/EvotecIT/ChartForgeX</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/ChartForgeX/Topology/TopologySvgRenderer.cs
+++ b/ChartForgeX/Topology/TopologySvgRenderer.cs
@@ -14,6 +14,14 @@ namespace ChartForgeX.Topology;
 /// Renders topology charts to static SVG markup.
 /// </summary>
 public sealed partial class TopologySvgRenderer {
+    private static readonly TopologyHealthStatus[] TopologyHealthStatuses = {
+        TopologyHealthStatus.Healthy,
+        TopologyHealthStatus.Warning,
+        TopologyHealthStatus.Critical,
+        TopologyHealthStatus.Unknown,
+        TopologyHealthStatus.Disabled
+    };
+
     /// <summary>
     /// Renders a topology chart to complete SVG markup.
     /// </summary>
@@ -264,7 +272,7 @@ public sealed partial class TopologySvgRenderer {
 
         AddDropShadowFilter(defs, id + "-shadow", "#0F172A", IsMonitoringDashboardStyle(options) ? 0.065 : 0.10);
         AddDropShadowFilter(defs, id + "-selected-shadow", "#2563EB", IsMonitoringDashboardStyle(options) ? 0.13 : 0.18);
-        foreach (var status in Enum.GetValues(typeof(TopologyHealthStatus)).Cast<TopologyHealthStatus>()) {
+        foreach (var status in GetTopologyHealthStatuses()) {
             var color = theme.StatusColor(status);
             defs.Element("marker", marker => {
                 marker
@@ -283,6 +291,8 @@ public sealed partial class TopologySvgRenderer {
 
         return defs;
     }
+
+    private static IEnumerable<TopologyHealthStatus> GetTopologyHealthStatuses() => TopologyHealthStatuses;
 
     private static string BuildCss(string id, string prefix, TopologyTheme theme) {
         var sb = new StringBuilder();

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Optional interaction support is split into separate packages:
 | `ChartForgeX.Interactivity` | Host-neutral interaction contracts. |
 | `ChartForgeX.Interactivity.Html` | Self-contained HTML/SVG interaction adapter. |
 
+## Native AOT and Trimming
+
+ChartForgeX is designed to work in trimmed and Native AOT applications on modern .NET targets. The `net8.0` and `net10.0` package assets declare AOT compatibility, enable trim/single-file/AOT analyzers, and avoid reflection-driven serialization or dynamic code paths in the rendering surface.
+
+The release quality loop publishes and runs `ChartForgeX.AotSmoke` as a Native AOT executable. That smoke app renders SVG, static HTML, PNG, chart grids, visual blocks, topology diagrams, and the self-contained HTML interaction adapter, so AOT regressions fail before a package is published.
+
 ## Output API
 
 The output API follows one rule: `To*` returns content, `Save*` writes a file, and `Write*` streams bytes.


### PR DESCRIPTION
## Summary
- declare AOT/trimming compatibility on modern package assets and add AOT-related package tags
- add a Native AOT smoke app that exercises SVG, HTML, PNG, grids, visual blocks, topology, and the HTML interactivity adapter
- wire Build.ps1 to publish and run the native smoke executable as part of the release quality loop
- remove the remaining dynamic-code-sensitive enum reflection path from topology SVG marker generation

## Validation
- dotnet test .\\ChartForgeX.Tests\\ChartForgeX.Tests.csproj -c Release
- dotnet publish .\\ChartForgeX.AotSmoke\\ChartForgeX.AotSmoke.csproj -c Release -r win-x64 --self-contained true
- .\\ChartForgeX.AotSmoke\\bin\\Release\\net8.0\\win-x64\\publish\\ChartForgeX.AotSmoke.exe
- .\\Build.ps1 -Configuration Release
- git diff --cached --check