### PR TITLE
Add simple chart definition API

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
@@ -1,0 +1,175 @@
+using ChartForgeX;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Simple;
+using System;
+using System.IO;
+using SimpleChartAnnotationDefinition = ChartForgeX.Simple.ChartAnnotationDefinition;
+using SimpleChartBubbleSeries = ChartForgeX.Simple.ChartBubbleSeries;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void SimpleChartApiRendersCommonDefinitions() {
+        var output = Path.Combine(Path.GetTempPath(), "chartforgex-simple-chart-api-" + Guid.NewGuid().ToString("N") + ".png");
+        Charts.Generate(
+            new ChartDefinition[] {
+                new ChartLine("CPU", new double[] { 35, 42, 58, 61 }, ChartColor.FromHex("#22C55E"), smooth: true)
+            },
+            output,
+            width: 420,
+            height: 260,
+            showGrid: true,
+            options: new ChartRenderOptions {
+                TransparentBackground = true,
+                ShowLegend = true,
+                Palette = new[] { ChartColor.FromHex("#22C55E"), ChartColor.FromHex("#3B82F6") }
+            });
+
+        Assert(File.Exists(output), "Simple chart API should save PNG output.");
+        Assert(new FileInfo(output).Length > 64, "Simple chart API should render non-empty PNG output.");
+
+        var chart = Charts.Build(
+            new ChartDefinition[] {
+                new ChartBar("Memory", new double[] { 62, 68, 71 }, ChartColor.FromHex("#3B82F6"))
+            },
+            width: 360,
+            height: 220,
+            options: new ChartRenderOptions {
+                UseOverlay = true,
+                ShowLegend = true,
+                ShowDataLabels = true
+            });
+
+        Assert(chart.Series.Count == 1, "Simple chart API should build native ChartForgeX charts without saving first.");
+        Assert(chart.Options.TransparentBackground, "Overlay mode should keep the raster background transparent.");
+        Assert(!chart.Options.ShowCard, "Overlay mode should remove card chrome.");
+        Assert(!chart.Options.ShowPlotBackground, "Overlay mode should remove plot background chrome.");
+        Assert(chart.Options.ShowLegend, "Explicit simple options should still override overlay defaults.");
+        Assert(chart.ToSvg().Contains("<svg", StringComparison.Ordinal), "Simple-built charts should render through native ChartForgeX extensions.");
+
+        var svgOutput = Path.Combine(Path.GetTempPath(), "chartforgex-simple-chart-api-" + Guid.NewGuid().ToString("N") + ".svg");
+        Charts.Save(chart, svgOutput);
+        Assert(File.Exists(svgOutput), "Simple chart API should save native ChartForgeX charts by extension.");
+        Assert(File.ReadAllText(svgOutput).Contains("<svg", StringComparison.Ordinal), "Simple chart API should save SVG output.");
+
+        var polarArea = Charts.Build(new ChartDefinition[] { new ChartPolarArea("Coverage", new double[] { 12, 18, 9 }, new[] { "Low", "Medium", "High" }) });
+        Assert(polarArea.Series[0].Kind == ChartSeriesKind.PolarArea, "Simple polar area definitions should build native polar area series.");
+        Assert(polarArea.Options.XAxisLabels.Count == 3, "Simple polar area definitions should preserve optional segment labels.");
+
+        var radar = Charts.Build(new ChartDefinition[] { new ChartRadar("Coverage", new double[] { 1, 2, 3 }, new double[] { 12, 18, 9 }) });
+        Assert(radar.Series[0].Kind == ChartSeriesKind.Radar, "Simple radar definitions should build native radar series.");
+
+        var area = Charts.Build(new ChartDefinition[] { new ChartArea("Coverage", new double[] { 2, 4, 3 }) });
+        Assert(!area.Series[0].Smooth, "Simple area definitions should create plain area series unless a smooth area model exists.");
+
+        var histograms = Charts.Build(new ChartDefinition[] {
+            new ChartHistogram("Fast", new double[] { 1, 2, 3, 4 }, 1),
+            new ChartHistogram("Slow", new double[] { 3, 4, 5, 6 }, 1)
+        });
+        Assert(histograms.Series.Count == 2, "Simple histogram definitions should support comparable multi-series histograms.");
+        Assert(histograms.Options.XAxisLabels.Count == histograms.Series[0].Points.Count && histograms.Options.XAxisLabels.Count == histograms.Series[1].Points.Count, "Simple histogram definitions should use one shared binning scheme.");
+
+        var points = ChartPoints.FromValues(10, 20, 30);
+        Assert(points.Length == 3 && points[0].X == 1 && points[2].Y == 30, "Core point helpers should create one-based chart points from raw values.");
+
+        var bubbles = ChartBubbles.FromXYSize(new[] { 1d, 2d }, new[] { 3d, 4d }, new[] { 5d, 6d });
+        Assert(bubbles.Length == 2 && bubbles[1].Size == 6, "Core bubble helpers should create native bubble values from raw sequences.");
+
+        var annotated = Charts.Build(
+            new ChartDefinition[] { new ChartLine("CPU", new double[] { 35, 42, 58 }) },
+            annotations: new[] { new SimpleChartAnnotationDefinition(3, 58, "Peak", arrow: true) });
+        Assert(annotated.Series.Any(series => string.Equals(series.SemanticRole, "point-callout", StringComparison.Ordinal)), "Arrow annotations should preserve point-callout semantics.");
+
+        var existing = Chart.Create();
+        var background = ChartColor.FromRgba(1, 2, 3, 200);
+        Charts.ApplySettings(existing, background: background);
+        Assert(existing.Options.Theme.Background.Equals(background), "ApplySettings should apply the requested background color.");
+        Assert(!existing.Options.TransparentBackground, "ApplySettings should disable transparency when a concrete background is requested.");
+
+        var reusableTheme = ChartForgeX.Themes.ChartTheme.ReportLight();
+        var originalBackground = reusableTheme.Background;
+        var themed = Charts.Build(
+            new ChartDefinition[] { new ChartLine("CPU", new double[] { 1, 2, 3 }, markerSize: 8) },
+            theme: reusableTheme,
+            background: ChartColor.FromRgba(10, 20, 30, 220));
+        Assert(themed.Options.Theme.Background.Equals(ChartColor.FromRgba(10, 20, 30, 220)), "Simple chart background should apply to the chart theme copy.");
+        Assert(reusableTheme.Background.Equals(originalBackground), "Simple chart background should not mutate caller-provided themes.");
+        Assert(Math.Abs(reusableTheme.MarkerRadius - ChartForgeX.Themes.ChartTheme.ReportLight().MarkerRadius) < 0.000001, "Simple chart marker settings should not mutate caller-provided themes.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(new ChartDefinition[] { new ChartScatter("Bad", new double[] { 1, 2 }, new double[] { 1 }) }),
+            "Simple scatter definitions should reject mismatched X/Y value counts instead of truncating data.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(new ChartDefinition[] { null! }),
+            "Simple chart definitions should reject null definition entries with a clear argument error.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(
+                new ChartDefinition[] { new ChartLine("CPU", new double[] { 35, 42, 58 }) },
+                annotations: new SimpleChartAnnotationDefinition[] { null! }),
+            "Simple annotations should reject null entries with a clear argument error.");
+
+        AssertThrows<ArgumentOutOfRangeException>(
+            () => Charts.Build(new ChartDefinition[] { new ChartRadial("Bad", 140) }),
+            "Simple radial definitions should reject out-of-range percentage values instead of clamping.");
+
+        AssertThrows<ArgumentOutOfRangeException>(
+            () => Charts.Build(new ChartDefinition[] { new SimpleChartBubbleSeries("Bad", new double[] { 1 }, new double[] { 1 }, new double[] { 0 }) }),
+            "Simple bubble definitions should reject non-positive bubble sizes instead of coercing them.");
+
+        AssertThrows<ArgumentException>(
+            () => ChartPoints.FromXY(new double[] { 1, 2 }, new double[] { 1 }),
+            "Core point helpers should reject mismatched X/Y value counts.");
+
+        AssertThrows<ArgumentOutOfRangeException>(
+            () => Charts.Build(new ChartDefinition[] { new ChartHistogram("Bad", new double[] { 1, 2 }, 0) }),
+            "Simple histogram definitions should reject non-positive bin sizes.");
+
+        AssertThrows<ArgumentNullException>(
+            () => Charts.Build(new ChartDefinition[] { new ChartHistogram("Bad", null!) }),
+            "Simple histogram definitions should reject null values with a clear argument error.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(new ChartDefinition[] {
+                new ChartHistogram("A", new double[] { 1, 2, 3 }, 1),
+                new ChartHistogram("B", new double[] { 1, 2, 3 }, 2)
+            }),
+            "Simple histogram definitions should reject conflicting bin sizes instead of rendering incomparable bins.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(new ChartDefinition[] { new ChartRadar("Bad", new double[] { 1, 2 }, new double[] { 12, 18 }) }),
+            "Simple radar definitions should reject fewer than three categories before render-time validation.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(new ChartDefinition[] {
+                new ChartPolarArea("A", new double[] { 1, 2, 3 }),
+                new ChartPolarArea("B", new double[] { 4, 5, 6 })
+            }),
+            "Simple polar area definitions should reject multiple definitions before render-time validation.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(
+                new ChartDefinition[] { new ChartPie("A", 1), new ChartPie("B", 2) },
+                annotations: new[] { new SimpleChartAnnotationDefinition(1, 1, "Peak", arrow: true) }),
+            "Simple point-callout annotations should reject exclusive chart kinds before render-time validation.");
+
+        var radial = Charts.Build(new ChartDefinition[] {
+            new ChartRadial("Healthy", 70),
+            new ChartRadial("Warning", 20)
+        });
+        Assert(radial.Options.XAxisLabels.Count == 2 && radial.Options.XAxisLabels[0].Text == "Healthy", "Simple radial definitions should preserve item labels.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(new ChartDefinition[] {
+                new ChartLine("A", new double[] { 1, 2 }, markerSize: 8),
+                new ChartLine("B", new double[] { 2, 3 }, markerSize: 14)
+            }),
+            "Simple line definitions should reject conflicting marker sizes because marker radius is chart-wide.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Save(chart, Path.Combine(Path.GetTempPath(), "chartforgex-simple-chart-api-" + Guid.NewGuid().ToString("N") + ".txt")),
+            "Simple save helper should reject unsupported file extensions.");
+    }
+}

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -142,6 +142,7 @@ internal static partial class SmokeTests {
         ("Small multiple grids render static HTML", SmallMultipleGridRendersStaticHtml),
         ("Shared y-axis handles secondary-only charts", SharedYAxisHandlesSecondaryOnlyCharts),
         ("Shared axes ignore progress bars", SharedAxesIgnoreProgressBars),
+        ("Simple chart API renders common definitions", SimpleChartApiRendersCommonDefinitions),
         ("Chart grids support panel spans", ChartGridsSupportPanelSpans),
         ("Chart grid headers support text styles", ChartGridHeadersSupportTextStyles),
         ("Visual blocks render tables lists and metric cards", VisualBlocksRenderTablesListsAndMetricCards),

--- a/ChartForgeX/Core/ChartBubbles.cs
+++ b/ChartForgeX/Core/ChartBubbles.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ChartForgeX.Core;
+
+/// <summary>
+/// Creates common <see cref="ChartBubble"/> sequences for bubble charts.
+/// </summary>
+public static class ChartBubbles {
+    /// <summary>
+    /// Creates bubble values from matching x, y, and size sequences.
+    /// </summary>
+    /// <param name="x">The x values.</param>
+    /// <param name="y">The y values.</param>
+    /// <param name="size">The bubble size values.</param>
+    /// <returns>Bubble values using the supplied x, y, and size values.</returns>
+    public static ChartBubble[] FromXYSize(IEnumerable<double> x, IEnumerable<double> y, IEnumerable<double> size) {
+        if (x is null) throw new ArgumentNullException(nameof(x));
+        if (y is null) throw new ArgumentNullException(nameof(y));
+        if (size is null) throw new ArgumentNullException(nameof(size));
+
+        var xValues = x.ToArray();
+        var yValues = y.ToArray();
+        var sizeValues = size.ToArray();
+        if (xValues.Length == 0) throw new ArgumentException("Bubble values cannot be empty.", nameof(x));
+        if (xValues.Length != yValues.Length || xValues.Length != sizeValues.Length) throw new ArgumentException("Bubble X, Y, and Size values must contain the same number of items.", nameof(size));
+
+        var bubbles = new ChartBubble[xValues.Length];
+        for (var i = 0; i < xValues.Length; i++) {
+            if (sizeValues[i] <= 0) throw new ArgumentOutOfRangeException(nameof(size), sizeValues[i], "Bubble size values must be greater than zero.");
+            bubbles[i] = new ChartBubble(xValues[i], yValues[i], sizeValues[i]);
+        }
+
+        return bubbles;
+    }
+}

--- a/ChartForgeX/Core/ChartPoints.cs
+++ b/ChartForgeX/Core/ChartPoints.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Core;
+
+/// <summary>
+/// Creates common <see cref="ChartPoint"/> sequences for chart series.
+/// </summary>
+public static class ChartPoints {
+    /// <summary>
+    /// Creates one-based x/y points from y values.
+    /// </summary>
+    /// <param name="values">The y values.</param>
+    /// <returns>Chart points with x values starting at one.</returns>
+    public static ChartPoint[] FromValues(params double[] values) => FromValues((IEnumerable<double>)values);
+
+    /// <summary>
+    /// Creates one-based x/y points from y values.
+    /// </summary>
+    /// <param name="values">The y values.</param>
+    /// <returns>Chart points with x values starting at one.</returns>
+    public static ChartPoint[] FromValues(IEnumerable<double> values) {
+        if (values is null) throw new ArgumentNullException(nameof(values));
+        var array = values.ToArray();
+        if (array.Length == 0) throw new ArgumentException("Chart values cannot be empty.", nameof(values));
+
+        var points = new ChartPoint[array.Length];
+        for (var i = 0; i < array.Length; i++) {
+            points[i] = new ChartPoint(i + 1, array[i]);
+        }
+
+        return points;
+    }
+
+    /// <summary>
+    /// Creates x/y points from matching x and y value sequences.
+    /// </summary>
+    /// <param name="x">The x values.</param>
+    /// <param name="y">The y values.</param>
+    /// <returns>Chart points using the supplied x and y values.</returns>
+    public static ChartPoint[] FromXY(IEnumerable<double> x, IEnumerable<double> y) {
+        if (x is null) throw new ArgumentNullException(nameof(x));
+        if (y is null) throw new ArgumentNullException(nameof(y));
+
+        var xValues = x.ToArray();
+        var yValues = y.ToArray();
+        if (xValues.Length == 0) throw new ArgumentException("X values cannot be empty.", nameof(x));
+        if (xValues.Length != yValues.Length) throw new ArgumentException("X and Y values must contain the same number of items.", nameof(y));
+
+        var points = new ChartPoint[xValues.Length];
+        for (var i = 0; i < xValues.Length; i++) {
+            points[i] = new ChartPoint(xValues[i], yValues[i]);
+        }
+
+        return points;
+    }
+}

--- a/ChartForgeX/Simple/ChartAnnotationDefinition.cs
+++ b/ChartForgeX/Simple/ChartAnnotationDefinition.cs
@@ -1,0 +1,28 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Chart annotation definition.</summary>
+public sealed class ChartAnnotationDefinition {
+    /// <summary>X coordinate of the annotation.</summary>
+    public double X { get; }
+
+    /// <summary>Y coordinate of the annotation.</summary>
+    public double Y { get; }
+
+    /// <summary>Annotation text.</summary>
+    public string Text { get; }
+
+    /// <summary>Render the annotation as a point callout at X/Y instead of a vertical line at X.</summary>
+    public bool Arrow { get; }
+
+    /// <summary>Create an annotation.</summary>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="text">Annotation text.</param>
+    /// <param name="arrow">Render as a point callout at X/Y.</param>
+    public ChartAnnotationDefinition(double x, double y, string text, bool arrow = false) {
+        X = x;
+        Y = y;
+        Text = text;
+        Arrow = arrow;
+    }
+}

--- a/ChartForgeX/Simple/ChartArea.cs
+++ b/ChartForgeX/Simple/ChartArea.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Area chart definition.</summary>
+public sealed class ChartArea : ChartDefinition {
+    /// <summary>Area values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Fill color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create an area chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Y values.</param>
+    /// <param name="color">Optional fill color.</param>
+    public ChartArea(string name, IList<double> value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartBar.cs
+++ b/ChartForgeX/Simple/ChartBar.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Bar chart definition.</summary>
+public sealed class ChartBar : ChartDefinition {
+    /// <summary>Bar values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Bar color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a bar chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Bar values.</param>
+    /// <param name="color">Optional bar color.</param>
+    public ChartBar(string name, IList<double> value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartBubbleSeries.cs
+++ b/ChartForgeX/Simple/ChartBubbleSeries.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Bubble chart definition.</summary>
+public sealed class ChartBubbleSeries : ChartDefinition {
+    /// <summary>X values.</summary>
+    public IList<double> X { get; }
+
+    /// <summary>Y values.</summary>
+    public IList<double> Y { get; }
+
+    /// <summary>Size values.</summary>
+    public IList<double> Size { get; }
+
+    /// <summary>Bubble color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a bubble chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="x">X data points.</param>
+    /// <param name="y">Y data points.</param>
+    /// <param name="size">Bubble sizes.</param>
+    /// <param name="color">Optional bubble color.</param>
+    public ChartBubbleSeries(string name, IList<double> x, IList<double> y, IList<double> size, ChartColor? color = null) : base(name) {
+        X = x;
+        Y = y;
+        Size = size;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartCircle.cs
+++ b/ChartForgeX/Simple/ChartCircle.cs
@@ -1,0 +1,31 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Circle status chart definition.</summary>
+public sealed class ChartCircle : ChartDefinition {
+    /// <summary>Circle value.</summary>
+    public double Value { get; }
+
+    /// <summary>Circle minimum.</summary>
+    public double Minimum { get; }
+
+    /// <summary>Circle maximum.</summary>
+    public double Maximum { get; }
+
+    /// <summary>Circle color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a circle status chart definition.</summary>
+    /// <param name="name">Circle label.</param>
+    /// <param name="value">Circle value.</param>
+    /// <param name="minimum">Circle minimum.</param>
+    /// <param name="maximum">Circle maximum.</param>
+    /// <param name="color">Optional circle color.</param>
+    public ChartCircle(string name, double value, double minimum = 0, double maximum = 100, ChartColor? color = null) : base(name) {
+        Value = value;
+        Minimum = minimum;
+        Maximum = maximum;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartDefinition.cs
+++ b/ChartForgeX/Simple/ChartDefinition.cs
@@ -1,0 +1,13 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Base class for chart definitions.</summary>
+public abstract class ChartDefinition {
+    /// <summary>Chart name.</summary>
+    public string Name { get; }
+
+    /// <summary>Initializes a chart definition.</summary>
+    /// <param name="name">Chart name.</param>
+    protected ChartDefinition(string name) {
+        Name = name;
+    }
+}

--- a/ChartForgeX/Simple/ChartDonut.cs
+++ b/ChartForgeX/Simple/ChartDonut.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Donut chart slice definition.</summary>
+public sealed class ChartDonut : ChartDefinition {
+    /// <summary>Slice value.</summary>
+    public double Value { get; }
+
+    /// <summary>Slice color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a donut slice definition.</summary>
+    /// <param name="name">Slice label.</param>
+    /// <param name="value">Slice value.</param>
+    /// <param name="color">Optional slice color.</param>
+    public ChartDonut(string name, double value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartGauge.cs
+++ b/ChartForgeX/Simple/ChartGauge.cs
@@ -1,0 +1,31 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Gauge chart definition.</summary>
+public sealed class ChartGauge : ChartDefinition {
+    /// <summary>Gauge value.</summary>
+    public double Value { get; }
+
+    /// <summary>Gauge minimum.</summary>
+    public double Minimum { get; }
+
+    /// <summary>Gauge maximum.</summary>
+    public double Maximum { get; }
+
+    /// <summary>Gauge color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a gauge chart definition.</summary>
+    /// <param name="name">Gauge label.</param>
+    /// <param name="value">Gauge value.</param>
+    /// <param name="minimum">Gauge minimum.</param>
+    /// <param name="maximum">Gauge maximum.</param>
+    /// <param name="color">Optional gauge color.</param>
+    public ChartGauge(string name, double value, double minimum = 0, double maximum = 100, ChartColor? color = null) : base(name) {
+        Value = value;
+        Minimum = minimum;
+        Maximum = maximum;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartHeatmap.cs
+++ b/ChartForgeX/Simple/ChartHeatmap.cs
@@ -1,0 +1,14 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Heatmap chart definition.</summary>
+public sealed class ChartHeatmap : ChartDefinition {
+    /// <summary>Values of the heatmap.</summary>
+    public double[,] Data { get; }
+
+    /// <summary>Create a heatmap definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="data">Heatmap values.</param>
+    public ChartHeatmap(string name, double[,] data) : base(name) {
+        Data = data;
+    }
+}

--- a/ChartForgeX/Simple/ChartHistogram.cs
+++ b/ChartForgeX/Simple/ChartHistogram.cs
@@ -1,0 +1,19 @@
+namespace ChartForgeX.Simple;
+
+/// <summary>Histogram chart definition.</summary>
+public sealed class ChartHistogram : ChartDefinition {
+    /// <summary>Values for the histogram.</summary>
+    public double[] Values { get; }
+
+    /// <summary>Size of each bin.</summary>
+    public int? BinSize { get; }
+
+    /// <summary>Create a histogram definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="values">Input values.</param>
+    /// <param name="binSize">Optional bin size.</param>
+    public ChartHistogram(string name, double[] values, int? binSize = null) : base(name) {
+        Values = values;
+        BinSize = binSize;
+    }
+}

--- a/ChartForgeX/Simple/ChartLine.cs
+++ b/ChartForgeX/Simple/ChartLine.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Line chart definition.</summary>
+public sealed class ChartLine : ChartDefinition {
+    /// <summary>Line values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Line color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Optional size of the markers.</summary>
+    public float? MarkerSize { get; }
+
+    /// <summary>Render the line using a smooth curve.</summary>
+    public bool Smooth { get; }
+
+    /// <summary>Create a line chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Line values.</param>
+    /// <param name="color">Optional line color.</param>
+    /// <param name="markerSize">Optional marker size.</param>
+    /// <param name="smooth">Render as a smooth curve.</param>
+    public ChartLine(
+        string name,
+        IList<double> value,
+        ChartColor? color = null,
+        float? markerSize = null,
+        bool smooth = false) : base(name) {
+        Value = value;
+        Color = color;
+        MarkerSize = markerSize;
+        Smooth = smooth;
+    }
+}

--- a/ChartForgeX/Simple/ChartPictorial.cs
+++ b/ChartForgeX/Simple/ChartPictorial.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Pictorial chart row definition.</summary>
+public sealed class ChartPictorial : ChartDefinition {
+    /// <summary>Pictorial value.</summary>
+    public double Value { get; }
+
+    /// <summary>Pictorial color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a pictorial chart row definition.</summary>
+    /// <param name="name">Pictorial label.</param>
+    /// <param name="value">Pictorial value.</param>
+    /// <param name="color">Optional pictorial color.</param>
+    public ChartPictorial(string name, double value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartPie.cs
+++ b/ChartForgeX/Simple/ChartPie.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Pie chart definition.</summary>
+public sealed class ChartPie : ChartDefinition {
+    /// <summary>Slice value.</summary>
+    public double Value { get; }
+
+    /// <summary>Slice color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a pie slice definition.</summary>
+    /// <param name="name">Slice label.</param>
+    /// <param name="value">Slice value.</param>
+    /// <param name="color">Optional slice color.</param>
+    public ChartPie(string name, double value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartPolarArea.cs
+++ b/ChartForgeX/Simple/ChartPolarArea.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Polar area chart definition.</summary>
+public sealed class ChartPolarArea : ChartDefinition {
+    /// <summary>Segment values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Optional segment labels.</summary>
+    public IList<string>? Labels { get; }
+
+    /// <summary>Create a polar area chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Segment values.</param>
+    /// <param name="labels">Optional segment labels.</param>
+    public ChartPolarArea(string name, IList<double> value, IList<string>? labels = null) : base(name) {
+        Value = value;
+        Labels = labels;
+    }
+}

--- a/ChartForgeX/Simple/ChartProgress.cs
+++ b/ChartForgeX/Simple/ChartProgress.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Progress-bar chart row definition.</summary>
+public sealed class ChartProgress : ChartDefinition {
+    /// <summary>Progress value.</summary>
+    public double Value { get; }
+
+    /// <summary>Progress color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a progress-bar row definition.</summary>
+    /// <param name="name">Progress label.</param>
+    /// <param name="value">Progress value.</param>
+    /// <param name="color">Optional progress color.</param>
+    public ChartProgress(string name, double value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartRadar.cs
+++ b/ChartForgeX/Simple/ChartRadar.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Radar chart definition.</summary>
+public sealed class ChartRadar : ChartDefinition {
+    /// <summary>Category values.</summary>
+    public IList<double> Category { get; }
+
+    /// <summary>Radar values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Line color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a radar chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="category">Category values.</param>
+    /// <param name="value">Radar values.</param>
+    /// <param name="color">Optional line color.</param>
+    public ChartRadar(string name, IList<double> category, IList<double> value, ChartColor? color = null) : base(name) {
+        Category = category;
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartRadial.cs
+++ b/ChartForgeX/Simple/ChartRadial.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Radial gauge chart definition.</summary>
+public sealed class ChartRadial : ChartDefinition {
+    /// <summary>Gauge value.</summary>
+    public double Value { get; }
+
+    /// <summary>Gauge color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a radial gauge definition.</summary>
+    /// <param name="name">Gauge label.</param>
+    /// <param name="value">Gauge value.</param>
+    /// <param name="color">Optional gauge color.</param>
+    public ChartRadial(string name, double value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartRenderOptions.cs
+++ b/ChartForgeX/Simple/ChartRenderOptions.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Renderer-neutral chart options for simple ChartForgeX definitions.</summary>
+public sealed class ChartRenderOptions {
+    /// <summary>Optional color palette used by series and point-based charts.</summary>
+    public IList<ChartColor>? Palette { get; set; }
+
+    /// <summary>Whether to render the legend.</summary>
+    public bool? ShowLegend { get; set; }
+
+    /// <summary>Whether legends for point-based charts list individual points.</summary>
+    public bool? ShowPointLegend { get; set; }
+
+    /// <summary>Legend placement.</summary>
+    public ChartLegendPosition? LegendPosition { get; set; }
+
+    /// <summary>Whether to render the chart header.</summary>
+    public bool? ShowHeader { get; set; }
+
+    /// <summary>Whether to render the outer chart card.</summary>
+    public bool? ShowCard { get; set; }
+
+    /// <summary>Whether to render the plot background.</summary>
+    public bool? ShowPlotBackground { get; set; }
+
+    /// <summary>Whether the chart background should be transparent.</summary>
+    public bool? TransparentBackground { get; set; }
+
+    /// <summary>Whether to apply ChartForgeX overlay mode for transparent composition on another image or surface.</summary>
+    public bool? UseOverlay { get; set; }
+
+    /// <summary>Whether overlay mode should keep the chart title and subtitle visible.</summary>
+    public bool OverlayShowHeader { get; set; }
+
+    /// <summary>Whether to render axes and tick labels.</summary>
+    public bool? ShowAxes { get; set; }
+
+    /// <summary>Whether to render the x-axis.</summary>
+    public bool? ShowXAxis { get; set; }
+
+    /// <summary>Whether to render the y-axis.</summary>
+    public bool? ShowYAxis { get; set; }
+
+    /// <summary>Whether to render axis rules.</summary>
+    public bool? ShowAxisLines { get; set; }
+
+    /// <summary>Whether to render grid lines.</summary>
+    public bool? ShowGrid { get; set; }
+
+    /// <summary>Whether to render data labels for supported charts.</summary>
+    public bool? ShowDataLabels { get; set; }
+
+    /// <summary>Preferred number of axis ticks.</summary>
+    public int? TickCount { get; set; }
+
+    /// <summary>Explicit x-axis minimum.</summary>
+    public double? XAxisMinimum { get; set; }
+
+    /// <summary>Explicit x-axis maximum.</summary>
+    public double? XAxisMaximum { get; set; }
+
+    /// <summary>Explicit y-axis minimum.</summary>
+    public double? YAxisMinimum { get; set; }
+
+    /// <summary>Explicit y-axis maximum.</summary>
+    public double? YAxisMaximum { get; set; }
+
+    /// <summary>Heatmap color scale.</summary>
+    public ChartHeatmapScale? HeatmapScale { get; set; }
+
+    /// <summary>Whether to render the heatmap scale legend.</summary>
+    public bool? ShowHeatmapScale { get; set; }
+
+    /// <summary>Whether to render heatmap column labels.</summary>
+    public bool? ShowHeatmapColumnLabels { get; set; }
+
+    /// <summary>Whether to render the donut center label.</summary>
+    public bool? ShowDonutCenterLabel { get; set; }
+
+    /// <summary>Donut hole radius ratio.</summary>
+    public double? DonutInnerRadiusRatio { get; set; }
+
+    /// <summary>Optional donut center value text.</summary>
+    public string? DonutCenterValue { get; set; }
+
+    /// <summary>Optional donut center label text.</summary>
+    public string? DonutCenterLabel { get; set; }
+
+    /// <summary>Pie and donut slice label content.</summary>
+    public ChartPieSliceLabelContent? PieLabelContent { get; set; }
+
+    /// <summary>Whether to render radial-bar center labels.</summary>
+    public bool? ShowRadialBarCenterLabel { get; set; }
+
+    /// <summary>Whether to render circle status labels.</summary>
+    public bool? ShowCircleStatusLabel { get; set; }
+
+    /// <summary>Progress maximum used by progress-bar charts.</summary>
+    public double? ProgressMaximum { get; set; }
+
+    /// <summary>Whether to render progress-bar values.</summary>
+    public bool? ShowProgressValues { get; set; }
+
+    /// <summary>Whether to render progress-bar handles.</summary>
+    public bool? ShowProgressHandles { get; set; }
+
+    /// <summary>Progress-bar thickness ratio.</summary>
+    public double? ProgressBarThicknessRatio { get; set; }
+
+    /// <summary>Pictorial chart symbol.</summary>
+    public ChartPictorialShape? PictorialShape { get; set; }
+
+    /// <summary>Number of pictorial symbols per row.</summary>
+    public int? PictorialColumns { get; set; }
+
+    /// <summary>Optional pictorial maximum.</summary>
+    public double? PictorialMaximum { get; set; }
+
+    /// <summary>Whether to render pictorial values.</summary>
+    public bool? ShowPictorialValues { get; set; }
+
+    /// <summary>Maximum number of word cloud terms.</summary>
+    public int? WordCloudMaximumTerms { get; set; }
+}

--- a/ChartForgeX/Simple/ChartScatter.cs
+++ b/ChartForgeX/Simple/ChartScatter.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Scatter chart definition.</summary>
+public sealed class ChartScatter : ChartDefinition {
+    /// <summary>X values.</summary>
+    public IList<double> X { get; }
+
+    /// <summary>Y values.</summary>
+    public IList<double> Y { get; }
+
+    /// <summary>Point color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a scatter chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="x">X data points.</param>
+    /// <param name="y">Y data points.</param>
+    /// <param name="color">Optional point color.</param>
+    public ChartScatter(string name, IList<double> x, IList<double> y, ChartColor? color = null) : base(name) {
+        X = x;
+        Y = y;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartWordCloud.cs
+++ b/ChartForgeX/Simple/ChartWordCloud.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Word cloud term definition.</summary>
+public sealed class ChartWordCloud : ChartDefinition {
+    /// <summary>Term weight.</summary>
+    public double Weight { get; }
+
+    /// <summary>Term color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a word cloud term definition.</summary>
+    /// <param name="text">Term text.</param>
+    /// <param name="weight">Term weight.</param>
+    /// <param name="color">Optional term color.</param>
+    public ChartWordCloud(string text, double weight, ChartColor? color = null) : base(text) {
+        Weight = weight;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/Charts.cs
+++ b/ChartForgeX/Simple/Charts.cs
@@ -1,0 +1,458 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using ChartForgeX;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using CfxChart = ChartForgeX.Core.Chart;
+using CfxPictorialItem = ChartForgeX.Core.ChartPictorialItem;
+using CfxProgressItem = ChartForgeX.Core.ChartProgressItem;
+using CfxTheme = ChartForgeX.Themes.ChartTheme;
+using CfxBubble = ChartForgeX.Core.ChartBubble;
+using CfxWordCloudItem = ChartForgeX.Core.ChartWordCloudItem;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Chart generation helpers.</summary>
+public static class Charts {
+    /// <summary>Create a ChartForgeX chart with simple render settings applied.</summary>
+    public static CfxChart Create(
+        int width = 600,
+        int height = 400,
+        string? xTitle = null,
+        string? yTitle = null,
+        bool showGrid = false,
+        CfxTheme? theme = null,
+        ChartColor? background = null,
+        ChartRenderOptions? options = null) {
+        var chart = CfxChart.Create()
+            .WithSize(width, height)
+            .WithTheme(CreateTheme(theme))
+            .WithGrid(showGrid);
+
+        ApplySettings(chart, xTitle, yTitle, background, options);
+        return chart;
+    }
+
+    /// <summary>Build a ChartForgeX chart from simple chart definitions.</summary>
+    public static CfxChart Build(
+        IEnumerable<ChartDefinition> definitions,
+        int width = 600,
+        int height = 400,
+        string? xTitle = null,
+        string? yTitle = null,
+        bool showGrid = false,
+        CfxTheme? theme = null,
+        IEnumerable<ChartAnnotationDefinition>? annotations = null,
+        ChartColor? background = null,
+        ChartRenderOptions? options = null) {
+        if (definitions is null) throw new ArgumentNullException(nameof(definitions));
+        var list = definitions.ToList();
+        if (list.Count == 0) throw new ArgumentException("No chart definitions provided", nameof(definitions));
+        if (list.Any(definition => definition is null)) throw new ArgumentException("Chart definitions cannot contain null entries.", nameof(definitions));
+
+        var type = list[0].GetType();
+        if (list.Any(d => d.GetType() != type)) {
+            throw new ArgumentException("Mixed chart definition types provided. All chart definitions must have the same concrete definition type.", nameof(definitions));
+        }
+
+        var chart = Create(width, height, xTitle, yTitle, showGrid, theme, background, options);
+
+        if (type == typeof(ChartBar)) {
+            foreach (var bar in list.Cast<ChartBar>()) chart.AddBar(bar.Name, BuildIndexedPoints(bar.Value), bar.Color);
+        } else if (type == typeof(ChartLine)) {
+            ApplySharedLineMarkerSize(chart, list.Cast<ChartLine>());
+            foreach (var line in list.Cast<ChartLine>()) {
+                var points = BuildIndexedPoints(line.Value);
+                if (line.Smooth) chart.AddSmoothLine(line.Name, points, line.Color);
+                else chart.AddLine(line.Name, points, line.Color);
+            }
+        } else if (type == typeof(ChartArea)) {
+            foreach (var area in list.Cast<ChartArea>()) chart.AddArea(area.Name, BuildIndexedPoints(area.Value), area.Color);
+        } else if (type == typeof(ChartScatter)) {
+            foreach (var scatter in list.Cast<ChartScatter>()) chart.AddScatter(scatter.Name, BuildXYPoints(scatter.X, scatter.Y), scatter.Color);
+        } else if (type == typeof(ChartBubbleSeries)) {
+            foreach (var bubble in list.Cast<ChartBubbleSeries>()) chart.AddBubble(bubble.Name, BuildBubbles(bubble.X, bubble.Y, bubble.Size), bubble.Color);
+        } else if (type == typeof(ChartRadar)) {
+            AddRadarDefinitions(chart, list.Cast<ChartRadar>());
+        } else if (type == typeof(ChartPolarArea)) {
+            var polar = RequireSingle<ChartPolarArea>(list);
+            ApplyLabels(chart, polar.Labels);
+            chart.AddPolarArea(polar.Name, BuildIndexedPoints(polar.Value));
+        } else if (type == typeof(ChartPie)) {
+            chart.WithXLabels(list.Select(d => d.Name).ToArray());
+            chart.AddPie("Values", list.Cast<ChartPie>().Select((pie, index) => new ChartPoint(index + 1, pie.Value)));
+            ApplyPointColors(chart, list.Cast<ChartPie>().Select(pie => pie.Color).ToArray());
+        } else if (type == typeof(ChartDonut)) {
+            chart.WithXLabels(list.Select(d => d.Name).ToArray());
+            chart.AddDonut("Values", list.Cast<ChartDonut>().Select((donut, index) => new ChartPoint(index + 1, donut.Value)));
+            ApplyPointColors(chart, list.Cast<ChartDonut>().Select(donut => donut.Color).ToArray());
+        } else if (type == typeof(ChartRadial)) {
+            chart.WithXLabels(list.Select(d => d.Name).ToArray());
+            chart.AddRadialBar("Values", list.Cast<ChartRadial>().Select((radial, index) => new ChartPoint(index + 1, RequirePercent(radial.Value, radial.Name))));
+            ApplyPointColors(chart, list.Cast<ChartRadial>().Select(radial => radial.Color).ToArray());
+        } else if (type == typeof(ChartGauge)) {
+            var gauge = RequireSingle<ChartGauge>(list);
+            chart.AddGauge(gauge.Name, gauge.Value, gauge.Minimum, gauge.Maximum, gauge.Color);
+        } else if (type == typeof(ChartCircle)) {
+            var circle = RequireSingle<ChartCircle>(list);
+            chart.AddCircle(circle.Name, circle.Value, circle.Minimum, circle.Maximum, circle.Color);
+        } else if (type == typeof(ChartProgress)) {
+            chart.AddProgressBars("Values", list.Cast<ChartProgress>().Select(progress => new CfxProgressItem(progress.Name, progress.Value, progress.Color)), options?.ProgressMaximum ?? 100);
+        } else if (type == typeof(ChartPictorial)) {
+            chart.AddPictorial("Values", list.Cast<ChartPictorial>().Select(item => new CfxPictorialItem(item.Name, item.Value, item.Color)), options?.PictorialShape ?? ChartPictorialShape.Circle);
+        } else if (type == typeof(ChartWordCloud)) {
+            chart.AddWordCloud("Values", list.Cast<ChartWordCloud>().Select(item => new CfxWordCloudItem(item.Name, item.Weight, item.Color)));
+        } else if (type == typeof(ChartHeatmap)) {
+            foreach (var map in list.Cast<ChartHeatmap>()) AddHeatmap(chart, map);
+        } else if (type == typeof(ChartHistogram)) {
+            AddHistogramDefinitions(chart, list.Cast<ChartHistogram>());
+        } else {
+            throw new ArgumentException("Unsupported chart definition type '" + type.FullName + "'.", nameof(definitions));
+        }
+
+        if (annotations is not null) {
+            foreach (var ann in annotations) {
+                if (ann is null) {
+                    throw new ArgumentException("Chart annotations cannot contain null entries.", nameof(annotations));
+                }
+
+                if (ann.Arrow) {
+                    if (HasExclusiveSeries(chart)) {
+                        throw new ArgumentException("Point-callout annotations cannot be used with exclusive chart kinds because they add a scatter series.", nameof(annotations));
+                    }
+
+                    chart.AddPointCallout(ann.Text, ann.X, ann.Y);
+                } else {
+                    chart.AddVerticalLine(ann.X, ann.Text);
+                }
+            }
+        }
+
+        return chart;
+    }
+
+    /// <summary>Generate and save a chart based on provided definitions.</summary>
+    public static void Generate(
+        IEnumerable<ChartDefinition> definitions,
+        string filePath,
+        int width = 600,
+        int height = 400,
+        string? xTitle = null,
+        string? yTitle = null,
+        bool showGrid = false,
+        CfxTheme? theme = null,
+        IEnumerable<ChartAnnotationDefinition>? annotations = null,
+        ChartColor? background = null,
+        ChartRenderOptions? options = null) {
+        var chart = Build(definitions, width, height, xTitle, yTitle, showGrid, theme, annotations, background, options);
+        Save(chart, filePath);
+    }
+
+    /// <summary>Apply simple render settings to an existing ChartForgeX chart.</summary>
+    public static void ApplySettings(CfxChart chart, string? xTitle = null, string? yTitle = null, ChartColor? background = null, ChartRenderOptions? options = null) {
+        if (chart is null) throw new ArgumentNullException(nameof(chart));
+
+        if (background.HasValue) {
+            ApplyBackground(chart.Options.Theme, background.Value);
+            chart.WithTransparentBackground(false);
+        }
+
+        if (!string.IsNullOrEmpty(xTitle)) {
+            chart.WithXAxis(xTitle!);
+        }
+
+        if (!string.IsNullOrEmpty(yTitle)) {
+            chart.WithYAxis(yTitle!);
+        }
+
+        ApplyRenderOptions(chart, options);
+    }
+
+    /// <summary>Save a ChartForgeX chart to SVG, HTML, or PNG based on the file extension.</summary>
+    public static void Save(CfxChart chart, string filePath) {
+        if (chart is null) throw new ArgumentNullException(nameof(chart));
+        filePath = Path.GetFullPath(filePath);
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        SaveChart(chart, filePath);
+    }
+
+    private static CfxTheme CreateTheme(CfxTheme? theme) => theme?.Clone() ?? CfxTheme.ReportLight();
+
+    private static void ApplyRenderOptions(CfxChart chart, ChartRenderOptions? options) {
+        if (options == null) {
+            return;
+        }
+
+        if (options.Palette != null && options.Palette.Count > 0) {
+            chart.WithPalette(options.Palette.ToArray());
+        }
+        if (options.UseOverlay.HasValue && options.UseOverlay.Value) chart.WithOverlay(options.OverlayShowHeader);
+        if (options.ShowLegend.HasValue) chart.WithLegend(options.ShowLegend.Value);
+        if (options.ShowPointLegend.HasValue) chart.WithPointLegend(options.ShowPointLegend.Value);
+        if (options.LegendPosition.HasValue) chart.WithLegendPosition(options.LegendPosition.Value);
+        if (options.ShowHeader.HasValue) chart.WithHeader(options.ShowHeader.Value);
+        if (options.ShowCard.HasValue) chart.WithCard(options.ShowCard.Value);
+        if (options.ShowPlotBackground.HasValue) chart.WithPlotBackground(options.ShowPlotBackground.Value);
+        if (options.TransparentBackground.HasValue) chart.WithTransparentBackground(options.TransparentBackground.Value);
+        if (options.ShowAxes.HasValue) chart.WithAxes(options.ShowAxes.Value);
+        if (options.ShowXAxis.HasValue) chart.WithXAxisVisible(options.ShowXAxis.Value);
+        if (options.ShowYAxis.HasValue) chart.WithYAxisVisible(options.ShowYAxis.Value);
+        if (options.ShowAxisLines.HasValue) chart.WithAxisLines(options.ShowAxisLines.Value);
+        if (options.ShowGrid.HasValue) chart.WithGrid(options.ShowGrid.Value);
+        if (options.ShowDataLabels.HasValue) chart.WithDataLabels(options.ShowDataLabels.Value);
+        if (options.TickCount.HasValue) chart.WithTickCount(options.TickCount.Value);
+        if (options.XAxisMinimum.HasValue && options.XAxisMaximum.HasValue) chart.WithXAxisBounds(options.XAxisMinimum.Value, options.XAxisMaximum.Value);
+        if (options.YAxisMinimum.HasValue && options.YAxisMaximum.HasValue) chart.WithYAxisBounds(options.YAxisMinimum.Value, options.YAxisMaximum.Value);
+        if (options.HeatmapScale.HasValue) chart.WithHeatmapScale(options.HeatmapScale.Value);
+        if (options.ShowHeatmapScale.HasValue) chart.WithHeatmapScaleLegend(options.ShowHeatmapScale.Value);
+        if (options.ShowHeatmapColumnLabels.HasValue) chart.WithHeatmapColumnLabels(options.ShowHeatmapColumnLabels.Value);
+        if (options.ShowDonutCenterLabel.HasValue) chart.WithDonutCenterLabel(options.ShowDonutCenterLabel.Value);
+        if (options.DonutInnerRadiusRatio.HasValue) chart.WithDonutInnerRadiusRatio(options.DonutInnerRadiusRatio.Value);
+        if (!string.IsNullOrWhiteSpace(options.DonutCenterValue) || !string.IsNullOrWhiteSpace(options.DonutCenterLabel)) chart.WithDonutCenterText(options.DonutCenterValue, options.DonutCenterLabel);
+        if (options.PieLabelContent.HasValue) chart.WithPieSliceLabelContent(options.PieLabelContent.Value);
+        if (options.ShowRadialBarCenterLabel.HasValue) chart.WithRadialBarCenterLabel(options.ShowRadialBarCenterLabel.Value);
+        if (options.ShowCircleStatusLabel.HasValue) chart.WithCircleStatusLabel(options.ShowCircleStatusLabel.Value);
+        if (options.ProgressMaximum.HasValue) chart.WithProgressMaximum(options.ProgressMaximum.Value);
+        if (options.ShowProgressValues.HasValue) chart.WithProgressValues(options.ShowProgressValues.Value);
+        if (options.ShowProgressHandles.HasValue) chart.WithProgressHandles(options.ShowProgressHandles.Value);
+        if (options.ProgressBarThicknessRatio.HasValue) chart.WithProgressBarThickness(options.ProgressBarThicknessRatio.Value);
+        if (options.PictorialShape.HasValue) chart.WithPictorialShape(options.PictorialShape.Value);
+        if (options.PictorialColumns.HasValue) chart.WithPictorialColumns(options.PictorialColumns.Value);
+        if (options.PictorialMaximum.HasValue) chart.WithPictorialMaximum(options.PictorialMaximum.Value);
+        if (options.ShowPictorialValues.HasValue) chart.WithPictorialValues(options.ShowPictorialValues.Value);
+        if (options.WordCloudMaximumTerms.HasValue) chart.WithWordCloudMaximumTerms(options.WordCloudMaximumTerms.Value);
+    }
+
+    private static ChartPoint[] BuildIndexedPoints(IList<double> values) {
+        return ChartPoints.FromValues(values);
+    }
+
+    private static ChartPoint[] BuildXYPoints(IList<double> x, IList<double> y) {
+        return ChartPoints.FromXY(x, y);
+    }
+
+    private static CfxBubble[] BuildBubbles(IList<double> x, IList<double> y, IList<double> size) {
+        return ChartBubbles.FromXYSize(x, y, size);
+    }
+
+    private static void AddHeatmap(CfxChart chart, ChartHeatmap map) {
+        if (map.Data is null) throw new ArgumentException("Heatmap data cannot be null.", nameof(map));
+        var rows = map.Data.GetLength(0);
+        var columns = map.Data.GetLength(1);
+        if (rows == 0 || columns == 0) throw new ArgumentException("Heatmap data cannot be empty.", nameof(map));
+
+        for (var row = 0; row < rows; row++) {
+            var points = new ChartPoint[columns];
+            for (var column = 0; column < columns; column++) {
+                points[column] = new ChartPoint(column + 1, map.Data[row, column]);
+            }
+
+            chart.AddHeatmapRow(map.Name + " " + (row + 1).ToString(CultureInfo.InvariantCulture), points);
+        }
+    }
+
+    private static void AddRadarDefinitions(CfxChart chart, IEnumerable<ChartRadar> definitions) {
+        var series = definitions
+            .Select(radar => new {
+                Radar = radar,
+                Points = BuildXYPoints(radar.Category, radar.Value)
+            })
+            .ToArray();
+
+        var categoryCount = series
+            .SelectMany(item => item.Points.Select(point => point.X))
+            .Distinct()
+            .Count();
+        if (categoryCount < 3) {
+            throw new ArgumentException("Radar charts require at least three categories.", nameof(definitions));
+        }
+
+        foreach (var item in series) {
+            chart.AddRadar(item.Radar.Name, item.Points, item.Radar.Color);
+        }
+    }
+
+    private static void AddHistogramDefinitions(CfxChart chart, IEnumerable<ChartHistogram> definitions) {
+        var histograms = definitions
+            .Select(histogram => new HistogramDefinition(histogram, ValidateHistogramValues(histogram)))
+            .ToArray();
+
+        if (histograms.Length == 0) {
+            return;
+        }
+
+        var binSize = ResolveSharedBinSize(histograms.Select(item => item.Definition));
+        var min = histograms.SelectMany(item => item.Values).Min();
+        var max = histograms.SelectMany(item => item.Values).Max();
+        if (Math.Abs(max - min) < 0.000001) {
+            chart.WithXLabels(FormatHistogramNumber(min));
+            foreach (var histogram in histograms) {
+                chart.AddBar(histogram.Definition.Name, new[] { new ChartPoint(1, histogram.Values.Length) });
+            }
+
+            return;
+        }
+
+        var binCount = binSize.HasValue ? Math.Max(1, (int)Math.Ceiling((max - min) / binSize.Value)) : 10;
+        var width = (max - min) / binCount;
+        var labels = new string[binCount];
+        for (var i = 0; i < binCount; i++) {
+            var start = min + width * i;
+            var end = i == binCount - 1 ? max : start + width;
+            labels[i] = FormatHistogramNumber(start) + "-" + FormatHistogramNumber(end);
+        }
+
+        chart.WithXLabels(labels);
+        foreach (var histogram in histograms) {
+            var counts = new int[binCount];
+            foreach (var value in histogram.Values) {
+                var index = value >= max ? binCount - 1 : (int)Math.Floor((value - min) / width);
+                counts[Math.Max(0, Math.Min(binCount - 1, index))]++;
+            }
+
+            chart.AddBar(histogram.Definition.Name, counts.Select((count, index) => new ChartPoint(index + 1, count)));
+        }
+    }
+
+    private static void ApplyPointColors(CfxChart chart, ChartColor?[] colors) {
+        if (chart.Series.Count == 0) {
+            return;
+        }
+
+        for (var i = 0; i < colors.Length; i++) {
+            var color = colors[i];
+            if (color.HasValue) {
+                chart.Series[0].WithPointColor(i, color.Value);
+            }
+        }
+    }
+
+    private static void ApplyLabels(CfxChart chart, IList<string>? labels) {
+        if (labels is null || labels.Count == 0) {
+            return;
+        }
+
+        chart.WithXLabels(labels.ToArray());
+    }
+
+    private static bool HasExclusiveSeries(CfxChart chart) {
+        foreach (var series in chart.Series) {
+            if (ChartSeriesKindTraits.IsExclusive(series.Kind)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static T RequireSingle<T>(IList<ChartDefinition> definitions) where T : ChartDefinition {
+        if (definitions.Count != 1) {
+            throw new ArgumentException(typeof(T).Name + " charts require exactly one definition.", nameof(definitions));
+        }
+
+        return (T)definitions[0];
+    }
+
+    private static double[] ValidateHistogramValues(ChartHistogram histogram) {
+        if (histogram.Values is null) {
+            throw new ArgumentNullException(nameof(histogram), "Histogram values cannot be null.");
+        }
+
+        if (histogram.Values.Length == 0) {
+            throw new ArgumentException("Histogram values must contain at least one value.", nameof(histogram));
+        }
+
+        for (var i = 0; i < histogram.Values.Length; i++) {
+            if (double.IsNaN(histogram.Values[i]) || double.IsInfinity(histogram.Values[i])) {
+                throw new ArgumentOutOfRangeException(nameof(histogram), histogram.Values[i], "Histogram values must be finite.");
+            }
+        }
+
+        if (histogram.BinSize.HasValue && histogram.BinSize.Value <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(histogram), histogram.BinSize.Value, "Histogram bin size must be greater than zero.");
+        }
+
+        return histogram.Values;
+    }
+
+    private static int? ResolveSharedBinSize(IEnumerable<ChartHistogram> histograms) {
+        int? binSize = null;
+        foreach (var histogram in histograms) {
+            if (!histogram.BinSize.HasValue) {
+                continue;
+            }
+
+            if (binSize.HasValue && binSize.Value != histogram.BinSize.Value) {
+                throw new ArgumentException("Multiple simple histogram definitions must use the same bin size so they share one binning scheme.", nameof(histograms));
+            }
+
+            binSize = histogram.BinSize.Value;
+        }
+
+        return binSize;
+    }
+
+    private static void SaveChart(CfxChart chart, string filePath) {
+        chart.Save(filePath);
+    }
+
+    private static void ApplyBackground(CfxTheme chartTheme, ChartColor color) {
+        chartTheme.Background = color;
+        chartTheme.CardBackground = color;
+        chartTheme.PlotBackground = WithAlpha(color, color.A);
+    }
+
+    private static void ApplySharedLineMarkerSize(CfxChart chart, IEnumerable<ChartLine> lines) {
+        double? markerRadius = null;
+        foreach (var line in lines) {
+            if (line.MarkerSize.HasValue && line.MarkerSize.Value < 0) {
+                throw new ArgumentOutOfRangeException(nameof(line), line.MarkerSize.Value, "Marker size must be zero or greater.");
+            }
+
+            if (!line.MarkerSize.HasValue) {
+                continue;
+            }
+
+            var candidate = Math.Max(0, line.MarkerSize.Value / 2d);
+            if (markerRadius.HasValue && Math.Abs(markerRadius.Value - candidate) > 0.000001) {
+                throw new ArgumentException("ChartForgeX simple line definitions require a shared marker size for all line series because marker radius is chart-wide.", nameof(lines));
+            }
+
+            markerRadius = candidate;
+        }
+
+        if (markerRadius.HasValue) {
+            chart.Options.Theme.MarkerRadius = markerRadius.Value;
+        }
+    }
+
+    private static double RequirePercent(double value, string name) {
+        if (value < 0 || value > 100) {
+            throw new ArgumentOutOfRangeException(nameof(value), value, "Radial values must be between zero and one hundred. Invalid series: " + name);
+        }
+
+        return value;
+    }
+
+    private static ChartColor WithAlpha(ChartColor color, byte alpha) => ChartColor.FromRgba(color.R, color.G, color.B, alpha);
+
+    private static string FormatHistogramNumber(double value) => value.ToString("0.###", CultureInfo.InvariantCulture);
+
+    private readonly struct HistogramDefinition {
+        public HistogramDefinition(ChartHistogram definition, double[] values) {
+            Definition = definition;
+            Values = values;
+        }
+
+        public ChartHistogram Definition { get; }
+
+        public double[] Values { get; }
+    }
+}

--- a/ChartForgeX/Themes/ChartTheme.cs
+++ b/ChartForgeX/Themes/ChartTheme.cs
@@ -200,6 +200,40 @@ public sealed partial class ChartTheme {
     }
 
     /// <summary>
+    /// Creates an independent copy of this theme.
+    /// </summary>
+    /// <returns>A copied chart theme.</returns>
+    public ChartTheme Clone() => new() {
+        Background = Background,
+        CardBackground = CardBackground,
+        PlotBackground = PlotBackground,
+        CardBorder = CardBorder,
+        PlotBorder = PlotBorder,
+        Text = Text,
+        MutedText = MutedText,
+        Grid = Grid,
+        Axis = Axis,
+        Positive = Positive,
+        Warning = Warning,
+        Negative = Negative,
+        Palette = Palette,
+        UseCard = UseCard,
+        CornerRadius = CornerRadius,
+        PlotCornerRadius = PlotCornerRadius,
+        StrokeWidth = StrokeWidth,
+        ShadowOpacity = ShadowOpacity,
+        ShadowColor = ShadowColor,
+        TitleFontSize = TitleFontSize,
+        SubtitleFontSize = SubtitleFontSize,
+        AxisTitleFontSize = AxisTitleFontSize,
+        TickLabelFontSize = TickLabelFontSize,
+        LegendFontSize = LegendFontSize,
+        DataLabelFontSize = DataLabelFontSize,
+        MarkerRadius = MarkerRadius,
+        FontFamily = FontFamily
+    };
+
+    /// <summary>
     /// Applies a default series palette.
     /// </summary>
     /// <param name="colors">The palette colors.</param>

--- a/README.md
+++ b/README.md
@@ -175,6 +175,42 @@ The output API follows one rule: `To*` returns content, `Save*` writes a file, a
 
 `Save(path)` infers `.svg`, `.html`, `.htm`, `.png`, `.bmp`, `.ppm`, `.tiff`, and `.tif`. Unsupported or empty extensions fail before a file is opened. `RasterImageOptions` applies to opaque raster formats; PNG keeps its dedicated renderer path and PNG output-scale options.
 
+## Simple Definitions
+
+`ChartForgeX.Simple` is the supported lightweight construction layer for script, UI, and host libraries that should not own chart DTOs. It only carries deferred chart definitions; enums, themes, rendering options, point helpers, bubble helpers, and output still come from the core ChartForgeX API. The result is a native `ChartForgeX.Core.Chart`, so callers can keep customizing or rendering it with the normal fluent API.
+
+```csharp
+using ChartForgeX;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Simple;
+
+var chart = Charts.Build(
+    new ChartDefinition[] {
+        new ChartLine("CPU", new double[] { 35, 42, 58, 61 }, ChartColor.FromHex("#22C55E"), smooth: true)
+    },
+    width: 420,
+    height: 260,
+    showGrid: true,
+    options: new ChartRenderOptions {
+        UseOverlay = true,
+        ShowLegend = true
+    });
+
+chart.SavePng("cpu-overlay.png");
+chart.SaveSvg("cpu-overlay.svg");
+```
+
+`UseOverlay` applies ChartForgeX transparent composition defaults: transparent background, no card, no plot fill, and quiet axes/grid. Explicit options still win, so callers can turn legends, axes, or data labels back on for wallpaper, report, and image-composition scenarios.
+
+When a host does not need deferred definitions, use core helpers directly:
+
+```csharp
+var direct = Chart.Create()
+    .AddSmoothLine("CPU", ChartPoints.FromValues(35, 42, 58, 61))
+    .AddBubble("Latency", ChartBubbles.FromXYSize(new[] { 1d, 2d }, new[] { 48d, 63d }, new[] { 8d, 14d }));
+```
+
 ## Project Status
 
 ChartForgeX is pre-1.0, but the current public surface is intended to be useful and stable where it models real charting, topology, visual block, rendering, and package concepts. Active follow-up work belongs in `TODO.md`; release notes belong in GitHub Releases and short NuGet package notes.

--- a/README.nuget.md
+++ b/README.nuget.md
@@ -62,6 +62,40 @@ static ChartPoint[] Points(params double[] values) =>
     values.Select((value, index) => new ChartPoint(index, value)).ToArray();
 ```
 
+## Simple Definitions
+
+For hosts that collect chart inputs from scripts, configuration, or UI forms, `ChartForgeX.Simple` provides small deferred definition objects and turns them into native `ChartForgeX.Core.Chart` instances. Simple uses core enums, themes, shapes, render options, point helpers, and bubble helpers instead of mirroring them, so direct ChartForgeX callers can stay on the core API.
+
+```csharp
+using ChartForgeX;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Simple;
+
+var chart = Charts.Build(
+    new ChartDefinition[] {
+        new ChartBar("CPU", new double[] { 32, 48, 61 }, ChartColor.FromHex("#2DD4BF")),
+        new ChartBar("Memory", new double[] { 44, 58, 72 }, ChartColor.FromHex("#60A5FA"))
+    },
+    width: 640,
+    height: 360,
+    xTitle: "Sample",
+    yTitle: "Percent",
+    showGrid: true,
+    options: new ChartRenderOptions {
+        UseOverlay = true,
+        ShowLegend = true,
+        ShowDataLabels = true
+    });
+
+chart.SavePng("wallpaper-overlay.png");
+chart.SaveSvg("wallpaper-overlay.svg");
+```
+
+`UseOverlay` applies the transparent composition preset: no card, no plot fill, no axes/grid by default, and a transparent PNG/SVG background. Individual options such as `ShowLegend`, `ShowGrid`, or `ShowAxes` can still be set explicitly after the preset.
+
+When you do not need deferred host definitions, build directly with helpers such as `ChartPoints.FromValues(...)` and `ChartBubbles.FromXYSize(...)`.
+
 ## Output API
 
 | Need | Use |


### PR DESCRIPTION
## Summary
- Add `ChartForgeX.Simple` definitions for host libraries, scripts, and UI-driven chart inputs.
- Build native `ChartForgeX.Core.Chart` instances from simple definitions, with extension-based save helpers for SVG, HTML, and PNG.
- Expose transparent overlay composition through simple render options and document the supported public surface.

## Validation
- `dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj --configuration Release --no-restore`
- `dotnet build ChartForgeX\ChartForgeX.csproj --configuration Release --no-restore`
- `git diff --check`