### PR TITLE
Bump ChartForgeX packages to 0.2.0

### DIFF
--- a/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
+++ b/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Interactivity.Html</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>Evotec</Authors>
     <Description>Self-contained HTML and SVG interaction adapter for ChartForgeX charts.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
+++ b/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Interactivity</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>Evotec</Authors>
     <Description>Host-neutral interaction contracts for ChartForgeX chart renderers and adapters.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX/ChartForgeX.csproj
+++ b/ChartForgeX/ChartForgeX.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>Evotec</Authors>
     <Description>Dependency-free SVG, HTML, PNG, BMP, PPM, and TIFF rendering for .NET charts, visual blocks, report tables, metric cards, and topology diagrams.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- bump ChartForgeX package version to 0.2.0
- bump ChartForgeX.Interactivity package version to 0.2.0
- bump ChartForgeX.Interactivity.Html package version to 0.2.0

## Tests
- dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj --configuration Release
- dotnet pack ChartForgeX\ChartForgeX.csproj --configuration Release
- dotnet pack ChartForgeX.Interactivity\ChartForgeX.Interactivity.csproj --configuration Release
- dotnet pack ChartForgeX.Interactivity.Html\ChartForgeX.Interactivity.Html.csproj --configuration Release produced 0.2.0 packages, but the local dotnet process did not exit after package creation and was stopped