### PR TITLE
Add simple chart definition API

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
@@ -1,0 +1,28 @@
+using ChartForgeX.Primitives;
+using ChartForgeX.Simple;
+using System;
+using System.IO;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void SimpleChartApiRendersCommonDefinitions() {
+        var output = Path.Combine(Path.GetTempPath(), "chartforgex-simple-chart-api-" + Guid.NewGuid().ToString("N") + ".png");
+        Charts.Generate(
+            new ChartDefinition[] {
+                new ChartLine("CPU", new double[] { 35, 42, 58, 61 }, ChartColor.FromHex("#22C55E"), smooth: true)
+            },
+            output,
+            width: 420,
+            height: 260,
+            showGrid: true,
+            options: new ChartRenderOptions {
+                TransparentBackground = true,
+                ShowLegend = true,
+                Palette = new[] { ChartColor.FromHex("#22C55E"), ChartColor.FromHex("#3B82F6") }
+            });
+
+        Assert(File.Exists(output), "Simple chart API should save PNG output.");
+        Assert(new FileInfo(output).Length > 64, "Simple chart API should render non-empty PNG output.");
+    }
+}

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -142,6 +142,7 @@ internal static partial class SmokeTests {
         ("Small multiple grids render static HTML", SmallMultipleGridRendersStaticHtml),
         ("Shared y-axis handles secondary-only charts", SharedYAxisHandlesSecondaryOnlyCharts),
         ("Shared axes ignore progress bars", SharedAxesIgnoreProgressBars),
+        ("Simple chart API renders common definitions", SimpleChartApiRendersCommonDefinitions),
         ("Chart grids support panel spans", ChartGridsSupportPanelSpans),
         ("Chart grid headers support text styles", ChartGridHeadersSupportTextStyles),
         ("Visual blocks render tables lists and metric cards", VisualBlocksRenderTablesListsAndMetricCards),

--- a/ChartForgeX/Simple/ChartAnnotation.cs
+++ b/ChartForgeX/Simple/ChartAnnotation.cs
@@ -1,0 +1,28 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Chart annotation definition.</summary>
+public sealed class ChartAnnotation {
+    /// <summary>X coordinate of the annotation.</summary>
+    public double X { get; }
+
+    /// <summary>Y coordinate of the annotation.</summary>
+    public double Y { get; }
+
+    /// <summary>Annotation text.</summary>
+    public string Text { get; }
+
+    /// <summary>Display arrow.</summary>
+    public bool Arrow { get; }
+
+    /// <summary>Create an annotation.</summary>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="text">Annotation text.</param>
+    /// <param name="arrow">Display arrow.</param>
+    public ChartAnnotation(double x, double y, string text, bool arrow = false) {
+        X = x;
+        Y = y;
+        Text = text;
+        Arrow = arrow;
+    }
+}

--- a/ChartForgeX/Simple/ChartArea.cs
+++ b/ChartForgeX/Simple/ChartArea.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Area chart definition.</summary>
+public sealed class ChartArea : ChartDefinition {
+    /// <summary>Area values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Fill color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create an area chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Y values.</param>
+    /// <param name="color">Optional fill color.</param>
+    public ChartArea(string name, IList<double> value, ChartColor? color = null) : base(ChartDefinitionType.Area, name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartBar.cs
+++ b/ChartForgeX/Simple/ChartBar.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Bar chart definition.</summary>
+public sealed class ChartBar : ChartDefinition {
+    /// <summary>Bar values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Bar color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a bar chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Bar values.</param>
+    /// <param name="color">Optional bar color.</param>
+    public ChartBar(string name, IList<double> value, ChartColor? color = null) : base(ChartDefinitionType.Bar, name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartBarOptions.cs
+++ b/ChartForgeX/Simple/ChartBarOptions.cs
@@ -1,0 +1,13 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Options for bar charts.</summary>
+public sealed class ChartBarOptions {
+    /// <summary>Whether to show values above bars.</summary>
+    public bool ShowValuesAboveBars { get; }
+
+    /// <summary>Initialize options for bar charts.</summary>
+    /// <param name="showValuesAboveBars">Show value labels.</param>
+    public ChartBarOptions(bool showValuesAboveBars) {
+        ShowValuesAboveBars = showValuesAboveBars;
+    }
+}

--- a/ChartForgeX/Simple/ChartBubble.cs
+++ b/ChartForgeX/Simple/ChartBubble.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Bubble chart definition.</summary>
+public sealed class ChartBubble : ChartDefinition {
+    /// <summary>X values.</summary>
+    public IList<double> X { get; }
+
+    /// <summary>Y values.</summary>
+    public IList<double> Y { get; }
+
+    /// <summary>Size values.</summary>
+    public IList<double> Size { get; }
+
+    /// <summary>Bubble color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a bubble chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="x">X data points.</param>
+    /// <param name="y">Y data points.</param>
+    /// <param name="size">Bubble sizes.</param>
+    /// <param name="color">Optional bubble color.</param>
+    public ChartBubble(string name, IList<double> x, IList<double> y, IList<double> size, ChartColor? color = null) : base(ChartDefinitionType.Bubble, name) {
+        X = x;
+        Y = y;
+        Size = size;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartCircle.cs
+++ b/ChartForgeX/Simple/ChartCircle.cs
@@ -1,0 +1,31 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Circle status chart definition.</summary>
+public sealed class ChartCircle : ChartDefinition {
+    /// <summary>Circle value.</summary>
+    public double Value { get; }
+
+    /// <summary>Circle minimum.</summary>
+    public double Minimum { get; }
+
+    /// <summary>Circle maximum.</summary>
+    public double Maximum { get; }
+
+    /// <summary>Circle color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a circle status chart definition.</summary>
+    /// <param name="name">Circle label.</param>
+    /// <param name="value">Circle value.</param>
+    /// <param name="minimum">Circle minimum.</param>
+    /// <param name="maximum">Circle maximum.</param>
+    /// <param name="color">Optional circle color.</param>
+    public ChartCircle(string name, double value, double minimum = 0, double maximum = 100, ChartColor? color = null) : base(ChartDefinitionType.Circle, name) {
+        Value = value;
+        Minimum = minimum;
+        Maximum = maximum;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartDefinition.cs
+++ b/ChartForgeX/Simple/ChartDefinition.cs
@@ -1,0 +1,18 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Base class for chart definitions.</summary>
+public abstract class ChartDefinition {
+    /// <summary>Chart type.</summary>
+    public ChartDefinitionType Type { get; }
+
+    /// <summary>Chart name.</summary>
+    public string Name { get; }
+
+    /// <summary>Initializes a chart definition.</summary>
+    /// <param name="type">Chart type.</param>
+    /// <param name="name">Chart name.</param>
+    protected ChartDefinition(ChartDefinitionType type, string name) {
+        Type = type;
+        Name = name;
+    }
+}

--- a/ChartForgeX/Simple/ChartDefinitionType.cs
+++ b/ChartForgeX/Simple/ChartDefinitionType.cs
@@ -1,0 +1,42 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>
+/// Type of chart definition.
+/// </summary>
+public enum ChartDefinitionType {
+    /// <summary>Bar chart.</summary>
+    Bar,
+    /// <summary>Line chart.</summary>
+    Line,
+    /// <summary>Scatter chart.</summary>
+    Scatter,
+    /// <summary>Bubble chart.</summary>
+
+    Bubble,
+    /// <summary>Polar plot.</summary>
+    Polar,
+    /// <summary>Pie chart.</summary>
+    Pie,
+    /// <summary>Radial gauge chart.</summary>
+    Radial,
+    /// <summary>Heatmap chart.</summary>
+    Heatmap,
+    /// <summary>Histogram chart.</summary>
+    Histogram,
+    /// <summary>Area chart.</summary>
+    Area,
+    /// <summary>Donut chart.</summary>
+    Donut,
+    /// <summary>Gauge chart.</summary>
+    Gauge,
+    /// <summary>Circle status chart.</summary>
+    Circle,
+    /// <summary>Progress-bar chart.</summary>
+    ProgressBar,
+    /// <summary>Pictorial chart.</summary>
+    Pictorial,
+    /// <summary>Word cloud chart.</summary>
+    WordCloud,
+    /// <summary>Polar area chart.</summary>
+    PolarArea
+}

--- a/ChartForgeX/Simple/ChartDonut.cs
+++ b/ChartForgeX/Simple/ChartDonut.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Donut chart slice definition.</summary>
+public sealed class ChartDonut : ChartDefinition {
+    /// <summary>Slice value.</summary>
+    public double Value { get; }
+
+    /// <summary>Slice color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a donut slice definition.</summary>
+    /// <param name="name">Slice label.</param>
+    /// <param name="value">Slice value.</param>
+    /// <param name="color">Optional slice color.</param>
+    public ChartDonut(string name, double value, ChartColor? color = null) : base(ChartDefinitionType.Donut, name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartGauge.cs
+++ b/ChartForgeX/Simple/ChartGauge.cs
@@ -1,0 +1,31 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Gauge chart definition.</summary>
+public sealed class ChartGauge : ChartDefinition {
+    /// <summary>Gauge value.</summary>
+    public double Value { get; }
+
+    /// <summary>Gauge minimum.</summary>
+    public double Minimum { get; }
+
+    /// <summary>Gauge maximum.</summary>
+    public double Maximum { get; }
+
+    /// <summary>Gauge color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a gauge chart definition.</summary>
+    /// <param name="name">Gauge label.</param>
+    /// <param name="value">Gauge value.</param>
+    /// <param name="minimum">Gauge minimum.</param>
+    /// <param name="maximum">Gauge maximum.</param>
+    /// <param name="color">Optional gauge color.</param>
+    public ChartGauge(string name, double value, double minimum = 0, double maximum = 100, ChartColor? color = null) : base(ChartDefinitionType.Gauge, name) {
+        Value = value;
+        Minimum = minimum;
+        Maximum = maximum;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartHeatmap.cs
+++ b/ChartForgeX/Simple/ChartHeatmap.cs
@@ -1,0 +1,14 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Heatmap chart definition.</summary>
+public sealed class ChartHeatmap : ChartDefinition {
+    /// <summary>Values of the heatmap.</summary>
+    public double[,] Data { get; }
+
+    /// <summary>Create a heatmap definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="data">Heatmap values.</param>
+    public ChartHeatmap(string name, double[,] data) : base(ChartDefinitionType.Heatmap, name) {
+        Data = data;
+    }
+}

--- a/ChartForgeX/Simple/ChartHeatmapColorScale.cs
+++ b/ChartForgeX/Simple/ChartHeatmapColorScale.cs
@@ -1,0 +1,9 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Heatmap color scale strategy.</summary>
+public enum ChartHeatmapColorScale {
+    /// <summary>Use a single low-to-high color ramp.</summary>
+    Sequential,
+    /// <summary>Use theme status colors for semantic matrices.</summary>
+    Semantic
+}

--- a/ChartForgeX/Simple/ChartHistogram.cs
+++ b/ChartForgeX/Simple/ChartHistogram.cs
@@ -1,0 +1,19 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Histogram chart definition.</summary>
+public sealed class ChartHistogram : ChartDefinition {
+    /// <summary>Values for the histogram.</summary>
+    public double[] Values { get; }
+
+    /// <summary>Size of each bin.</summary>
+    public int? BinSize { get; }
+
+    /// <summary>Create a histogram definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="values">Input values.</param>
+    /// <param name="binSize">Optional bin size.</param>
+    public ChartHistogram(string name, double[] values, int? binSize = null) : base(ChartDefinitionType.Histogram, name) {
+        Values = values;
+        BinSize = binSize;
+    }
+}

--- a/ChartForgeX/Simple/ChartLegendPosition.cs
+++ b/ChartForgeX/Simple/ChartLegendPosition.cs
@@ -1,0 +1,13 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Legend position used by generated charts.</summary>
+public enum ChartLegendPosition {
+    /// <summary>Place the legend below the chart.</summary>
+    Bottom,
+    /// <summary>Place the legend above the chart.</summary>
+    Top,
+    /// <summary>Place the legend on the left.</summary>
+    Left,
+    /// <summary>Place the legend on the right.</summary>
+    Right
+}

--- a/ChartForgeX/Simple/ChartLine.cs
+++ b/ChartForgeX/Simple/ChartLine.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Line chart definition.</summary>
+public sealed class ChartLine : ChartDefinition {
+    /// <summary>Line values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Line color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Shape of markers used for data points.</summary>
+    public ChartMarkerShape MarkerShape { get; }
+
+    /// <summary>Optional size of the markers.</summary>
+    public float? MarkerSize { get; }
+
+    /// <summary>Render the line using a smooth curve.</summary>
+    public bool Smooth { get; }
+
+    /// <summary>Create a line chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Line values.</param>
+    /// <param name="color">Optional line color.</param>
+    /// <param name="markerShape">Marker shape.</param>
+    /// <param name="markerSize">Optional marker size.</param>
+    /// <param name="smooth">Render as a smooth curve.</param>
+    public ChartLine(
+        string name,
+        IList<double> value,
+        ChartColor? color = null,
+        ChartMarkerShape markerShape = ChartMarkerShape.None,
+        float? markerSize = null,
+        bool smooth = false) : base(ChartDefinitionType.Line, name) {
+        Value = value;
+        Color = color;
+        MarkerShape = markerShape;
+        MarkerSize = markerSize;
+        Smooth = smooth;
+    }
+}

--- a/ChartForgeX/Simple/ChartMarkerShape.cs
+++ b/ChartForgeX/Simple/ChartMarkerShape.cs
@@ -1,0 +1,13 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Marker shape used for chart points.</summary>
+public enum ChartMarkerShape {
+    /// <summary>No marker.</summary>
+    None,
+    /// <summary>Circle marker.</summary>
+    Circle,
+    /// <summary>Square marker.</summary>
+    Square,
+    /// <summary>Diamond marker.</summary>
+    Diamond
+}

--- a/ChartForgeX/Simple/ChartPictorial.cs
+++ b/ChartForgeX/Simple/ChartPictorial.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Pictorial chart row definition.</summary>
+public sealed class ChartPictorial : ChartDefinition {
+    /// <summary>Pictorial value.</summary>
+    public double Value { get; }
+
+    /// <summary>Pictorial color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a pictorial chart row definition.</summary>
+    /// <param name="name">Pictorial label.</param>
+    /// <param name="value">Pictorial value.</param>
+    /// <param name="color">Optional pictorial color.</param>
+    public ChartPictorial(string name, double value, ChartColor? color = null) : base(ChartDefinitionType.Pictorial, name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartPictorialSymbol.cs
+++ b/ChartForgeX/Simple/ChartPictorialSymbol.cs
@@ -1,0 +1,17 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Built-in pictorial chart symbol.</summary>
+public enum ChartPictorialSymbol {
+    /// <summary>Circle symbol.</summary>
+    Circle,
+    /// <summary>Square symbol.</summary>
+    Square,
+    /// <summary>Diamond symbol.</summary>
+    Diamond,
+    /// <summary>Triangle symbol.</summary>
+    Triangle,
+    /// <summary>Star symbol.</summary>
+    Star,
+    /// <summary>Person symbol.</summary>
+    Person
+}

--- a/ChartForgeX/Simple/ChartPie.cs
+++ b/ChartForgeX/Simple/ChartPie.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Pie chart definition.</summary>
+public sealed class ChartPie : ChartDefinition {
+    /// <summary>Slice value.</summary>
+    public double Value { get; }
+
+    /// <summary>Slice color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a pie slice definition.</summary>
+    /// <param name="name">Slice label.</param>
+    /// <param name="value">Slice value.</param>
+    /// <param name="color">Optional slice color.</param>
+    public ChartPie(string name, double value, ChartColor? color = null) : base(ChartDefinitionType.Pie, name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartPieLabelContent.cs
+++ b/ChartForgeX/Simple/ChartPieLabelContent.cs
@@ -1,0 +1,15 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Content rendered in pie and donut slice labels.</summary>
+public enum ChartPieLabelContent {
+    /// <summary>Render the slice label.</summary>
+    Label,
+    /// <summary>Render the numeric value.</summary>
+    Value,
+    /// <summary>Render the percent of total.</summary>
+    Percent,
+    /// <summary>Render label and value.</summary>
+    LabelAndValue,
+    /// <summary>Render label and percent.</summary>
+    LabelAndPercent
+}

--- a/ChartForgeX/Simple/ChartPolar.cs
+++ b/ChartForgeX/Simple/ChartPolar.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Polar plot definition.</summary>
+public sealed class ChartPolar : ChartDefinition {
+    /// <summary>Angle values.</summary>
+    public IList<double> Angle { get; }
+
+    /// <summary>Radius values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Line color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a polar chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="angle">Angle values.</param>
+    /// <param name="value">Radius values.</param>
+    /// <param name="color">Optional line color.</param>
+    public ChartPolar(string name, IList<double> angle, IList<double> value, ChartColor? color = null) : base(ChartDefinitionType.Polar, name) {
+        Angle = angle;
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartProgress.cs
+++ b/ChartForgeX/Simple/ChartProgress.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Progress-bar chart row definition.</summary>
+public sealed class ChartProgress : ChartDefinition {
+    /// <summary>Progress value.</summary>
+    public double Value { get; }
+
+    /// <summary>Progress color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a progress-bar row definition.</summary>
+    /// <param name="name">Progress label.</param>
+    /// <param name="value">Progress value.</param>
+    /// <param name="color">Optional progress color.</param>
+    public ChartProgress(string name, double value, ChartColor? color = null) : base(ChartDefinitionType.ProgressBar, name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartRadial.cs
+++ b/ChartForgeX/Simple/ChartRadial.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Radial gauge chart definition.</summary>
+public sealed class ChartRadial : ChartDefinition {
+    /// <summary>Gauge value.</summary>
+    public double Value { get; }
+
+    /// <summary>Gauge color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a radial gauge definition.</summary>
+    /// <param name="name">Gauge label.</param>
+    /// <param name="value">Gauge value.</param>
+    /// <param name="color">Optional gauge color.</param>
+    public ChartRadial(string name, double value, ChartColor? color = null) : base(ChartDefinitionType.Radial, name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartRenderOptions.cs
+++ b/ChartForgeX/Simple/ChartRenderOptions.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Renderer-neutral chart options exposed by ImagePlayground.</summary>
+public sealed class ChartRenderOptions {
+    /// <summary>Optional color palette used by series and point-based charts.</summary>
+    public IList<ChartColor>? Palette { get; set; }
+
+    /// <summary>Whether to render the legend.</summary>
+    public bool? ShowLegend { get; set; }
+
+    /// <summary>Whether legends for point-based charts list individual points.</summary>
+    public bool? ShowPointLegend { get; set; }
+
+    /// <summary>Legend placement.</summary>
+    public ChartLegendPosition? LegendPosition { get; set; }
+
+    /// <summary>Whether to render the chart header.</summary>
+    public bool? ShowHeader { get; set; }
+
+    /// <summary>Whether to render the outer chart card.</summary>
+    public bool? ShowCard { get; set; }
+
+    /// <summary>Whether to render the plot background.</summary>
+    public bool? ShowPlotBackground { get; set; }
+
+    /// <summary>Whether the chart background should be transparent.</summary>
+    public bool? TransparentBackground { get; set; }
+
+    /// <summary>Whether to render axes and tick labels.</summary>
+    public bool? ShowAxes { get; set; }
+
+    /// <summary>Whether to render the x-axis.</summary>
+    public bool? ShowXAxis { get; set; }
+
+    /// <summary>Whether to render the y-axis.</summary>
+    public bool? ShowYAxis { get; set; }
+
+    /// <summary>Whether to render axis rules.</summary>
+    public bool? ShowAxisLines { get; set; }
+
+    /// <summary>Whether to render grid lines.</summary>
+    public bool? ShowGrid { get; set; }
+
+    /// <summary>Whether to render data labels for supported charts.</summary>
+    public bool? ShowDataLabels { get; set; }
+
+    /// <summary>Preferred number of axis ticks.</summary>
+    public int? TickCount { get; set; }
+
+    /// <summary>Explicit x-axis minimum.</summary>
+    public double? XAxisMinimum { get; set; }
+
+    /// <summary>Explicit x-axis maximum.</summary>
+    public double? XAxisMaximum { get; set; }
+
+    /// <summary>Explicit y-axis minimum.</summary>
+    public double? YAxisMinimum { get; set; }
+
+    /// <summary>Explicit y-axis maximum.</summary>
+    public double? YAxisMaximum { get; set; }
+
+    /// <summary>Heatmap color scale.</summary>
+    public ChartHeatmapColorScale? HeatmapScale { get; set; }
+
+    /// <summary>Whether to render the heatmap scale legend.</summary>
+    public bool? ShowHeatmapScale { get; set; }
+
+    /// <summary>Whether to render heatmap column labels.</summary>
+    public bool? ShowHeatmapColumnLabels { get; set; }
+
+    /// <summary>Whether to render the donut center label.</summary>
+    public bool? ShowDonutCenterLabel { get; set; }
+
+    /// <summary>Donut hole radius ratio.</summary>
+    public double? DonutInnerRadiusRatio { get; set; }
+
+    /// <summary>Optional donut center value text.</summary>
+    public string? DonutCenterValue { get; set; }
+
+    /// <summary>Optional donut center label text.</summary>
+    public string? DonutCenterLabel { get; set; }
+
+    /// <summary>Pie and donut slice label content.</summary>
+    public ChartPieLabelContent? PieLabelContent { get; set; }
+
+    /// <summary>Whether to render radial-bar center labels.</summary>
+    public bool? ShowRadialBarCenterLabel { get; set; }
+
+    /// <summary>Whether to render circle status labels.</summary>
+    public bool? ShowCircleStatusLabel { get; set; }
+
+    /// <summary>Progress maximum used by progress-bar charts.</summary>
+    public double? ProgressMaximum { get; set; }
+
+    /// <summary>Whether to render progress-bar values.</summary>
+    public bool? ShowProgressValues { get; set; }
+
+    /// <summary>Whether to render progress-bar handles.</summary>
+    public bool? ShowProgressHandles { get; set; }
+
+    /// <summary>Progress-bar thickness ratio.</summary>
+    public double? ProgressBarThicknessRatio { get; set; }
+
+    /// <summary>Pictorial chart symbol.</summary>
+    public ChartPictorialSymbol? PictorialSymbol { get; set; }
+
+    /// <summary>Number of pictorial symbols per row.</summary>
+    public int? PictorialColumns { get; set; }
+
+    /// <summary>Optional pictorial maximum.</summary>
+    public double? PictorialMaximum { get; set; }
+
+    /// <summary>Whether to render pictorial values.</summary>
+    public bool? ShowPictorialValues { get; set; }
+
+    /// <summary>Maximum number of word cloud terms.</summary>
+    public int? WordCloudMaximumTerms { get; set; }
+}

--- a/ChartForgeX/Simple/ChartScatter.cs
+++ b/ChartForgeX/Simple/ChartScatter.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Scatter chart definition.</summary>
+public sealed class ChartScatter : ChartDefinition {
+    /// <summary>X values.</summary>
+    public IList<double> X { get; }
+
+    /// <summary>Y values.</summary>
+    public IList<double> Y { get; }
+
+    /// <summary>Point color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a scatter chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="x">X data points.</param>
+    /// <param name="y">Y data points.</param>
+    /// <param name="color">Optional point color.</param>
+    public ChartScatter(string name, IList<double> x, IList<double> y, ChartColor? color = null) : base(ChartDefinitionType.Scatter, name) {
+        X = x;
+        Y = y;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartTheme.cs
+++ b/ChartForgeX/Simple/ChartTheme.cs
@@ -1,0 +1,14 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>
+/// Available chart themes.
+/// </summary>
+public enum ChartTheme
+{
+    /// <summary>Use the default ChartForgeX report style.</summary>
+    Default,
+    /// <summary>Apply the dark theme.</summary>
+    Dark,
+    /// <summary>Apply the light theme.</summary>
+    Light
+}

--- a/ChartForgeX/Simple/ChartWordCloud.cs
+++ b/ChartForgeX/Simple/ChartWordCloud.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Word cloud term definition.</summary>
+public sealed class ChartWordCloud : ChartDefinition {
+    /// <summary>Term weight.</summary>
+    public double Weight { get; }
+
+    /// <summary>Term color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a word cloud term definition.</summary>
+    /// <param name="text">Term text.</param>
+    /// <param name="weight">Term weight.</param>
+    /// <param name="color">Optional term color.</param>
+    public ChartWordCloud(string text, double weight, ChartColor? color = null) : base(ChartDefinitionType.WordCloud, text) {
+        Weight = weight;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/Charts.cs
+++ b/ChartForgeX/Simple/Charts.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using ChartForgeX;
+using ChartForgeX.Primitives;
+using CfxChart = ChartForgeX.Core.Chart;
+using CfxHeatmapScale = ChartForgeX.Core.ChartHeatmapScale;
+using CfxLegendPosition = ChartForgeX.Core.ChartLegendPosition;
+using CfxPictorialItem = ChartForgeX.Core.ChartPictorialItem;
+using CfxPictorialShape = ChartForgeX.Core.ChartPictorialShape;
+using CfxPieLabelContent = ChartForgeX.Core.ChartPieSliceLabelContent;
+using CfxProgressItem = ChartForgeX.Core.ChartProgressItem;
+using CfxTheme = ChartForgeX.Themes.ChartTheme;
+using CfxBubble = ChartForgeX.Core.ChartBubble;
+using CfxWordCloudItem = ChartForgeX.Core.ChartWordCloudItem;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Chart generation helpers.</summary>
+public static class Charts {
+
+    /// <summary>Generate a chart based on provided definitions.</summary>
+    public static void Generate(
+        IEnumerable<ChartDefinition> definitions,
+        string filePath,
+        int width = 600,
+        int height = 400,
+        ChartBarOptions? barOptions = null,
+        string? xTitle = null,
+        string? yTitle = null,
+        bool showGrid = false,
+        ChartTheme theme = ChartTheme.Default,
+        IEnumerable<ChartAnnotation>? annotations = null,
+        ChartColor? background = null,
+        ChartRenderOptions? options = null) {
+        if (definitions is null) throw new ArgumentNullException(nameof(definitions));
+        var list = definitions.ToList();
+        if (list.Count == 0) throw new ArgumentException("No chart definitions provided", nameof(definitions));
+
+        var type = list[0].Type;
+        if (list.Any(d => d.Type != type)) {
+            throw new ArgumentException("Mixed chart definition types provided. All chart definitions must have the same ChartDefinitionType.", nameof(definitions));
+        }
+
+        var chart = CfxChart.Create()
+            .WithSize(width, height)
+            .WithTheme(CreateTheme(theme, background))
+            .WithGrid(showGrid);
+
+        if (background.HasValue) {
+            chart.WithTransparentBackground(false);
+        }
+
+        if (!string.IsNullOrEmpty(xTitle)) {
+            chart.WithXAxis(xTitle!);
+        }
+
+        if (!string.IsNullOrEmpty(yTitle)) {
+            chart.WithYAxis(yTitle!);
+        }
+
+        ApplyRenderOptions(chart, options);
+
+        switch (type) {
+            case ChartDefinitionType.Bar:
+                foreach (var bar in list.Cast<ChartBar>()) {
+                    chart.AddBar(bar.Name, BuildIndexedPoints(bar.Value), bar.Color);
+                }
+                if (barOptions?.ShowValuesAboveBars == true) {
+                    chart.WithDataLabels();
+                }
+                break;
+            case ChartDefinitionType.Line:
+                foreach (var line in list.Cast<ChartLine>()) {
+                    var points = BuildIndexedPoints(line.Value);
+                    if (line.Smooth) {
+                        chart.AddSmoothLine(line.Name, points, line.Color);
+                    } else {
+                        chart.AddLine(line.Name, points, line.Color);
+                    }
+
+                    if (line.MarkerShape != ChartMarkerShape.None && line.MarkerSize.HasValue) {
+                        chart.Options.Theme.MarkerRadius = Math.Max(0, line.MarkerSize.Value / 2d);
+                    }
+                }
+                break;
+            case ChartDefinitionType.Area:
+                foreach (var area in list.Cast<ChartArea>()) {
+                    chart.AddSmoothArea(area.Name, BuildIndexedPoints(area.Value), area.Color);
+                }
+                break;
+            case ChartDefinitionType.Scatter:
+                foreach (var scatter in list.Cast<ChartScatter>()) {
+                    chart.AddScatter(scatter.Name, BuildXYPoints(scatter.X, scatter.Y), scatter.Color);
+                }
+                break;
+            case ChartDefinitionType.Bubble:
+                foreach (var bubble in list.Cast<ChartBubble>()) {
+                    chart.AddBubble(bubble.Name, BuildBubbles(bubble.X, bubble.Y, bubble.Size), bubble.Color);
+                }
+                break;
+            case ChartDefinitionType.Polar:
+                foreach (var polar in list.Cast<ChartPolar>()) {
+                    chart.AddRadar(polar.Name, BuildXYPoints(polar.Angle, polar.Value), polar.Color);
+                }
+                break;
+            case ChartDefinitionType.PolarArea:
+                foreach (var polar in list.Cast<ChartPolar>()) {
+                    chart.AddPolarArea(polar.Name, BuildXYPoints(polar.Angle, polar.Value));
+                }
+                break;
+            case ChartDefinitionType.Pie:
+                chart.WithXLabels(list.Select(d => d.Name).ToArray());
+                chart.AddPie("Values", list.Cast<ChartPie>().Select((pie, index) => new ChartPoint(index + 1, pie.Value)));
+                ApplyPointColors(chart, list.Cast<ChartPie>().Select(pie => pie.Color).ToArray());
+                break;
+            case ChartDefinitionType.Donut:
+                chart.WithXLabels(list.Select(d => d.Name).ToArray());
+                chart.AddDonut("Values", list.Cast<ChartDonut>().Select((donut, index) => new ChartPoint(index + 1, donut.Value)));
+                ApplyPointColors(chart, list.Cast<ChartDonut>().Select(donut => donut.Color).ToArray());
+                break;
+            case ChartDefinitionType.Radial:
+                chart.AddRadialBar("Values", list.Cast<ChartRadial>().Select((radial, index) => new ChartPoint(index + 1, Clamp(radial.Value, 0, 100))));
+                ApplyPointColors(chart, list.Cast<ChartRadial>().Select(radial => radial.Color).ToArray());
+                break;
+            case ChartDefinitionType.Gauge:
+                var gauge = RequireSingle<ChartGauge>(list, type);
+                chart.AddGauge(gauge.Name, gauge.Value, gauge.Minimum, gauge.Maximum, gauge.Color);
+                break;
+            case ChartDefinitionType.Circle:
+                var circle = RequireSingle<ChartCircle>(list, type);
+                chart.AddCircle(circle.Name, circle.Value, circle.Minimum, circle.Maximum, circle.Color);
+                break;
+            case ChartDefinitionType.ProgressBar:
+                chart.AddProgressBars("Values", list.Cast<ChartProgress>().Select(progress => new CfxProgressItem(progress.Name, progress.Value, progress.Color)), options?.ProgressMaximum ?? 100);
+                break;
+            case ChartDefinitionType.Pictorial:
+                chart.AddPictorial("Values", list.Cast<ChartPictorial>().Select(item => new CfxPictorialItem(item.Name, item.Value, item.Color)), ResolvePictorialShape(options?.PictorialSymbol));
+                break;
+            case ChartDefinitionType.WordCloud:
+                chart.AddWordCloud("Values", list.Cast<ChartWordCloud>().Select(item => new CfxWordCloudItem(item.Name, item.Weight, item.Color)));
+                break;
+            case ChartDefinitionType.Heatmap:
+                foreach (var map in list.Cast<ChartHeatmap>()) {
+                    AddHeatmap(chart, map);
+                }
+                break;
+            case ChartDefinitionType.Histogram:
+                foreach (var hist in list.Cast<ChartHistogram>()) {
+                    chart.AddHistogram(hist.Name, hist.Values, ResolveBinCount(hist));
+                }
+                break;
+        }
+
+        if (annotations is not null) {
+            foreach (var ann in annotations) {
+                chart.AddVerticalLine(ann.X, ann.Text);
+            }
+        }
+
+        filePath = Path.GetFullPath(filePath);
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        SaveChart(chart, filePath);
+    }
+
+    private static CfxTheme CreateTheme(ChartTheme theme, ChartColor? background) {
+        var chartTheme = theme == ChartTheme.Dark ? CfxTheme.ReportDark() : CfxTheme.ReportLight();
+        if (background.HasValue) {
+            var color = background.Value;
+            chartTheme.Background = color;
+            chartTheme.CardBackground = color;
+            chartTheme.PlotBackground = WithAlpha(color, color.A);
+        }
+
+        return chartTheme;
+    }
+
+    private static void ApplyRenderOptions(CfxChart chart, ChartRenderOptions? options) {
+        if (options == null) {
+            return;
+        }
+
+        if (options.Palette != null && options.Palette.Count > 0) {
+            chart.WithPalette(options.Palette.ToArray());
+        }
+        if (options.ShowLegend.HasValue) chart.WithLegend(options.ShowLegend.Value);
+        if (options.ShowPointLegend.HasValue) chart.WithPointLegend(options.ShowPointLegend.Value);
+        if (options.LegendPosition.HasValue) chart.WithLegendPosition(ResolveLegendPosition(options.LegendPosition.Value));
+        if (options.ShowHeader.HasValue) chart.WithHeader(options.ShowHeader.Value);
+        if (options.ShowCard.HasValue) chart.WithCard(options.ShowCard.Value);
+        if (options.ShowPlotBackground.HasValue) chart.WithPlotBackground(options.ShowPlotBackground.Value);
+        if (options.TransparentBackground.HasValue) chart.WithTransparentBackground(options.TransparentBackground.Value);
+        if (options.ShowAxes.HasValue) chart.WithAxes(options.ShowAxes.Value);
+        if (options.ShowXAxis.HasValue) chart.WithXAxisVisible(options.ShowXAxis.Value);
+        if (options.ShowYAxis.HasValue) chart.WithYAxisVisible(options.ShowYAxis.Value);
+        if (options.ShowAxisLines.HasValue) chart.WithAxisLines(options.ShowAxisLines.Value);
+        if (options.ShowGrid.HasValue) chart.WithGrid(options.ShowGrid.Value);
+        if (options.ShowDataLabels.HasValue) chart.WithDataLabels(options.ShowDataLabels.Value);
+        if (options.TickCount.HasValue) chart.WithTickCount(options.TickCount.Value);
+        if (options.XAxisMinimum.HasValue && options.XAxisMaximum.HasValue) chart.WithXAxisBounds(options.XAxisMinimum.Value, options.XAxisMaximum.Value);
+        if (options.YAxisMinimum.HasValue && options.YAxisMaximum.HasValue) chart.WithYAxisBounds(options.YAxisMinimum.Value, options.YAxisMaximum.Value);
+        if (options.HeatmapScale.HasValue) chart.WithHeatmapScale(ResolveHeatmapScale(options.HeatmapScale.Value));
+        if (options.ShowHeatmapScale.HasValue) chart.WithHeatmapScaleLegend(options.ShowHeatmapScale.Value);
+        if (options.ShowHeatmapColumnLabels.HasValue) chart.WithHeatmapColumnLabels(options.ShowHeatmapColumnLabels.Value);
+        if (options.ShowDonutCenterLabel.HasValue) chart.WithDonutCenterLabel(options.ShowDonutCenterLabel.Value);
+        if (options.DonutInnerRadiusRatio.HasValue) chart.WithDonutInnerRadiusRatio(options.DonutInnerRadiusRatio.Value);
+        if (!string.IsNullOrWhiteSpace(options.DonutCenterValue) || !string.IsNullOrWhiteSpace(options.DonutCenterLabel)) chart.WithDonutCenterText(options.DonutCenterValue, options.DonutCenterLabel);
+        if (options.PieLabelContent.HasValue) chart.WithPieSliceLabelContent(ResolvePieLabelContent(options.PieLabelContent.Value));
+        if (options.ShowRadialBarCenterLabel.HasValue) chart.WithRadialBarCenterLabel(options.ShowRadialBarCenterLabel.Value);
+        if (options.ShowCircleStatusLabel.HasValue) chart.WithCircleStatusLabel(options.ShowCircleStatusLabel.Value);
+        if (options.ProgressMaximum.HasValue) chart.WithProgressMaximum(options.ProgressMaximum.Value);
+        if (options.ShowProgressValues.HasValue) chart.WithProgressValues(options.ShowProgressValues.Value);
+        if (options.ShowProgressHandles.HasValue) chart.WithProgressHandles(options.ShowProgressHandles.Value);
+        if (options.ProgressBarThicknessRatio.HasValue) chart.WithProgressBarThickness(options.ProgressBarThicknessRatio.Value);
+        if (options.PictorialSymbol.HasValue) chart.WithPictorialShape(ResolvePictorialShape(options.PictorialSymbol.Value));
+        if (options.PictorialColumns.HasValue) chart.WithPictorialColumns(options.PictorialColumns.Value);
+        if (options.PictorialMaximum.HasValue) chart.WithPictorialMaximum(options.PictorialMaximum.Value);
+        if (options.ShowPictorialValues.HasValue) chart.WithPictorialValues(options.ShowPictorialValues.Value);
+        if (options.WordCloudMaximumTerms.HasValue) chart.WithWordCloudMaximumTerms(options.WordCloudMaximumTerms.Value);
+    }
+
+    private static ChartPoint[] BuildIndexedPoints(IList<double> values) {
+        var points = new ChartPoint[values.Count];
+        for (var i = 0; i < values.Count; i++) {
+            points[i] = new ChartPoint(i + 1, values[i]);
+        }
+
+        return points;
+    }
+
+    private static ChartPoint[] BuildXYPoints(IList<double> x, IList<double> y) {
+        var count = Math.Min(x.Count, y.Count);
+        var points = new ChartPoint[count];
+        for (var i = 0; i < count; i++) {
+            points[i] = new ChartPoint(x[i], y[i]);
+        }
+
+        return points;
+    }
+
+    private static CfxBubble[] BuildBubbles(IList<double> x, IList<double> y, IList<double> size) {
+        var count = Math.Min(Math.Min(x.Count, y.Count), size.Count);
+        var bubbles = new CfxBubble[count];
+        for (var i = 0; i < count; i++) {
+            bubbles[i] = new CfxBubble(x[i], y[i], Math.Max(0.001, size[i]));
+        }
+
+        return bubbles;
+    }
+
+    private static void AddHeatmap(CfxChart chart, ChartHeatmap map) {
+        var rows = map.Data.GetLength(0);
+        var columns = map.Data.GetLength(1);
+        for (var row = 0; row < rows; row++) {
+            var points = new ChartPoint[columns];
+            for (var column = 0; column < columns; column++) {
+                points[column] = new ChartPoint(column + 1, map.Data[row, column]);
+            }
+
+            chart.AddHeatmapRow(map.Name + " " + (row + 1).ToString(CultureInfo.InvariantCulture), points);
+        }
+    }
+
+    private static void ApplyPointColors(CfxChart chart, ChartColor?[] colors) {
+        if (chart.Series.Count == 0) {
+            return;
+        }
+
+        for (var i = 0; i < colors.Length; i++) {
+            var color = colors[i];
+            if (color.HasValue) {
+                chart.Series[0].WithPointColor(i, color.Value);
+            }
+        }
+    }
+
+    private static T RequireSingle<T>(IList<ChartDefinition> definitions, ChartDefinitionType type) where T : ChartDefinition {
+        if (definitions.Count != 1) {
+            throw new ArgumentException(type + " charts require exactly one definition.", nameof(definitions));
+        }
+
+        return (T)definitions[0];
+    }
+
+    private static CfxLegendPosition ResolveLegendPosition(ChartLegendPosition position) {
+        switch (position) {
+            case ChartLegendPosition.Top:
+                return CfxLegendPosition.Top;
+            case ChartLegendPosition.Left:
+                return CfxLegendPosition.Left;
+            case ChartLegendPosition.Right:
+                return CfxLegendPosition.Right;
+            default:
+                return CfxLegendPosition.Bottom;
+        }
+    }
+
+    private static CfxHeatmapScale ResolveHeatmapScale(ChartHeatmapColorScale scale) {
+        switch (scale) {
+            case ChartHeatmapColorScale.Semantic:
+                return CfxHeatmapScale.Semantic;
+            default:
+                return CfxHeatmapScale.Sequential;
+        }
+    }
+
+    private static CfxPictorialShape ResolvePictorialShape(ChartPictorialSymbol? shape) {
+        switch (shape) {
+            case ChartPictorialSymbol.Square:
+                return CfxPictorialShape.Square;
+            case ChartPictorialSymbol.Diamond:
+                return CfxPictorialShape.Diamond;
+            case ChartPictorialSymbol.Triangle:
+                return CfxPictorialShape.Triangle;
+            case ChartPictorialSymbol.Star:
+                return CfxPictorialShape.Star;
+            case ChartPictorialSymbol.Person:
+                return CfxPictorialShape.Person;
+            default:
+                return CfxPictorialShape.Circle;
+        }
+    }
+
+    private static CfxPieLabelContent ResolvePieLabelContent(ChartPieLabelContent content) {
+        switch (content) {
+            case ChartPieLabelContent.Value:
+                return CfxPieLabelContent.Value;
+            case ChartPieLabelContent.Percent:
+                return CfxPieLabelContent.Percent;
+            case ChartPieLabelContent.LabelAndValue:
+                return CfxPieLabelContent.LabelAndValue;
+            case ChartPieLabelContent.LabelAndPercent:
+                return CfxPieLabelContent.LabelAndPercent;
+            default:
+                return CfxPieLabelContent.Label;
+        }
+    }
+
+    private static int ResolveBinCount(ChartHistogram histogram) {
+        if (!histogram.BinSize.HasValue || histogram.Values.Length == 0) {
+            return 10;
+        }
+
+        var min = histogram.Values.Min();
+        var max = histogram.Values.Max();
+        if (Math.Abs(max - min) < 0.000001) {
+            return 1;
+        }
+
+        return Math.Max(1, (int)Math.Ceiling((max - min) / histogram.BinSize.Value));
+    }
+
+    private static void SaveChart(CfxChart chart, string filePath) {
+        var extension = Path.GetExtension(filePath).ToLowerInvariant();
+        if (extension == ".svg") {
+            File.WriteAllText(filePath, chart.ToSvg(), Encoding.UTF8);
+        } else if (extension == ".html" || extension == ".htm") {
+            File.WriteAllText(filePath, chart.ToHtmlPage(), Encoding.UTF8);
+        } else {
+            chart.SavePng(filePath);
+        }
+    }
+
+    private static ChartColor WithAlpha(ChartColor color, byte alpha) => ChartColor.FromRgba(color.R, color.G, color.B, alpha);
+
+    private static double Clamp(double value, double min, double max) {
+        if (value < min) return min;
+        if (value > max) return max;
+        return value;
+    }
+}


### PR DESCRIPTION
## Summary\n- Add a dependency-free ChartForgeX.Simple chart definition API for host libraries and PowerShell adapters\n- Support common chart families, render options, transparent backgrounds, palettes, annotations, and SVG/HTML/PNG output dispatch\n- Add smoke coverage for the simple API rendering path\n\n## Validation\n- dotnet test ChartForgeX.Tests\\ChartForgeX.Tests.csproj -c Debug\n- dotnet build ChartForgeX\\ChartForgeX.csproj -c Debug