### PR TITLE
Relax package metadata smoke assertions

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/RepositoryQualityTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/RepositoryQualityTests.cs
@@ -231,8 +231,8 @@ internal static partial class SmokeTests {
         Assert(HasXmlProperty(libraryProject, "IncludeSymbols", "true"), "Package should include symbol package generation.");
         Assert(HasXmlProperty(libraryProject, "SymbolPackageFormat", "snupkg"), "Package symbols should use snupkg format.");
         var releaseNotes = GetXmlValue(libraryProject, "PackageReleaseNotes");
-        Assert(releaseNotes.Contains("SVG", StringComparison.OrdinalIgnoreCase) && releaseNotes.Contains("PNG", StringComparison.OrdinalIgnoreCase) && releaseNotes.Contains("validation", StringComparison.OrdinalIgnoreCase), "Package release notes should summarize renderer coverage and validation work.");
-        Assert(releaseNotes.Contains("brand kits", StringComparison.OrdinalIgnoreCase) && releaseNotes.Contains("pictorial", StringComparison.OrdinalIgnoreCase) && releaseNotes.Contains("word cloud", StringComparison.OrdinalIgnoreCase), "Package release notes should summarize the current chart and styling surface.");
+        Assert(ContainsMetadataConcepts(releaseNotes, "SVG", "PNG", "validation"), "Package release notes should summarize renderer coverage and validation work.");
+        Assert(ContainsMetadataConcepts(releaseNotes, "brand kit", "pictorial", "word cloud"), "Package release notes should summarize the current chart and styling surface.");
         Assert(File.Exists(Path.Combine(FindRepositoryRoot(), "CONTRIBUTING.md")), "Repository should include contribution guidance.");
         Assert(File.Exists(Path.Combine(FindRepositoryRoot(), "TODO.md")), "Repository should include centralized follow-up guidance.");
         Assert(File.Exists(Path.Combine(FindRepositoryRoot(), "AGENTS.md")), "Repository should include agent guidance.");
@@ -506,5 +506,30 @@ internal static partial class SmokeTests {
             Assert(text.Contains("if: runner.os == 'Linux'", StringComparison.Ordinal), "GitHub Actions workflows should keep Linux package provisioning off Windows and macOS runners: " + Path.GetFileName(workflow));
             Assert(text.Contains("chartforgex-packages-${{ matrix.runner }}", StringComparison.Ordinal) && text.Contains("chartforgex-example-gallery-${{ matrix.runner }}", StringComparison.Ordinal), "GitHub Actions matrix jobs should upload OS-specific artifact names: " + Path.GetFileName(workflow));
         }
+    }
+
+    private static bool ContainsMetadataConcepts(string value, params string[] concepts) {
+        var normalizedValue = NormalizeMetadataText(value);
+        foreach (var concept in concepts) {
+            if (!normalizedValue.Contains(NormalizeMetadataText(concept), StringComparison.Ordinal)) return false;
+        }
+
+        return true;
+    }
+
+    private static string NormalizeMetadataText(string value) {
+        var normalized = new System.Text.StringBuilder(value.Length);
+        var previousWasSpace = true;
+        foreach (var character in value) {
+            if (char.IsLetterOrDigit(character)) {
+                normalized.Append(char.ToLowerInvariant(character));
+                previousWasSpace = false;
+            } else if (!previousWasSpace) {
+                normalized.Append(' ');
+                previousWasSpace = true;
+            }
+        }
+
+        return normalized.ToString().TrimEnd();
     }
 }


### PR DESCRIPTION
## Summary
- Normalize package release-note text before checking required metadata concepts
- Keep the existing renderer, validation, styling, and package metadata requirements intact while allowing harmless NuGet wording differences like hyphenation

## Validation
- dotnet test .\ChartForgeX.sln -c Release --filter "FullyQualifiedName~SmokeSuiteTests"
- ./Build.ps1 -Configuration Release
- Verified PR #54 release notes satisfy the normalized concept checks
