### PR TITLE
Expand simple chart definition coverage

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
@@ -70,6 +70,52 @@ internal static partial class SmokeTests {
         Assert(histograms.Series.Count == 2, "Simple histogram definitions should support comparable multi-series histograms.");
         Assert(histograms.Options.XAxisLabels.Count == histograms.Series[0].Points.Count && histograms.Options.XAxisLabels.Count == histograms.Series[1].Points.Count, "Simple histogram definitions should use one shared binning scheme.");
 
+        Assert(
+            Charts.Build(new ChartDefinition[] { new ChartHorizontalBar("Disk", new double[] { 72, 28 }) }).Series[0].Kind == ChartSeriesKind.HorizontalBar,
+            "Simple horizontal bar definitions should build native horizontal bar series.");
+        Assert(
+            Charts.Build(new ChartDefinition[] { new ChartStepLine("Requests", new double[] { 4, 8, 7 }) }).Series[0].Kind == ChartSeriesKind.StepLine,
+            "Simple step line definitions should build native step line series.");
+        Assert(
+            Charts.Build(new ChartDefinition[] { new ChartStepArea("Capacity", new double[] { 4, 8, 7 }) }).Series[0].Kind == ChartSeriesKind.StepArea,
+            "Simple step area definitions should build native step area series.");
+        Assert(
+            Charts.Build(new ChartDefinition[] { new ChartStackedArea("A", new double[] { 2, 3 }), new ChartStackedArea("B", new double[] { 1, 2 }, smooth: true) }).Series.All(series => series.Kind == ChartSeriesKind.StackedArea),
+            "Simple stacked area definitions should build native stacked area series.");
+        Assert(
+            Charts.Build(new ChartDefinition[] { new ChartLollipop("Latency", new double[] { 12, 18, 9 }) }).Series[0].Kind == ChartSeriesKind.Lollipop,
+            "Simple lollipop definitions should build native lollipop series.");
+        Assert(
+            Charts.Build(new ChartDefinition[] { new ChartSlope("Current", 62, 71, "Before", "After") }).Series[0].Kind == ChartSeriesKind.Slope,
+            "Simple slope definitions should build native slope series.");
+
+        var rangeBar = Charts.Build(new ChartDefinition[] { new ChartRangeBar("Maintenance", new double[] { 1, 2 }, new double[] { 2, 4 }, new double[] { 5, 8 }) });
+        Assert(rangeBar.Series[0].Kind == ChartSeriesKind.RangeBar, "Simple range bar definitions should build native range bar series.");
+
+        var rangeBand = Charts.Build(new ChartDefinition[] { new ChartRangeBandSeries("Expected", new double[] { 1, 2 }, new double[] { 8, 9 }, new double[] { 12, 15 }) });
+        Assert(rangeBand.Series[0].Kind == ChartSeriesKind.RangeBand, "Simple range band definitions should build native range band series.");
+
+        var rangeArea = Charts.Build(new ChartDefinition[] { new ChartRangeBandSeries("Expected", new double[] { 1, 2 }, new double[] { 8, 9 }, new double[] { 12, 15 }, area: true, smooth: false) });
+        Assert(rangeArea.Series[0].Kind == ChartSeriesKind.RangeArea && !rangeArea.Series[0].Smooth, "Simple range band definitions should optionally build plain range area series.");
+
+        var boxPlot = Charts.Build(new ChartDefinition[] { new ChartBoxPlotSeries("Latency", new double[] { 1, 2 }, new double[] { 2, 3 }, new double[] { 4, 5 }, new double[] { 6, 7 }, new double[] { 8, 9 }, new double[] { 10, 11 }) });
+        Assert(boxPlot.Series[0].Kind == ChartSeriesKind.BoxPlot, "Simple box plot definitions should build native box plot series.");
+
+        var bullet = Charts.Build(new ChartDefinition[] {
+            new ChartBullet("Servers", 92, 95, rangeEnds: new double[] { 70, 85 }),
+            new ChartBullet("Workstations", 86, 90)
+        });
+        Assert(bullet.Series.Count == 2 && bullet.Series.All(series => series.Kind == ChartSeriesKind.Bullet), "Simple bullet definitions should build native bullet rows.");
+
+        var waterfall = Charts.Build(new ChartDefinition[] { new ChartWaterfall("Change", new double[] { 120, -24, 42 }, new[] { "Start", "Churn", "Expansion" }) });
+        Assert(waterfall.Series[0].Kind == ChartSeriesKind.Waterfall && waterfall.Options.XAxisLabels.Count == 3, "Simple waterfall definitions should build native waterfall series and preserve labels.");
+
+        var funnel = Charts.Build(new ChartDefinition[] { new ChartFunnel("Visitors", 1000), new ChartFunnel("Trials", 220), new ChartFunnel("Customers", 64) });
+        Assert(funnel.Series[0].Kind == ChartSeriesKind.Funnel && funnel.Options.XAxisLabels.Count == 3, "Simple funnel item definitions should build a labeled native funnel chart.");
+
+        var treemap = Charts.Build(new ChartDefinition[] { new ChartTreemap("Servers", 42), new ChartTreemap("Workstations", 120), new ChartTreemap("Laptops", 80) });
+        Assert(treemap.Series[0].Kind == ChartSeriesKind.Treemap && treemap.Options.XAxisLabels.Count == 3, "Simple treemap item definitions should build a labeled native treemap chart.");
+
         var points = ChartPoints.FromValues(10, 20, 30);
         Assert(points.Length == 3 && points[0].X == 1 && points[2].Y == 30, "Core point helpers should create one-based chart points from raw values.");
 
@@ -141,6 +187,14 @@ internal static partial class SmokeTests {
         AssertThrows<ArgumentException>(
             () => Charts.Build(new ChartDefinition[] { new ChartRadar("Bad", new double[] { 1, 2 }, new double[] { 12, 18 }) }),
             "Simple radar definitions should reject fewer than three categories before render-time validation.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(new ChartDefinition[] { new ChartRangeBar("Bad", new double[] { 1, 2 }, new double[] { 1 }, new double[] { 2, 3 }) }),
+            "Simple range bar definitions should reject mismatched interval arrays.");
+
+        AssertThrows<ArgumentOutOfRangeException>(
+            () => Charts.Build(new ChartDefinition[] { new ChartBoxPlotSeries("Bad", new double[] { 1 }, new double[] { 5 }, new double[] { 4 }, new double[] { 3 }, new double[] { 2 }, new double[] { 1 }) }),
+            "Simple box plot definitions should reject unordered summaries.");
 
         AssertThrows<ArgumentException>(
             () => Charts.Build(new ChartDefinition[] {

--- a/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
@@ -95,6 +95,12 @@ internal static partial class SmokeTests {
         });
         Assert(slopeLabels.Options.XAxisLabels[0].Text == "Before" && slopeLabels.Options.XAxisLabels[1].Text == "After", "Simple slope definitions should preserve explicit axis labels even when the first series omits them.");
 
+        var partialSlopeLabels = Charts.Build(new ChartDefinition[] {
+            new ChartSlope("Previous", 52, 61, startLabel: "Before"),
+            new ChartSlope("Current", 62, 71, endLabel: "After")
+        });
+        Assert(partialSlopeLabels.Options.XAxisLabels[0].Text == "Before" && partialSlopeLabels.Options.XAxisLabels[1].Text == "After", "Simple slope definitions should merge compatible partial axis labels.");
+
         var rangeBar = Charts.Build(new ChartDefinition[] { new ChartRangeBar("Maintenance", new double[] { 1, 2 }, new double[] { 2, 4 }, new double[] { 5, 8 }) });
         Assert(rangeBar.Series[0].Kind == ChartSeriesKind.RangeBar, "Simple range bar definitions should build native range bar series.");
 

--- a/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/SimpleChartApiTests.cs
@@ -89,6 +89,12 @@ internal static partial class SmokeTests {
             Charts.Build(new ChartDefinition[] { new ChartSlope("Current", 62, 71, "Before", "After") }).Series[0].Kind == ChartSeriesKind.Slope,
             "Simple slope definitions should build native slope series.");
 
+        var slopeLabels = Charts.Build(new ChartDefinition[] {
+            new ChartSlope("Previous", 52, 61),
+            new ChartSlope("Current", 62, 71, "Before", "After")
+        });
+        Assert(slopeLabels.Options.XAxisLabels[0].Text == "Before" && slopeLabels.Options.XAxisLabels[1].Text == "After", "Simple slope definitions should preserve explicit axis labels even when the first series omits them.");
+
         var rangeBar = Charts.Build(new ChartDefinition[] { new ChartRangeBar("Maintenance", new double[] { 1, 2 }, new double[] { 2, 4 }, new double[] { 5, 8 }) });
         Assert(rangeBar.Series[0].Kind == ChartSeriesKind.RangeBar, "Simple range bar definitions should build native range bar series.");
 
@@ -221,6 +227,13 @@ internal static partial class SmokeTests {
                 new ChartLine("B", new double[] { 2, 3 }, markerSize: 14)
             }),
             "Simple line definitions should reject conflicting marker sizes because marker radius is chart-wide.");
+
+        AssertThrows<ArgumentException>(
+            () => Charts.Build(new ChartDefinition[] {
+                new ChartSlope("A", 1, 2, "Before", "After"),
+                new ChartSlope("B", 3, 4, "Old", "New")
+            }),
+            "Simple slope definitions should reject conflicting explicit axis labels because slope labels are chart-wide.");
 
         AssertThrows<ArgumentException>(
             () => Charts.Save(chart, Path.Combine(Path.GetTempPath(), "chartforgex-simple-chart-api-" + Guid.NewGuid().ToString("N") + ".txt")),

--- a/ChartForgeX/Simple/ChartBoxPlotSeries.cs
+++ b/ChartForgeX/Simple/ChartBoxPlotSeries.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Box plot chart definition.</summary>
+public sealed class ChartBoxPlotSeries : ChartDefinition {
+    /// <summary>X or category values.</summary>
+    public IList<double> X { get; }
+
+    /// <summary>Minimum whisker values.</summary>
+    public IList<double> Minimum { get; }
+
+    /// <summary>First quartile values.</summary>
+    public IList<double> Q1 { get; }
+
+    /// <summary>Median values.</summary>
+    public IList<double> Median { get; }
+
+    /// <summary>Third quartile values.</summary>
+    public IList<double> Q3 { get; }
+
+    /// <summary>Maximum whisker values.</summary>
+    public IList<double> Maximum { get; }
+
+    /// <summary>Box plot color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a box plot chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="x">X or category values.</param>
+    /// <param name="minimum">Minimum whisker values.</param>
+    /// <param name="q1">First quartile values.</param>
+    /// <param name="median">Median values.</param>
+    /// <param name="q3">Third quartile values.</param>
+    /// <param name="maximum">Maximum whisker values.</param>
+    /// <param name="color">Optional box plot color.</param>
+    public ChartBoxPlotSeries(string name, IList<double> x, IList<double> minimum, IList<double> q1, IList<double> median, IList<double> q3, IList<double> maximum, ChartColor? color = null) : base(name) {
+        X = x;
+        Minimum = minimum;
+        Q1 = q1;
+        Median = median;
+        Q3 = q3;
+        Maximum = maximum;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartBullet.cs
+++ b/ChartForgeX/Simple/ChartBullet.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Bullet chart definition.</summary>
+public sealed class ChartBullet : ChartDefinition {
+    /// <summary>Current value.</summary>
+    public double Value { get; }
+
+    /// <summary>Target value.</summary>
+    public double Target { get; }
+
+    /// <summary>Minimum scale value.</summary>
+    public double Minimum { get; }
+
+    /// <summary>Maximum scale value.</summary>
+    public double Maximum { get; }
+
+    /// <summary>Optional qualitative range end values.</summary>
+    public IList<double>? RangeEnds { get; }
+
+    /// <summary>Bullet color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a bullet chart definition.</summary>
+    /// <param name="name">Bullet label.</param>
+    /// <param name="value">Current value.</param>
+    /// <param name="target">Target value.</param>
+    /// <param name="minimum">Minimum scale value.</param>
+    /// <param name="maximum">Maximum scale value.</param>
+    /// <param name="rangeEnds">Optional qualitative range end values.</param>
+    /// <param name="color">Optional bullet color.</param>
+    public ChartBullet(string name, double value, double target, double minimum = 0, double maximum = 100, IList<double>? rangeEnds = null, ChartColor? color = null) : base(name) {
+        Value = value;
+        Target = target;
+        Minimum = minimum;
+        Maximum = maximum;
+        RangeEnds = rangeEnds;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartFunnel.cs
+++ b/ChartForgeX/Simple/ChartFunnel.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Funnel chart item definition.</summary>
+public sealed class ChartFunnel : ChartDefinition {
+    /// <summary>Stage value.</summary>
+    public double Value { get; }
+
+    /// <summary>Stage color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a funnel chart item definition.</summary>
+    /// <param name="name">Stage label.</param>
+    /// <param name="value">Stage value.</param>
+    /// <param name="color">Optional stage color.</param>
+    public ChartFunnel(string name, double value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartHorizontalBar.cs
+++ b/ChartForgeX/Simple/ChartHorizontalBar.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Horizontal bar chart definition.</summary>
+public sealed class ChartHorizontalBar : ChartDefinition {
+    /// <summary>Bar values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Bar color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a horizontal bar chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Bar values.</param>
+    /// <param name="color">Optional bar color.</param>
+    public ChartHorizontalBar(string name, IList<double> value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartLollipop.cs
+++ b/ChartForgeX/Simple/ChartLollipop.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Lollipop chart definition.</summary>
+public sealed class ChartLollipop : ChartDefinition {
+    /// <summary>Lollipop values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Lollipop color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a lollipop chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Lollipop values.</param>
+    /// <param name="color">Optional lollipop color.</param>
+    public ChartLollipop(string name, IList<double> value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartRangeBandSeries.cs
+++ b/ChartForgeX/Simple/ChartRangeBandSeries.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Range band chart definition.</summary>
+public sealed class ChartRangeBandSeries : ChartDefinition {
+    /// <summary>X or category values.</summary>
+    public IList<double> X { get; }
+
+    /// <summary>Lower values.</summary>
+    public IList<double> Lower { get; }
+
+    /// <summary>Upper values.</summary>
+    public IList<double> Upper { get; }
+
+    /// <summary>Range band color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Render the range as an area instead of a band.</summary>
+    public bool Area { get; }
+
+    /// <summary>Render range-area boundaries using smooth curves.</summary>
+    public bool Smooth { get; }
+
+    /// <summary>Create a range band chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="x">X or category values.</param>
+    /// <param name="lower">Lower values.</param>
+    /// <param name="upper">Upper values.</param>
+    /// <param name="color">Optional range band color.</param>
+    /// <param name="area">Render as a range area.</param>
+    /// <param name="smooth">Render range-area boundaries using smooth curves.</param>
+    public ChartRangeBandSeries(string name, IList<double> x, IList<double> lower, IList<double> upper, ChartColor? color = null, bool area = false, bool smooth = true) : base(name) {
+        X = x;
+        Lower = lower;
+        Upper = upper;
+        Color = color;
+        Area = area;
+        Smooth = smooth;
+    }
+}

--- a/ChartForgeX/Simple/ChartRangeBar.cs
+++ b/ChartForgeX/Simple/ChartRangeBar.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Range bar chart definition.</summary>
+public sealed class ChartRangeBar : ChartDefinition {
+    /// <summary>X or category values.</summary>
+    public IList<double> X { get; }
+
+    /// <summary>Interval start values.</summary>
+    public IList<double> Start { get; }
+
+    /// <summary>Interval end values.</summary>
+    public IList<double> End { get; }
+
+    /// <summary>Range bar color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a range bar chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="x">X or category values.</param>
+    /// <param name="start">Interval start values.</param>
+    /// <param name="end">Interval end values.</param>
+    /// <param name="color">Optional range bar color.</param>
+    public ChartRangeBar(string name, IList<double> x, IList<double> start, IList<double> end, ChartColor? color = null) : base(name) {
+        X = x;
+        Start = start;
+        End = end;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartSlope.cs
+++ b/ChartForgeX/Simple/ChartSlope.cs
@@ -1,0 +1,36 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Slope chart definition.</summary>
+public sealed class ChartSlope : ChartDefinition {
+    /// <summary>Start value.</summary>
+    public double Start { get; }
+
+    /// <summary>End value.</summary>
+    public double End { get; }
+
+    /// <summary>Optional start axis label.</summary>
+    public string? StartLabel { get; }
+
+    /// <summary>Optional end axis label.</summary>
+    public string? EndLabel { get; }
+
+    /// <summary>Slope color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a slope chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="start">Start value.</param>
+    /// <param name="end">End value.</param>
+    /// <param name="startLabel">Optional start axis label.</param>
+    /// <param name="endLabel">Optional end axis label.</param>
+    /// <param name="color">Optional slope color.</param>
+    public ChartSlope(string name, double start, double end, string? startLabel = null, string? endLabel = null, ChartColor? color = null) : base(name) {
+        Start = start;
+        End = end;
+        StartLabel = startLabel;
+        EndLabel = endLabel;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartStackedArea.cs
+++ b/ChartForgeX/Simple/ChartStackedArea.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Stacked area chart definition.</summary>
+public sealed class ChartStackedArea : ChartDefinition {
+    /// <summary>Area values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Area color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Render the area using a smooth curve.</summary>
+    public bool Smooth { get; }
+
+    /// <summary>Create a stacked area chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Area values.</param>
+    /// <param name="color">Optional area color.</param>
+    /// <param name="smooth">Render as a smooth curve.</param>
+    public ChartStackedArea(string name, IList<double> value, ChartColor? color = null, bool smooth = false) : base(name) {
+        Value = value;
+        Color = color;
+        Smooth = smooth;
+    }
+}

--- a/ChartForgeX/Simple/ChartStepArea.cs
+++ b/ChartForgeX/Simple/ChartStepArea.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Step area chart definition.</summary>
+public sealed class ChartStepArea : ChartDefinition {
+    /// <summary>Area values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Area color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a step area chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Area values.</param>
+    /// <param name="color">Optional area color.</param>
+    public ChartStepArea(string name, IList<double> value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartStepLine.cs
+++ b/ChartForgeX/Simple/ChartStepLine.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Step line chart definition.</summary>
+public sealed class ChartStepLine : ChartDefinition {
+    /// <summary>Line values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Line color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a step line chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Line values.</param>
+    /// <param name="color">Optional line color.</param>
+    public ChartStepLine(string name, IList<double> value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartTreemap.cs
+++ b/ChartForgeX/Simple/ChartTreemap.cs
@@ -1,0 +1,21 @@
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Treemap chart item definition.</summary>
+public sealed class ChartTreemap : ChartDefinition {
+    /// <summary>Item value.</summary>
+    public double Value { get; }
+
+    /// <summary>Item color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a treemap item definition.</summary>
+    /// <param name="name">Item label.</param>
+    /// <param name="value">Item value.</param>
+    /// <param name="color">Optional item color.</param>
+    public ChartTreemap(string name, double value, ChartColor? color = null) : base(name) {
+        Value = value;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/ChartWaterfall.cs
+++ b/ChartForgeX/Simple/ChartWaterfall.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Simple;
+
+/// <summary>Waterfall chart definition.</summary>
+public sealed class ChartWaterfall : ChartDefinition {
+    /// <summary>Delta values.</summary>
+    public IList<double> Value { get; }
+
+    /// <summary>Optional step labels.</summary>
+    public IList<string>? Labels { get; }
+
+    /// <summary>Waterfall color.</summary>
+    public ChartColor? Color { get; }
+
+    /// <summary>Create a waterfall chart definition.</summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="value">Delta values.</param>
+    /// <param name="labels">Optional step labels.</param>
+    /// <param name="color">Optional waterfall color.</param>
+    public ChartWaterfall(string name, IList<double> value, IList<string>? labels = null, ChartColor? color = null) : base(name) {
+        Value = value;
+        Labels = labels;
+        Color = color;
+    }
+}

--- a/ChartForgeX/Simple/Charts.cs
+++ b/ChartForgeX/Simple/Charts.cs
@@ -296,20 +296,20 @@ public static class Charts {
         string? start = null;
         string? end = null;
         foreach (var slope in slopes) {
-            var currentStart = string.IsNullOrWhiteSpace(slope.StartLabel) ? "Start" : slope.StartLabel!;
-            var currentEnd = string.IsNullOrWhiteSpace(slope.EndLabel) ? "End" : slope.EndLabel!;
-            if (string.IsNullOrWhiteSpace(slope.StartLabel) && string.IsNullOrWhiteSpace(slope.EndLabel)) {
-                continue;
+            if (!string.IsNullOrWhiteSpace(slope.StartLabel)) {
+                if (start is null) {
+                    start = slope.StartLabel;
+                } else if (!string.Equals(start, slope.StartLabel, StringComparison.Ordinal)) {
+                    throw new ArgumentException("Slope chart definitions must use one shared start label.", nameof(slopes));
+                }
             }
 
-            if (start is null) {
-                start = currentStart;
-                end = currentEnd;
-                continue;
-            }
-
-            if (!string.Equals(start, currentStart, StringComparison.Ordinal) || !string.Equals(end, currentEnd, StringComparison.Ordinal)) {
-                throw new ArgumentException("Slope chart definitions must use one shared start/end label pair.", nameof(slopes));
+            if (!string.IsNullOrWhiteSpace(slope.EndLabel)) {
+                if (end is null) {
+                    end = slope.EndLabel;
+                } else if (!string.Equals(end, slope.EndLabel, StringComparison.Ordinal)) {
+                    throw new ArgumentException("Slope chart definitions must use one shared end label.", nameof(slopes));
+                }
             }
         }
 

--- a/ChartForgeX/Simple/Charts.cs
+++ b/ChartForgeX/Simple/Charts.cs
@@ -121,13 +121,7 @@ public static class Charts {
             chart.AddRadialBar("Values", list.Cast<ChartRadial>().Select((radial, index) => new ChartPoint(index + 1, RequirePercent(radial.Value, radial.Name))));
             ApplyPointColors(chart, list.Cast<ChartRadial>().Select(radial => radial.Color).ToArray());
         } else if (type == typeof(ChartSlope)) {
-            foreach (var slope in list.Cast<ChartSlope>()) {
-                if (!string.IsNullOrWhiteSpace(slope.StartLabel) || !string.IsNullOrWhiteSpace(slope.EndLabel)) {
-                    chart.AddSlope(slope.Name, slope.Start, slope.End, slope.StartLabel ?? "Start", slope.EndLabel ?? "End", slope.Color);
-                } else {
-                    chart.AddSlope(slope.Name, slope.Start, slope.End, slope.Color);
-                }
-            }
+            AddSlopeDefinitions(chart, list.Cast<ChartSlope>());
         } else if (type == typeof(ChartGauge)) {
             var gauge = RequireSingle<ChartGauge>(list);
             chart.AddGauge(gauge.Name, gauge.Value, gauge.Minimum, gauge.Maximum, gauge.Color);
@@ -288,6 +282,38 @@ public static class Charts {
 
     private static CfxBubble[] BuildBubbles(IList<double> x, IList<double> y, IList<double> size) {
         return ChartBubbles.FromXYSize(x, y, size);
+    }
+
+    private static void AddSlopeDefinitions(CfxChart chart, IEnumerable<ChartSlope> slopes) {
+        var list = slopes.ToList();
+        var labels = ResolveSlopeAxisLabels(list);
+        foreach (var slope in list) {
+            chart.AddSlope(slope.Name, slope.Start, slope.End, labels.Start, labels.End, slope.Color);
+        }
+    }
+
+    private static (string Start, string End) ResolveSlopeAxisLabels(IEnumerable<ChartSlope> slopes) {
+        string? start = null;
+        string? end = null;
+        foreach (var slope in slopes) {
+            var currentStart = string.IsNullOrWhiteSpace(slope.StartLabel) ? "Start" : slope.StartLabel!;
+            var currentEnd = string.IsNullOrWhiteSpace(slope.EndLabel) ? "End" : slope.EndLabel!;
+            if (string.IsNullOrWhiteSpace(slope.StartLabel) && string.IsNullOrWhiteSpace(slope.EndLabel)) {
+                continue;
+            }
+
+            if (start is null) {
+                start = currentStart;
+                end = currentEnd;
+                continue;
+            }
+
+            if (!string.Equals(start, currentStart, StringComparison.Ordinal) || !string.Equals(end, currentEnd, StringComparison.Ordinal)) {
+                throw new ArgumentException("Slope chart definitions must use one shared start/end label pair.", nameof(slopes));
+            }
+        }
+
+        return (start ?? "Start", end ?? "End");
     }
 
     private static CfxInterval[] BuildIntervals(IList<double> x, IList<double> start, IList<double> end) {

--- a/ChartForgeX/Simple/Charts.cs
+++ b/ChartForgeX/Simple/Charts.cs
@@ -11,6 +11,10 @@ using CfxPictorialItem = ChartForgeX.Core.ChartPictorialItem;
 using CfxProgressItem = ChartForgeX.Core.ChartProgressItem;
 using CfxTheme = ChartForgeX.Themes.ChartTheme;
 using CfxBubble = ChartForgeX.Core.ChartBubble;
+using CfxBoxPlot = ChartForgeX.Core.ChartBoxPlot;
+using CfxInterval = ChartForgeX.Core.ChartInterval;
+using CfxRangeBand = ChartForgeX.Core.ChartRangeBand;
+using CfxTreemapItem = ChartForgeX.Core.ChartTreemapItem;
 using CfxWordCloudItem = ChartForgeX.Core.ChartWordCloudItem;
 
 namespace ChartForgeX.Simple;
@@ -62,6 +66,8 @@ public static class Charts {
 
         if (type == typeof(ChartBar)) {
             foreach (var bar in list.Cast<ChartBar>()) chart.AddBar(bar.Name, BuildIndexedPoints(bar.Value), bar.Color);
+        } else if (type == typeof(ChartHorizontalBar)) {
+            foreach (var bar in list.Cast<ChartHorizontalBar>()) chart.AddHorizontalBar(bar.Name, BuildIndexedPoints(bar.Value), bar.Color);
         } else if (type == typeof(ChartLine)) {
             ApplySharedLineMarkerSize(chart, list.Cast<ChartLine>());
             foreach (var line in list.Cast<ChartLine>()) {
@@ -69,12 +75,33 @@ public static class Charts {
                 if (line.Smooth) chart.AddSmoothLine(line.Name, points, line.Color);
                 else chart.AddLine(line.Name, points, line.Color);
             }
+        } else if (type == typeof(ChartStepLine)) {
+            foreach (var line in list.Cast<ChartStepLine>()) chart.AddStepLine(line.Name, BuildIndexedPoints(line.Value), line.Color);
         } else if (type == typeof(ChartArea)) {
             foreach (var area in list.Cast<ChartArea>()) chart.AddArea(area.Name, BuildIndexedPoints(area.Value), area.Color);
+        } else if (type == typeof(ChartStepArea)) {
+            foreach (var area in list.Cast<ChartStepArea>()) chart.AddStepArea(area.Name, BuildIndexedPoints(area.Value), area.Color);
+        } else if (type == typeof(ChartStackedArea)) {
+            foreach (var area in list.Cast<ChartStackedArea>()) {
+                if (area.Smooth) chart.AddSmoothStackedArea(area.Name, BuildIndexedPoints(area.Value), area.Color);
+                else chart.AddStackedArea(area.Name, BuildIndexedPoints(area.Value), area.Color);
+            }
         } else if (type == typeof(ChartScatter)) {
             foreach (var scatter in list.Cast<ChartScatter>()) chart.AddScatter(scatter.Name, BuildXYPoints(scatter.X, scatter.Y), scatter.Color);
         } else if (type == typeof(ChartBubbleSeries)) {
             foreach (var bubble in list.Cast<ChartBubbleSeries>()) chart.AddBubble(bubble.Name, BuildBubbles(bubble.X, bubble.Y, bubble.Size), bubble.Color);
+        } else if (type == typeof(ChartLollipop)) {
+            foreach (var lollipop in list.Cast<ChartLollipop>()) chart.AddLollipop(lollipop.Name, BuildIndexedPoints(lollipop.Value), lollipop.Color);
+        } else if (type == typeof(ChartRangeBar)) {
+            foreach (var range in list.Cast<ChartRangeBar>()) chart.AddRangeBar(range.Name, BuildIntervals(range.X, range.Start, range.End), range.Color);
+        } else if (type == typeof(ChartRangeBandSeries)) {
+            foreach (var range in list.Cast<ChartRangeBandSeries>()) {
+                var ranges = BuildRanges(range.X, range.Lower, range.Upper);
+                if (range.Area) chart.AddRangeArea(range.Name, ranges, range.Color, range.Smooth);
+                else chart.AddRangeBand(range.Name, ranges, range.Color);
+            }
+        } else if (type == typeof(ChartBoxPlotSeries)) {
+            foreach (var box in list.Cast<ChartBoxPlotSeries>()) chart.AddBoxPlot(box.Name, BuildBoxPlots(box), box.Color);
         } else if (type == typeof(ChartRadar)) {
             AddRadarDefinitions(chart, list.Cast<ChartRadar>());
         } else if (type == typeof(ChartPolarArea)) {
@@ -93,12 +120,33 @@ public static class Charts {
             chart.WithXLabels(list.Select(d => d.Name).ToArray());
             chart.AddRadialBar("Values", list.Cast<ChartRadial>().Select((radial, index) => new ChartPoint(index + 1, RequirePercent(radial.Value, radial.Name))));
             ApplyPointColors(chart, list.Cast<ChartRadial>().Select(radial => radial.Color).ToArray());
+        } else if (type == typeof(ChartSlope)) {
+            foreach (var slope in list.Cast<ChartSlope>()) {
+                if (!string.IsNullOrWhiteSpace(slope.StartLabel) || !string.IsNullOrWhiteSpace(slope.EndLabel)) {
+                    chart.AddSlope(slope.Name, slope.Start, slope.End, slope.StartLabel ?? "Start", slope.EndLabel ?? "End", slope.Color);
+                } else {
+                    chart.AddSlope(slope.Name, slope.Start, slope.End, slope.Color);
+                }
+            }
         } else if (type == typeof(ChartGauge)) {
             var gauge = RequireSingle<ChartGauge>(list);
             chart.AddGauge(gauge.Name, gauge.Value, gauge.Minimum, gauge.Maximum, gauge.Color);
         } else if (type == typeof(ChartCircle)) {
             var circle = RequireSingle<ChartCircle>(list);
             chart.AddCircle(circle.Name, circle.Value, circle.Minimum, circle.Maximum, circle.Color);
+        } else if (type == typeof(ChartBullet)) {
+            foreach (var bullet in list.Cast<ChartBullet>()) chart.AddBullet(bullet.Name, bullet.Value, bullet.Target, bullet.Minimum, bullet.Maximum, bullet.RangeEnds, bullet.Color);
+        } else if (type == typeof(ChartWaterfall)) {
+            var waterfall = RequireSingle<ChartWaterfall>(list);
+            ApplyLabels(chart, waterfall.Labels);
+            chart.AddWaterfall(waterfall.Name, BuildIndexedPoints(waterfall.Value), waterfall.Color);
+        } else if (type == typeof(ChartFunnel)) {
+            chart.WithXLabels(list.Select(d => d.Name).ToArray());
+            chart.AddFunnel("Values", list.Cast<ChartFunnel>().Select((funnel, index) => new ChartPoint(index + 1, funnel.Value)));
+            ApplyPointColors(chart, list.Cast<ChartFunnel>().Select(funnel => funnel.Color).ToArray());
+        } else if (type == typeof(ChartTreemap)) {
+            chart.AddTreemap("Values", list.Cast<ChartTreemap>().Select(item => new CfxTreemapItem(item.Name, item.Value)));
+            ApplyPointColors(chart, list.Cast<ChartTreemap>().Select(item => item.Color).ToArray());
         } else if (type == typeof(ChartProgress)) {
             chart.AddProgressBars("Values", list.Cast<ChartProgress>().Select(progress => new CfxProgressItem(progress.Name, progress.Value, progress.Color)), options?.ProgressMaximum ?? 100);
         } else if (type == typeof(ChartPictorial)) {
@@ -240,6 +288,62 @@ public static class Charts {
 
     private static CfxBubble[] BuildBubbles(IList<double> x, IList<double> y, IList<double> size) {
         return ChartBubbles.FromXYSize(x, y, size);
+    }
+
+    private static CfxInterval[] BuildIntervals(IList<double> x, IList<double> start, IList<double> end) {
+        if (x is null) throw new ArgumentNullException(nameof(x));
+        if (start is null) throw new ArgumentNullException(nameof(start));
+        if (end is null) throw new ArgumentNullException(nameof(end));
+        if (x.Count != start.Count || x.Count != end.Count) {
+            throw new ArgumentException("Range bar X, start, and end values must contain the same number of items.", nameof(x));
+        }
+
+        var intervals = new CfxInterval[x.Count];
+        for (var i = 0; i < intervals.Length; i++) {
+            intervals[i] = new CfxInterval(x[i], start[i], end[i]);
+        }
+
+        return intervals;
+    }
+
+    private static CfxRangeBand[] BuildRanges(IList<double> x, IList<double> lower, IList<double> upper) {
+        if (x is null) throw new ArgumentNullException(nameof(x));
+        if (lower is null) throw new ArgumentNullException(nameof(lower));
+        if (upper is null) throw new ArgumentNullException(nameof(upper));
+        if (x.Count != lower.Count || x.Count != upper.Count) {
+            throw new ArgumentException("Range X, lower, and upper values must contain the same number of items.", nameof(x));
+        }
+
+        var ranges = new CfxRangeBand[x.Count];
+        for (var i = 0; i < ranges.Length; i++) {
+            ranges[i] = new CfxRangeBand(x[i], lower[i], upper[i]);
+        }
+
+        return ranges;
+    }
+
+    private static CfxBoxPlot[] BuildBoxPlots(ChartBoxPlotSeries box) {
+        if (box is null) throw new ArgumentNullException(nameof(box));
+        if (box.X is null) throw new ArgumentNullException(nameof(box.X));
+        if (box.Minimum is null) throw new ArgumentNullException(nameof(box.Minimum));
+        if (box.Q1 is null) throw new ArgumentNullException(nameof(box.Q1));
+        if (box.Median is null) throw new ArgumentNullException(nameof(box.Median));
+        if (box.Q3 is null) throw new ArgumentNullException(nameof(box.Q3));
+        if (box.Maximum is null) throw new ArgumentNullException(nameof(box.Maximum));
+        if (box.X.Count != box.Minimum.Count ||
+            box.X.Count != box.Q1.Count ||
+            box.X.Count != box.Median.Count ||
+            box.X.Count != box.Q3.Count ||
+            box.X.Count != box.Maximum.Count) {
+            throw new ArgumentException("Box plot X, minimum, quartile, median, and maximum values must contain the same number of items.", nameof(box));
+        }
+
+        var boxes = new CfxBoxPlot[box.X.Count];
+        for (var i = 0; i < boxes.Length; i++) {
+            boxes[i] = new CfxBoxPlot(box.X[i], box.Minimum[i], box.Q1[i], box.Median[i], box.Q3[i], box.Maximum[i]);
+        }
+
+        return boxes;
     }
 
     private static void AddHeatmap(CfxChart chart, ChartHeatmap map) {


### PR DESCRIPTION
## Summary
- add Simple chart definitions for horizontal bar, step/stacked area, lollipop, range, box plot, slope, bullet, waterfall, funnel, and treemap charts
- route the new definitions through the native ChartForgeX core builders
- cover the expanded Simple API with smoke tests and validation checks

## Tests
- dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj --configuration Release