### PR TITLE
Add reusable visual canvas compositions

### DIFF
--- a/ChartForgeX.Examples/ExampleProgramOptions.cs
+++ b/ChartForgeX.Examples/ExampleProgramOptions.cs
@@ -32,6 +32,12 @@ internal static class ExampleProgramOptions {
             return true;
         }
 
+        if (HasArg(args, "--visual-canvas-only")) {
+            WellnessDashboardExamples.WritePowerBgInfoSocialPreview(output, (int)pngOutputScale);
+            Console.WriteLine("Generated visual canvas files in: " + output);
+            return true;
+        }
+
         if (HasArg(args, "--dashboard-shipment-only")) {
             DashboardPatternExamples.WriteShipmentActivityPanel(output, pngOutputScale);
             Console.WriteLine("Generated dashboard shipment panel in: " + output);

--- a/ChartForgeX.Examples/GalleryWriter.cs
+++ b/ChartForgeX.Examples/GalleryWriter.cs
@@ -640,7 +640,7 @@ figure{margin:0;background:var(--frame);border:1px solid #1f2937;border-radius:8
             var edgeBackground = DominantPngCornerColor(cornerColors);
             var visualBackground = DominantPngVisibleColor(pixelColors, edgeBackground);
             var foreground = CountPngForeground(pixelColors, dimensions, visualBackground, out var contentBounds);
-            var edgeInkPixels = CountPngEdgeInk(edgeColors, edgeBackground);
+            var edgeInkPixels = IsFullBleedVisualCanvasPng(fileName) ? 0 : CountPngEdgeInk(edgeColors, edgeBackground);
             return new PngHealth(visiblePixels, foreground, contentBounds, colors.Count, edgeInkPixels, edgeColors.Count);
         } catch (IOException) {
         } catch (UnauthorizedAccessException) {
@@ -648,6 +648,14 @@ figure{margin:0;background:var(--frame);border:1px solid #1f2937;border-radius:8
         }
 
         return default;
+    }
+
+    private static bool IsFullBleedVisualCanvasPng(string pngFileName) {
+        var directory = Path.GetDirectoryName(pngFileName) ?? string.Empty;
+        var svgFileName = Path.Combine(directory, Path.GetFileNameWithoutExtension(pngFileName) + ".svg");
+        if (!File.Exists(svgFileName)) return false;
+        var svg = File.ReadAllText(svgFileName);
+        return svg.Contains("data-cfx-role=\"visual-canvas-background\"", StringComparison.Ordinal);
     }
 
     private static bool UnfilterPngRow(byte[] raw, int rawOffset, byte[] output, byte[] previous, int stride, int bytesPerPixel, int filter) {

--- a/ChartForgeX.Examples/WellnessDashboardExamples.cs
+++ b/ChartForgeX.Examples/WellnessDashboardExamples.cs
@@ -54,6 +54,7 @@ internal static class WellnessDashboardExamples {
             });
 
         canvas.SaveSvg(Path.Combine(output, "powerbginfo-social-preview-canvas.svg"));
+        canvas.SaveHtml(Path.Combine(output, "powerbginfo-social-preview-canvas.html"));
         canvas.SavePng(Path.Combine(output, "powerbginfo-social-preview-canvas.png"));
     }
 

--- a/ChartForgeX.Examples/WellnessDashboardExamples.cs
+++ b/ChartForgeX.Examples/WellnessDashboardExamples.cs
@@ -1,4 +1,5 @@
 using ChartForgeX;
+using ChartForgeX.Composition;
 using ChartForgeX.Core;
 using ChartForgeX.Primitives;
 using ChartForgeX.Themes;
@@ -18,12 +19,42 @@ internal static class WellnessDashboardExamples {
 
     public static void Write(string output, ChartPngOutputScale pngOutputScale) {
         SaveLayeredRadial(output, pngOutputScale);
+        WritePowerBgInfoSocialPreview(output, (int)pngOutputScale);
         SaveWeightCard(output, (int)pngOutputScale);
         SaveCaloriesCard(output, (int)pngOutputScale);
         SavePowerBgInfoStatsSection(output, (int)pngOutputScale);
         SaveReportMetricStrip(output, (int)pngOutputScale);
         SaveTransparentReportMetricStrip(output, (int)pngOutputScale);
         SaveWeeklyProgressDashboard(output, (int)pngOutputScale);
+    }
+
+    public static void WritePowerBgInfoSocialPreview(string output, int outputScale) {
+        var canvas = VisualCanvas.CreateSocialPreview()
+            .WithTitle("PowerBGInfo social preview")
+            .WithBackground(ChartColor.FromHex("#020713"), ChartColor.FromHex("#071A35"))
+            .WithBackdrop(VisualCanvasBackdropStyle.TechHorizon)
+            .WithPngOutputScale(outputScale)
+            .AddInfoTile(48, 92, 300, 82, "PC", "HOSTNAME", "DEV-WKS-01", accent: ChartColor.FromHex("#2F80FF"))
+            .AddInfoTile(48, 190, 300, 82, "IP", "IP ADDRESS", "10.0.0.42", "192.168.1.42", ChartColor.FromHex("#2F80FF"))
+            .AddInfoTile(48, 288, 300, 82, "OS", "OS", "Windows 11", "24H2", ChartColor.FromHex("#2F80FF"))
+            .AddInfoTile(852, 70, 300, 96, "CPU", "CPU", "Intel Core i7", accent: ChartColor.FromHex("#60A5FA"), progress: 0.23)
+            .AddInfoTile(852, 184, 300, 96, "RAM", "RAM", "32.0 GB", accent: ChartColor.FromHex("#60A5FA"), progress: 0.41)
+            .AddInfoTile(852, 298, 300, 82, "USR", "USER", "jdoe", accent: ChartColor.FromHex("#60A5FA"))
+            .AddHeroBadge(538, 157, 124, 88, ">_", ChartColor.FromHex("#22A7FF"))
+            .AddHeroTitle(312, 296, 576, 82, new[] {
+                new VisualCanvasTextRun("Power", ChartColor.FromHex("#F8FAFC")),
+                new VisualCanvasTextRun("BGInfo", ChartColor.FromHex("#2F80FF"))
+            })
+            .AddText(240, 402, 720, "Desktop background insights for Windows and PowerShell", 24, ChartColor.FromHex("#C6D3EA"), VisualCanvasTextAlignment.Center)
+            .AddFeatureStrip(290, 522, 620, 62, new[] {
+                new VisualCanvasFeatureItem("PS", "LIGHTWEIGHT"),
+                new VisualCanvasFeatureItem("OK", "SECURE"),
+                new VisualCanvasFeatureItem("UI", "CUSTOMIZABLE"),
+                new VisualCanvasFeatureItem("OS", "OPEN SOURCE")
+            });
+
+        canvas.SaveSvg(Path.Combine(output, "powerbginfo-social-preview-canvas.svg"));
+        canvas.SavePng(Path.Combine(output, "powerbginfo-social-preview-canvas.png"));
     }
 
     private static void SaveLayeredRadial(string output, ChartPngOutputScale pngOutputScale) {

--- a/ChartForgeX.Examples/visual-baseline.json
+++ b/ChartForgeX.Examples/visual-baseline.json
@@ -1474,6 +1474,22 @@
       }
     },
     {
+      "name": "powerbginfo-social-preview-canvas",
+      "width": 1200,
+      "height": 630,
+      "svg": {
+        "minVisualNodes": 64,
+        "maxClippedTextNodes": 0,
+        "maxNearEdgeTextNodes": 0
+      },
+      "png": {
+        "outputScale": 2,
+        "minVisiblePixels": 1512000,
+        "minDistinctColors": 2048,
+        "maxEdgeInkPixels": 0
+      }
+    },
+    {
       "name": "remediation-impact-waterfall-dark",
       "width": 920,
       "height": 540,
@@ -2046,22 +2062,6 @@
         "outputScale": 2,
         "minVisiblePixels": 695869,
         "minDistinctColors": 1558,
-        "maxEdgeInkPixels": 0
-      }
-    },
-    {
-      "name": "powerbginfo-social-preview-canvas",
-      "width": 1200,
-      "height": 630,
-      "svg": {
-        "minVisualNodes": 64,
-        "maxClippedTextNodes": 0,
-        "maxNearEdgeTextNodes": 0
-      },
-      "png": {
-        "outputScale": 2,
-        "minVisiblePixels": 1512000,
-        "minDistinctColors": 2048,
         "maxEdgeInkPixels": 0
       }
     }

--- a/ChartForgeX.Examples/visual-baseline.json
+++ b/ChartForgeX.Examples/visual-baseline.json
@@ -2048,6 +2048,22 @@
         "minDistinctColors": 1558,
         "maxEdgeInkPixels": 0
       }
+    },
+    {
+      "name": "powerbginfo-social-preview-canvas",
+      "width": 1200,
+      "height": 630,
+      "svg": {
+        "minVisualNodes": 64,
+        "maxClippedTextNodes": 0,
+        "maxNearEdgeTextNodes": 0
+      },
+      "png": {
+        "outputScale": 2,
+        "minVisiblePixels": 1512000,
+        "minDistinctColors": 2048,
+        "maxEdgeInkPixels": 0
+      }
     }
   ]
 }

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -159,6 +159,7 @@ internal static partial class SmokeTests {
         ("Visual blocks render tables lists and metric cards", VisualBlocksRenderTablesListsAndMetricCards),
         ("Visual block review regressions stay covered", VisualBlockReviewRegressionsStayCovered),
         ("Visual grid composes charts and visual blocks", VisualGridComposesChartsAndVisualBlocks),
+        ("Visual canvas composes wallpaper style artboards", VisualCanvasComposesWallpaperStyleArtboards),
         ("Visual blocks reject invalid inputs close to caller", VisualBlocksRejectInvalidInputsCloseToCaller),
         ("Explicit axis bounds affect SVG ticks", ExplicitAxisBoundsAffectSvgTicks),
         ("Example gallery is static and links generated artifacts", ExampleGalleryIsStaticAndLinksGeneratedArtifacts),

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -12,8 +12,8 @@ internal static partial class SmokeTests {
             .WithBackdrop(VisualCanvasBackdropStyle.TechHorizon)
             .AddInfoTile(48, 92, 300, 82, "PC", "HOSTNAME", "DEV-WKS-01", accent: ChartColor.FromHex("#2F80FF"))
             .AddInfoTile(48, 190, 300, 82, "IP", "IP ADDRESS", "10.0.0.42", "192.168.1.42", ChartColor.FromHex("#2F80FF"))
-            .AddInfoTile(852, 70, 300, 96, "CPU", "CPU", "Intel Core i7", accent: ChartColor.FromHex("#60A5FA"), progress: 0.23)
-            .AddInfoTile(852, 184, 300, 96, "RAM", "RAM", "32.0 GB", accent: ChartColor.FromHex("#60A5FA"), progress: 0.41)
+            .AddInfoTile(852, 70, 300, 96, "CPU", "CPU", "Intel Core i7", accent: ChartColor.FromHex("#60A5FA"), progress: 0.23, miniChartKind: VisualCanvasInfoTileMiniChartKind.Area, miniChartValues: new[] { 18d, 26d, 22d, 37d, 48d, 43d })
+            .AddInfoTile(852, 184, 300, 96, "RAM", "RAM", "32.0 GB", accent: ChartColor.FromHex("#60A5FA"), progress: 0.41, miniChartKind: VisualCanvasInfoTileMiniChartKind.Bars, miniChartValues: new[] { 42d, 48d, 51d, 55d, 52d })
             .AddHeroBadge(538, 157, 124, 88, ">_", ChartColor.FromHex("#22A7FF"))
             .AddHeroTitle(312, 296, 576, 82, new[] {
                 new VisualCanvasTextRun("Power", ChartColor.FromHex("#F8FAFC")),
@@ -30,6 +30,7 @@ internal static partial class SmokeTests {
         var svg = canvas.ToSvg("visual-canvas-smoke");
         Assert(svg.Contains("data-cfx-role=\"visual-canvas-background\"", StringComparison.Ordinal), "VisualCanvas should render a background role in SVG.");
         Assert(svg.Contains("data-cfx-role=\"visual-canvas-info-tile\"", StringComparison.Ordinal), "VisualCanvas should render info tile layers in SVG.");
+        Assert(svg.Contains("data-cfx-role=\"visual-canvas-info-tile-mini-chart\"", StringComparison.Ordinal), "VisualCanvas should render info tile mini chart layers in SVG.");
         Assert(svg.Contains("data-cfx-role=\"visual-canvas-hero-title\"", StringComparison.Ordinal), "VisualCanvas should render multi-run hero titles in SVG.");
         Assert(svg.Contains("Power", StringComparison.Ordinal) && svg.Contains("BGInfo", StringComparison.Ordinal), "VisualCanvas hero title should preserve colored title runs.");
         Assert(canvas.ToPng().Length > 64, "VisualCanvas should render PNG output.");
@@ -45,6 +46,7 @@ internal static partial class SmokeTests {
         AssertThrows<ArgumentOutOfRangeException>(() => VisualCanvas.Create(0, 630), "VisualCanvas should reject invalid widths.");
         AssertThrows<ArgumentOutOfRangeException>(() => canvas.PngOutputScale = 5, "VisualCanvas should reject unsupported PNG output scales.");
         AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").Progress = 1.2, "VisualCanvas info tile progress should stay normalized.");
+        AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").WithMiniChart(VisualCanvasInfoTileMiniChartKind.Sparkline, new[] { double.NaN }), "VisualCanvas info tile mini charts should reject invalid values.");
         AssertThrows<NotSupportedException>(() => canvas.Save("canvas.html"), "VisualCanvas extension-inferred save should fail clearly for unsupported formats.");
     }
 }

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -80,6 +80,23 @@ internal static partial class SmokeTests {
         Assert(nativeCanvas.ToPng().Length > 64, "VisualCanvas should render embedded ChartForgeX renderables to PNG output.");
         Assert(nativeCanvas.ToBmp().Length > 64, "VisualCanvas should render embedded ChartForgeX renderables to BMP output.");
 
+        var anchoredCanvas = VisualCanvas.Create(400, 300)
+            .AddInfoTile(VisualCanvasPlacement.At(VisualCanvasAnchor.TopLeft, 20, 20), 120, 60, "PC", "HOST", "WK01")
+            .AddInfoTile(VisualCanvasPlacement.At(VisualCanvasAnchor.BottomRight, 20, 20), 120, 60, "IP", "IP", "10.0.0.42")
+            .AddChart(VisualCanvasPlacement.At(VisualCanvasAnchor.TopRight, 20, 90), 140, 72, cpuChart, VisualCanvasImageFit.Contain)
+            .AddTopology(VisualCanvasPlacement.At(VisualCanvasAnchor.BottomLeft, 20, 20), 140, 72, topology, fit: VisualCanvasImageFit.Cover);
+        var topLeftTile = anchoredCanvas.Layers[0];
+        var bottomRightTile = anchoredCanvas.Layers[1];
+        var topRightChart = anchoredCanvas.Layers[2];
+        var bottomLeftTopology = anchoredCanvas.Layers[3];
+        Assert(IsClose(topLeftTile.X, 20) && IsClose(topLeftTile.Y, 20), "VisualCanvas TopLeft placement should use offsets from the top-left edge.");
+        Assert(IsClose(bottomRightTile.X, 260) && IsClose(bottomRightTile.Y, 220), "VisualCanvas BottomRight placement should use offsets as insets from the bottom-right edge.");
+        Assert(IsClose(topRightChart.X, 240) && IsClose(topRightChart.Y, 90), "VisualCanvas chart placement should support top-right anchors.");
+        Assert(IsClose(bottomLeftTopology.X, 20) && IsClose(bottomLeftTopology.Y, 208), "VisualCanvas topology placement should support bottom-left anchors.");
+        var relativeBounds = VisualCanvasPlacement.At(VisualCanvasAnchor.Center, 10, -8).Resolve(topLeftTile.Bounds, 20, 10);
+        Assert(IsClose(relativeBounds.X, 80) && IsClose(relativeBounds.Y, 37), "VisualCanvas placements should resolve relative to another layer's bounds.");
+        AssertThrows<ArgumentOutOfRangeException>(() => VisualCanvasPlacement.At((VisualCanvasAnchor)999, 0, 0), "VisualCanvas placement should reject unknown anchors.");
+
         var overlay = VisualCanvas.CreateDesktopWallpaper()
             .WithTitle("Transparent overlay")
             .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
@@ -107,4 +124,6 @@ internal static partial class SmokeTests {
             if (System.IO.File.Exists(ppmPath)) System.IO.File.Delete(ppmPath);
         }
     }
+
+    private static bool IsClose(double actual, double expected) => Math.Abs(actual - expected) < 0.001;
 }

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -1,6 +1,9 @@
 using System;
 using ChartForgeX.Composition;
+using ChartForgeX.Core;
 using ChartForgeX.Primitives;
+using ChartForgeX.Topology;
+using ChartForgeX.VisualBlocks;
 
 namespace ChartForgeX.Tests;
 
@@ -35,6 +38,48 @@ internal static partial class SmokeTests {
         Assert(svg.Contains("Power", StringComparison.Ordinal) && svg.Contains("BGInfo", StringComparison.Ordinal), "VisualCanvas hero title should preserve colored title runs.");
         Assert(canvas.ToPng().Length > 64, "VisualCanvas should render PNG output.");
 
+        var cpuChart = Chart.Create()
+            .WithSize(220, 120)
+            .WithTransparentBackground()
+            .WithHeader(false)
+            .WithCard(false)
+            .AddLine("CPU", new[] {
+                new ChartPoint(1, 18),
+                new ChartPoint(2, 31),
+                new ChartPoint(3, 24),
+                new ChartPoint(4, 45),
+                new ChartPoint(5, 39)
+            }, ChartColor.FromHex("#60A5FA"));
+        var memoryCard = MetricCard.Create()
+            .WithSize(180, 104)
+            .WithTransparentBackground()
+            .WithCard(false)
+            .WithMetric("RAM", "41%")
+            .WithMiniSparkline(new[] { 32d, 36d, 41d, 38d, 43d }, color: ChartColor.FromHex("#22C55E"));
+        var topology = TopologyChart.Create()
+            .WithViewport(260, 142, 14)
+            .WithLayout(TopologyLayoutMode.Manual)
+            .AddNode("host", "Host", 20, 45, TopologyNodeKind.Endpoint, TopologyHealthStatus.Healthy, symbol: "PC")
+            .AddNode("dc", "DC", 160, 45, TopologyNodeKind.Server, TopologyHealthStatus.Healthy, symbol: "AD")
+            .AddEdge("host-dc", "host", "dc", "LDAP", status: TopologyHealthStatus.Healthy);
+        var nativeCanvas = VisualCanvas.Create(760, 260)
+            .WithTitle("Native renderables")
+            .WithBackground(ChartColor.FromHex("#09111F"), ChartColor.FromHex("#102A43"))
+            .AddImage(24, 24, 120, 78, "data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2020%2010%22%3E%3Crect%20width%3D%2220%22%20height%3D%2210%22%20fill%3D%22%23ff0000%22%2F%3E%3C%2Fsvg%3E", new byte[] {
+                255, 0, 0, 255, 0, 255, 0, 255,
+                0, 0, 255, 255, 255, 255, 0, 255
+            }, 2, 2, fit: VisualCanvasImageFit.Cover)
+            .AddChart(160, 24, 220, 120, cpuChart, VisualCanvasImageFit.Contain)
+            .AddVisualBlock(400, 24, 180, 104, memoryCard, VisualCanvasImageFit.Center)
+            .AddTopology(160, 150, 260, 86, topology, fit: VisualCanvasImageFit.Cover)
+            .AddText(446, 160, 260, "ChartForgeX renderables can be composed as canvas layers.", 20, ChartColor.FromHex("#DBEAFE"));
+        var nativeSvg = nativeCanvas.ToSvg("visual-canvas-native-renderables");
+        Assert(nativeSvg.Contains("data:image/svg+xml", StringComparison.Ordinal), "VisualCanvas should embed SVG renderables for SVG/HTML output.");
+        Assert(nativeSvg.Contains("preserveAspectRatio=\"xMidYMid slice\"", StringComparison.Ordinal), "VisualCanvas Cover image fit should map to SVG slice behavior.");
+        Assert(nativeSvg.Contains("preserveAspectRatio=\"xMidYMid meet\"", StringComparison.Ordinal), "VisualCanvas Contain image fit should map to SVG meet behavior.");
+        Assert(nativeCanvas.ToPng().Length > 64, "VisualCanvas should render embedded ChartForgeX renderables to PNG output.");
+        Assert(nativeCanvas.ToBmp().Length > 64, "VisualCanvas should render embedded ChartForgeX renderables to BMP output.");
+
         var overlay = VisualCanvas.CreateDesktopWallpaper()
             .WithTitle("Transparent overlay")
             .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
@@ -47,6 +92,19 @@ internal static partial class SmokeTests {
         AssertThrows<ArgumentOutOfRangeException>(() => canvas.PngOutputScale = 5, "VisualCanvas should reject unsupported PNG output scales.");
         AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").Progress = 1.2, "VisualCanvas info tile progress should stay normalized.");
         AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").WithMiniChart(VisualCanvasInfoTileMiniChartKind.Sparkline, new[] { double.NaN }), "VisualCanvas info tile mini charts should reject invalid values.");
-        AssertThrows<NotSupportedException>(() => canvas.Save("canvas.html"), "VisualCanvas extension-inferred save should fail clearly for unsupported formats.");
+        AssertThrows<ArgumentOutOfRangeException>(() => VisualCanvas.Create(24, 24).AddImage(0, 0, 12, 12, rgba: new byte[] { 0, 0, 0, 255 }, sourceWidth: 1, sourceHeight: 1, fit: (VisualCanvasImageFit)999), "VisualCanvas image fit should reject unknown values.");
+        var htmlPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "chartforgex-visual-canvas-" + Guid.NewGuid().ToString("N") + ".html");
+        var ppmPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "chartforgex-visual-canvas-" + Guid.NewGuid().ToString("N") + ".ppm");
+        try {
+            canvas.Save(htmlPath);
+            var html = System.IO.File.ReadAllText(htmlPath, System.Text.Encoding.UTF8);
+            Assert(html.Contains("<!DOCTYPE html>", StringComparison.OrdinalIgnoreCase) && html.Contains("data-cfx-role=\"visual-canvas-info-tile\"", StringComparison.Ordinal), "VisualCanvas extension-inferred save should support HTML output.");
+            nativeCanvas.Save(ppmPath);
+            var ppm = System.IO.File.ReadAllBytes(ppmPath);
+            Assert(ppm.Length > 64 && ppm[0] == (byte)'P' && ppm[1] == (byte)'6', "VisualCanvas extension-inferred save should support opaque raster output.");
+        } finally {
+            if (System.IO.File.Exists(htmlPath)) System.IO.File.Delete(htmlPath);
+            if (System.IO.File.Exists(ppmPath)) System.IO.File.Delete(ppmPath);
+        }
     }
 }

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -12,7 +12,7 @@ internal static partial class SmokeTests {
             .WithBackdrop(VisualCanvasBackdropStyle.TechHorizon)
             .AddInfoTile(48, 92, 300, 82, "PC", "HOSTNAME", "DEV-WKS-01", accent: ChartColor.FromHex("#2F80FF"))
             .AddInfoTile(48, 190, 300, 82, "IP", "IP ADDRESS", "10.0.0.42", "192.168.1.42", ChartColor.FromHex("#2F80FF"))
-            .AddInfoTile(852, 70, 300, 96, "CPU", "CPU", "Intel Core i7", accent: ChartColor.FromHex("#60A5FA"), progress: 0.23, miniChartKind: VisualCanvasInfoTileMiniChartKind.Area, miniChartValues: new[] { 18d, 26d, 22d, 37d, 48d, 43d })
+            .AddInfoTile(852, 70, 300, 96, "CPU", "CPU", "Intel Core i7", accent: ChartColor.FromHex("#60A5FA"), progress: 0.23, surfaceStyle: VisualCanvasInfoTileSurfaceStyle.Raised, miniChartKind: VisualCanvasInfoTileMiniChartKind.Area, miniChartValues: new[] { 18d, 26d, 22d, 37d, 48d, 43d })
             .AddInfoTile(852, 184, 300, 96, "RAM", "RAM", "32.0 GB", accent: ChartColor.FromHex("#60A5FA"), progress: 0.41, miniChartKind: VisualCanvasInfoTileMiniChartKind.Bars, miniChartValues: new[] { 42d, 48d, 51d, 55d, 52d })
             .AddHeroBadge(538, 157, 124, 88, ">_", ChartColor.FromHex("#22A7FF"))
             .AddHeroTitle(312, 296, 576, 82, new[] {

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -1,0 +1,50 @@
+using System;
+using ChartForgeX.Composition;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void VisualCanvasComposesWallpaperStyleArtboards() {
+        var canvas = VisualCanvas.CreateSocialPreview()
+            .WithTitle("PowerBGInfo social preview")
+            .WithBackground(ChartColor.FromHex("#020713"), ChartColor.FromHex("#071A35"))
+            .WithBackdrop(VisualCanvasBackdropStyle.TechHorizon)
+            .AddInfoTile(48, 92, 300, 82, "PC", "HOSTNAME", "DEV-WKS-01", accent: ChartColor.FromHex("#2F80FF"))
+            .AddInfoTile(48, 190, 300, 82, "IP", "IP ADDRESS", "10.0.0.42", "192.168.1.42", ChartColor.FromHex("#2F80FF"))
+            .AddInfoTile(852, 70, 300, 96, "CPU", "CPU", "Intel Core i7", accent: ChartColor.FromHex("#60A5FA"), progress: 0.23)
+            .AddInfoTile(852, 184, 300, 96, "RAM", "RAM", "32.0 GB", accent: ChartColor.FromHex("#60A5FA"), progress: 0.41)
+            .AddHeroBadge(538, 157, 124, 88, ">_", ChartColor.FromHex("#22A7FF"))
+            .AddHeroTitle(312, 296, 576, 82, new[] {
+                new VisualCanvasTextRun("Power", ChartColor.FromHex("#F8FAFC")),
+                new VisualCanvasTextRun("BGInfo", ChartColor.FromHex("#2F80FF"))
+            })
+            .AddText(240, 402, 720, "Desktop background insights for Windows and PowerShell", 24, ChartColor.FromHex("#C6D3EA"), VisualCanvasTextAlignment.Center)
+            .AddFeatureStrip(290, 522, 620, 62, new[] {
+                new VisualCanvasFeatureItem("PS", "LIGHTWEIGHT"),
+                new VisualCanvasFeatureItem("OK", "SECURE"),
+                new VisualCanvasFeatureItem("UI", "CUSTOMIZABLE"),
+                new VisualCanvasFeatureItem("OS", "OPEN SOURCE")
+            });
+
+        var svg = canvas.ToSvg("visual-canvas-smoke");
+        Assert(svg.Contains("data-cfx-role=\"visual-canvas-background\"", StringComparison.Ordinal), "VisualCanvas should render a background role in SVG.");
+        Assert(svg.Contains("data-cfx-role=\"visual-canvas-info-tile\"", StringComparison.Ordinal), "VisualCanvas should render info tile layers in SVG.");
+        Assert(svg.Contains("data-cfx-role=\"visual-canvas-hero-title\"", StringComparison.Ordinal), "VisualCanvas should render multi-run hero titles in SVG.");
+        Assert(svg.Contains("Power", StringComparison.Ordinal) && svg.Contains("BGInfo", StringComparison.Ordinal), "VisualCanvas hero title should preserve colored title runs.");
+        Assert(canvas.ToPng().Length > 64, "VisualCanvas should render PNG output.");
+
+        var overlay = VisualCanvas.CreateDesktopWallpaper()
+            .WithTitle("Transparent overlay")
+            .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+            .AddInfoTile(80, 120, 360, 92, "PC", "HOSTNAME", "DEV-WKS-01", surfaceStyle: VisualCanvasInfoTileSurfaceStyle.Outline, iconKind: VisualCanvasInfoTileIconKind.Computer);
+        var overlaySvg = overlay.ToSvg("visual-canvas-overlay");
+        Assert(!overlaySvg.Contains("data-cfx-role=\"visual-canvas-background\"", StringComparison.Ordinal), "Transparent VisualCanvas overlays should not render a full background rect.");
+        Assert(overlay.ToPng().Length > 64, "Transparent VisualCanvas overlays should render PNG output.");
+
+        AssertThrows<ArgumentOutOfRangeException>(() => VisualCanvas.Create(0, 630), "VisualCanvas should reject invalid widths.");
+        AssertThrows<ArgumentOutOfRangeException>(() => canvas.PngOutputScale = 5, "VisualCanvas should reject unsupported PNG output scales.");
+        AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").Progress = 1.2, "VisualCanvas info tile progress should stay normalized.");
+        AssertThrows<NotSupportedException>(() => canvas.Save("canvas.html"), "VisualCanvas extension-inferred save should fail clearly for unsupported formats.");
+    }
+}

--- a/ChartForgeX/ChartExtensions.Raster.cs
+++ b/ChartForgeX/ChartExtensions.Raster.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using ChartForgeX.Composition;
 using ChartForgeX.Core;
 using ChartForgeX.Raster;
 using ChartForgeX.VisualBlocks;
@@ -469,4 +470,102 @@ public static partial class ChartExtensions {
     /// <param name="path">The output file path.</param>
     /// <param name="options">Optional raster export options.</param>
     public static void SaveRasterImage(this VisualGrid grid, string path, RasterImageOptions? options = null) => grid.SaveRasterImage(path, RasterImageFormatExtensions.FromFileExtension(path), options);
+
+    /// <summary>
+    /// Renders a visual canvas to BMP bytes.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="options">Optional raster export options.</param>
+    /// <returns>A BMP image.</returns>
+    public static byte[] ToBmp(this VisualCanvas canvas, RasterImageOptions? options = null) => canvas.ToRasterImage(RasterImageFormat.Bmp, options);
+
+    /// <summary>
+    /// Renders a visual canvas to PPM bytes.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="options">Optional raster export options.</param>
+    /// <returns>A PPM image.</returns>
+    public static byte[] ToPpm(this VisualCanvas canvas, RasterImageOptions? options = null) => canvas.ToRasterImage(RasterImageFormat.Ppm, options);
+
+    /// <summary>
+    /// Renders a visual canvas to TIFF bytes.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="options">Optional raster export options.</param>
+    /// <returns>A TIFF image.</returns>
+    public static byte[] ToTiff(this VisualCanvas canvas, RasterImageOptions? options = null) => canvas.ToRasterImage(RasterImageFormat.Tiff, options);
+
+    /// <summary>
+    /// Renders a visual canvas to opaque raster image bytes.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="format">The raster image format.</param>
+    /// <param name="options">Optional raster export options.</param>
+    /// <returns>Encoded raster image bytes.</returns>
+    public static byte[] ToRasterImage(this VisualCanvas canvas, RasterImageFormat format, RasterImageOptions? options = null) {
+        RasterImageEncoder.ThrowIfUnsupported(format);
+        return RasterImageEncoder.Encode(new PngVisualCanvasRenderer().RenderImage(canvas), format, options);
+    }
+
+    /// <summary>
+    /// Writes a visual canvas to an opaque raster image stream.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="stream">The destination stream.</param>
+    /// <param name="format">The raster image format.</param>
+    /// <param name="options">Optional raster export options.</param>
+    public static void WriteRasterImage(this VisualCanvas canvas, Stream stream, RasterImageFormat format, RasterImageOptions? options = null) {
+        RasterImageEncoder.ThrowIfNull(stream);
+        RasterImageEncoder.ThrowIfUnsupported(format);
+        RasterImageEncoder.WriteTo(stream, new PngVisualCanvasRenderer().RenderImage(canvas), format, options);
+    }
+
+    /// <summary>
+    /// Writes a visual canvas to a BMP stream.
+    /// </summary>
+    public static void WriteBmp(this VisualCanvas canvas, Stream stream, RasterImageOptions? options = null) => canvas.WriteRasterImage(stream, RasterImageFormat.Bmp, options);
+
+    /// <summary>
+    /// Writes a visual canvas to a PPM stream.
+    /// </summary>
+    public static void WritePpm(this VisualCanvas canvas, Stream stream, RasterImageOptions? options = null) => canvas.WriteRasterImage(stream, RasterImageFormat.Ppm, options);
+
+    /// <summary>
+    /// Writes a visual canvas to a TIFF stream.
+    /// </summary>
+    public static void WriteTiff(this VisualCanvas canvas, Stream stream, RasterImageOptions? options = null) => canvas.WriteRasterImage(stream, RasterImageFormat.Tiff, options);
+
+    /// <summary>
+    /// Saves a visual canvas as a BMP file.
+    /// </summary>
+    public static void SaveBmp(this VisualCanvas canvas, string path, RasterImageOptions? options = null) => canvas.SaveRasterImage(path, RasterImageFormat.Bmp, options);
+
+    /// <summary>
+    /// Saves a visual canvas as a PPM file.
+    /// </summary>
+    public static void SavePpm(this VisualCanvas canvas, string path, RasterImageOptions? options = null) => canvas.SaveRasterImage(path, RasterImageFormat.Ppm, options);
+
+    /// <summary>
+    /// Saves a visual canvas as a TIFF file.
+    /// </summary>
+    public static void SaveTiff(this VisualCanvas canvas, string path, RasterImageOptions? options = null) => canvas.SaveRasterImage(path, RasterImageFormat.Tiff, options);
+
+    /// <summary>
+    /// Saves a visual canvas as an opaque raster image file.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="path">The output file path.</param>
+    /// <param name="format">The raster image format.</param>
+    /// <param name="options">Optional raster export options.</param>
+    public static void SaveRasterImage(this VisualCanvas canvas, string path, RasterImageFormat format, RasterImageOptions? options = null) {
+        File.WriteAllBytes(path, canvas.ToRasterImage(format, options));
+    }
+
+    /// <summary>
+    /// Saves a visual canvas as an opaque raster image file using the output path extension to choose the format.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="path">The output file path.</param>
+    /// <param name="options">Optional raster export options.</param>
+    public static void SaveRasterImage(this VisualCanvas canvas, string path, RasterImageOptions? options = null) => canvas.SaveRasterImage(path, RasterImageFormatExtensions.FromFileExtension(path), options);
 }

--- a/ChartForgeX/ChartExtensions.Save.cs
+++ b/ChartForgeX/ChartExtensions.Save.cs
@@ -1,5 +1,6 @@
 using System;
 using ChartForgeX.Core;
+using ChartForgeX.Composition;
 using ChartForgeX.VisualBlocks;
 
 namespace ChartForgeX;
@@ -47,6 +48,25 @@ public static partial class ChartExtensions {
     public static void Save(this VisualGrid grid, string path, RasterImageOptions? rasterOptions = null) {
         if (TrySaveCommonOutput(path, () => grid.SaveSvg(path), () => grid.SaveHtml(path), () => grid.SavePng(path))) return;
         grid.SaveRasterImage(path, rasterOptions);
+    }
+
+    /// <summary>
+    /// Saves a visual canvas using the output path extension to choose SVG or PNG.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="path">The output file path.</param>
+    public static void Save(this VisualCanvas canvas, string path) {
+        var extension = GetExportExtension(path);
+        switch (extension) {
+            case ".svg":
+                canvas.SaveSvg(path);
+                return;
+            case ".png":
+                canvas.SavePng(path);
+                return;
+            default:
+                throw new NotSupportedException("Visual canvas Save supports .svg and .png output.");
+        }
     }
 
     private static bool TrySaveCommonOutput(string path, Action saveSvg, Action saveHtml, Action savePng) {

--- a/ChartForgeX/ChartExtensions.Save.cs
+++ b/ChartForgeX/ChartExtensions.Save.cs
@@ -51,22 +51,14 @@ public static partial class ChartExtensions {
     }
 
     /// <summary>
-    /// Saves a visual canvas using the output path extension to choose SVG or PNG.
+    /// Saves a visual canvas using the output path extension to choose SVG, HTML, PNG, or an opaque raster image format.
     /// </summary>
     /// <param name="canvas">The visual canvas to render.</param>
     /// <param name="path">The output file path.</param>
-    public static void Save(this VisualCanvas canvas, string path) {
-        var extension = GetExportExtension(path);
-        switch (extension) {
-            case ".svg":
-                canvas.SaveSvg(path);
-                return;
-            case ".png":
-                canvas.SavePng(path);
-                return;
-            default:
-                throw new NotSupportedException("Visual canvas Save supports .svg and .png output.");
-        }
+    /// <param name="rasterOptions">Optional raster export options for opaque raster formats.</param>
+    public static void Save(this VisualCanvas canvas, string path, RasterImageOptions? rasterOptions = null) {
+        if (TrySaveCommonOutput(path, () => canvas.SaveSvg(path), () => canvas.SaveHtml(path), () => canvas.SavePng(path))) return;
+        canvas.SaveRasterImage(path, rasterOptions);
     }
 
     private static bool TrySaveCommonOutput(string path, Action saveSvg, Action saveHtml, Action savePng) {

--- a/ChartForgeX/ChartExtensions.cs
+++ b/ChartForgeX/ChartExtensions.cs
@@ -7,6 +7,7 @@ using ChartForgeX.Primitives;
 using ChartForgeX.Raster;
 using ChartForgeX.Svg;
 using ChartForgeX.Themes;
+using ChartForgeX.Composition;
 using ChartForgeX.VisualBlocks;
 
 namespace ChartForgeX;
@@ -408,4 +409,40 @@ public static partial class ChartExtensions {
     /// <param name="grid">The visual grid to render.</param>
     /// <param name="path">The output file path.</param>
     public static void SavePng(this VisualGrid grid, string path) => File.WriteAllBytes(path, grid.ToPng());
+
+    /// <summary>
+    /// Renders a visual canvas to SVG markup.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <returns>SVG markup.</returns>
+    public static string ToSvg(this VisualCanvas canvas) => new SvgVisualCanvasRenderer().Render(canvas);
+
+    /// <summary>
+    /// Renders a visual canvas to SVG markup with an additional deterministic ID scope.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="idScope">A caller-provided scope used to keep SVG element IDs unique when embedding multiple SVGs in one document.</param>
+    /// <returns>SVG markup.</returns>
+    public static string ToSvg(this VisualCanvas canvas, string idScope) => new SvgVisualCanvasRenderer().Render(canvas, idScope);
+
+    /// <summary>
+    /// Renders a visual canvas to PNG bytes.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <returns>A PNG image.</returns>
+    public static byte[] ToPng(this VisualCanvas canvas) => new PngVisualCanvasRenderer().Render(canvas);
+
+    /// <summary>
+    /// Saves a visual canvas as an SVG file.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="path">The output file path.</param>
+    public static void SaveSvg(this VisualCanvas canvas, string path) => File.WriteAllText(path, canvas.ToSvg(), Encoding.UTF8);
+
+    /// <summary>
+    /// Saves a visual canvas as a PNG file.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="path">The output file path.</param>
+    public static void SavePng(this VisualCanvas canvas, string path) => File.WriteAllBytes(path, canvas.ToPng());
 }

--- a/ChartForgeX/ChartExtensions.cs
+++ b/ChartForgeX/ChartExtensions.cs
@@ -475,11 +475,29 @@ public static partial class ChartExtensions {
     }
 
     /// <summary>
+    /// Adds a rendered chart layer to a visual canvas using anchor-based placement.
+    /// </summary>
+    public static VisualCanvas AddChart(this VisualCanvas canvas, VisualCanvasPlacement placement, double width, double height, Chart chart, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var bounds = canvas.ResolvePlacement(placement, width, height);
+        return canvas.AddChart(bounds.X, bounds.Y, bounds.Width, bounds.Height, chart, fit, opacity);
+    }
+
+    /// <summary>
     /// Adds a rendered chart grid layer to a visual canvas.
     /// </summary>
     public static VisualCanvas AddChartGrid(this VisualCanvas canvas, double x, double y, double width, double height, ChartGrid grid, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
         if (grid == null) throw new ArgumentNullException(nameof(grid));
         return AddRenderedImage(canvas, x, y, width, height, RasterRenderer.RenderImage(grid), SvgDataUri(grid.ToSvg()), fit, opacity);
+    }
+
+    /// <summary>
+    /// Adds a rendered chart grid layer to a visual canvas using anchor-based placement.
+    /// </summary>
+    public static VisualCanvas AddChartGrid(this VisualCanvas canvas, VisualCanvasPlacement placement, double width, double height, ChartGrid grid, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var bounds = canvas.ResolvePlacement(placement, width, height);
+        return canvas.AddChartGrid(bounds.X, bounds.Y, bounds.Width, bounds.Height, grid, fit, opacity);
     }
 
     /// <summary>
@@ -491,6 +509,15 @@ public static partial class ChartExtensions {
     }
 
     /// <summary>
+    /// Adds a rendered visual block layer to a visual canvas using anchor-based placement.
+    /// </summary>
+    public static VisualCanvas AddVisualBlock(this VisualCanvas canvas, VisualCanvasPlacement placement, double width, double height, IVisualBlock block, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var bounds = canvas.ResolvePlacement(placement, width, height);
+        return canvas.AddVisualBlock(bounds.X, bounds.Y, bounds.Width, bounds.Height, block, fit, opacity);
+    }
+
+    /// <summary>
     /// Adds a rendered visual grid layer to a visual canvas.
     /// </summary>
     public static VisualCanvas AddVisualGrid(this VisualCanvas canvas, double x, double y, double width, double height, VisualGrid grid, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
@@ -499,11 +526,29 @@ public static partial class ChartExtensions {
     }
 
     /// <summary>
+    /// Adds a rendered visual grid layer to a visual canvas using anchor-based placement.
+    /// </summary>
+    public static VisualCanvas AddVisualGrid(this VisualCanvas canvas, VisualCanvasPlacement placement, double width, double height, VisualGrid grid, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var bounds = canvas.ResolvePlacement(placement, width, height);
+        return canvas.AddVisualGrid(bounds.X, bounds.Y, bounds.Width, bounds.Height, grid, fit, opacity);
+    }
+
+    /// <summary>
     /// Adds a rendered topology chart layer to a visual canvas.
     /// </summary>
     public static VisualCanvas AddTopology(this VisualCanvas canvas, double x, double y, double width, double height, TopologyChart topology, TopologyRenderOptions? options = null, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
         if (topology == null) throw new ArgumentNullException(nameof(topology));
         return AddRenderedImage(canvas, x, y, width, height, TopologyRasterRenderer.RenderImage(topology, options), SvgDataUri(topology.ToSvg(options)), fit, opacity);
+    }
+
+    /// <summary>
+    /// Adds a rendered topology chart layer to a visual canvas using anchor-based placement.
+    /// </summary>
+    public static VisualCanvas AddTopology(this VisualCanvas canvas, VisualCanvasPlacement placement, double width, double height, TopologyChart topology, TopologyRenderOptions? options = null, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var bounds = canvas.ResolvePlacement(placement, width, height);
+        return canvas.AddTopology(bounds.X, bounds.Y, bounds.Width, bounds.Height, topology, options, fit, opacity);
     }
 
     private static VisualCanvas AddRenderedImage(VisualCanvas canvas, double x, double y, double width, double height, RgbaImage image, string href, VisualCanvasImageFit fit, double opacity) {

--- a/ChartForgeX/ChartExtensions.cs
+++ b/ChartForgeX/ChartExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net;
 using System.Text;
 using ChartForgeX.Core;
 using ChartForgeX.Html;
@@ -8,6 +9,7 @@ using ChartForgeX.Raster;
 using ChartForgeX.Svg;
 using ChartForgeX.Themes;
 using ChartForgeX.Composition;
+using ChartForgeX.Topology;
 using ChartForgeX.VisualBlocks;
 
 namespace ChartForgeX;
@@ -433,6 +435,17 @@ public static partial class ChartExtensions {
     public static byte[] ToPng(this VisualCanvas canvas) => new PngVisualCanvasRenderer().Render(canvas);
 
     /// <summary>
+    /// Renders a visual canvas to a complete HTML document.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <returns>An HTML page.</returns>
+    public static string ToHtmlPage(this VisualCanvas canvas) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var title = WebUtility.HtmlEncode(canvas.Title.Length == 0 ? "ChartForgeX visual canvas" : canvas.Title);
+        return "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>" + title + "</title><style>html,body{margin:0;min-height:100%;background:#020617}body{display:grid;place-items:center;padding:24px;box-sizing:border-box;background:linear-gradient(180deg,#020617,#0b1120);font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;text-rendering:geometricPrecision}.chartforgex-visual-canvas{max-width:100%;height:auto}.chartforgex-visual-canvas svg{display:block;max-width:100%;height:auto;overflow:visible}@media print{html,body{background:transparent}body{padding:0}.chartforgex-visual-canvas{max-width:none}}</style></head><body><div class=\"chartforgex-visual-canvas\">" + canvas.ToSvg("html-page") + "</div></body></html>";
+    }
+
+    /// <summary>
     /// Saves a visual canvas as an SVG file.
     /// </summary>
     /// <param name="canvas">The visual canvas to render.</param>
@@ -440,9 +453,67 @@ public static partial class ChartExtensions {
     public static void SaveSvg(this VisualCanvas canvas, string path) => File.WriteAllText(path, canvas.ToSvg(), Encoding.UTF8);
 
     /// <summary>
+    /// Saves a visual canvas as a complete HTML file.
+    /// </summary>
+    /// <param name="canvas">The visual canvas to render.</param>
+    /// <param name="path">The output file path.</param>
+    public static void SaveHtml(this VisualCanvas canvas, string path) => File.WriteAllText(path, canvas.ToHtmlPage(), Encoding.UTF8);
+
+    /// <summary>
     /// Saves a visual canvas as a PNG file.
     /// </summary>
     /// <param name="canvas">The visual canvas to render.</param>
     /// <param name="path">The output file path.</param>
     public static void SavePng(this VisualCanvas canvas, string path) => File.WriteAllBytes(path, canvas.ToPng());
+
+    /// <summary>
+    /// Adds a rendered chart layer to a visual canvas.
+    /// </summary>
+    public static VisualCanvas AddChart(this VisualCanvas canvas, double x, double y, double width, double height, Chart chart, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (chart == null) throw new ArgumentNullException(nameof(chart));
+        return AddRenderedImage(canvas, x, y, width, height, RasterRenderer.RenderImage(chart), SvgDataUri(chart.ToSvg("visual-canvas-chart")), fit, opacity);
+    }
+
+    /// <summary>
+    /// Adds a rendered chart grid layer to a visual canvas.
+    /// </summary>
+    public static VisualCanvas AddChartGrid(this VisualCanvas canvas, double x, double y, double width, double height, ChartGrid grid, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (grid == null) throw new ArgumentNullException(nameof(grid));
+        return AddRenderedImage(canvas, x, y, width, height, RasterRenderer.RenderImage(grid), SvgDataUri(grid.ToSvg()), fit, opacity);
+    }
+
+    /// <summary>
+    /// Adds a rendered visual block layer to a visual canvas.
+    /// </summary>
+    public static VisualCanvas AddVisualBlock(this VisualCanvas canvas, double x, double y, double width, double height, IVisualBlock block, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (block == null) throw new ArgumentNullException(nameof(block));
+        return AddRenderedImage(canvas, x, y, width, height, RasterRenderer.RenderImage(block), SvgDataUri(block.ToSvg()), fit, opacity);
+    }
+
+    /// <summary>
+    /// Adds a rendered visual grid layer to a visual canvas.
+    /// </summary>
+    public static VisualCanvas AddVisualGrid(this VisualCanvas canvas, double x, double y, double width, double height, VisualGrid grid, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (grid == null) throw new ArgumentNullException(nameof(grid));
+        return AddRenderedImage(canvas, x, y, width, height, RasterRenderer.RenderImage(grid), SvgDataUri(grid.ToSvg()), fit, opacity);
+    }
+
+    /// <summary>
+    /// Adds a rendered topology chart layer to a visual canvas.
+    /// </summary>
+    public static VisualCanvas AddTopology(this VisualCanvas canvas, double x, double y, double width, double height, TopologyChart topology, TopologyRenderOptions? options = null, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (topology == null) throw new ArgumentNullException(nameof(topology));
+        return AddRenderedImage(canvas, x, y, width, height, TopologyRasterRenderer.RenderImage(topology, options), SvgDataUri(topology.ToSvg(options)), fit, opacity);
+    }
+
+    private static VisualCanvas AddRenderedImage(VisualCanvas canvas, double x, double y, double width, double height, RgbaImage image, string href, VisualCanvasImageFit fit, double opacity) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        VisualCanvas.ValidateEnum(fit, nameof(fit));
+        return canvas.AddImage(x, y, width, height, href, image.Pixels, image.Width, image.Height, opacity, fit);
+    }
+
+    private static string SvgDataUri(string svg) {
+        if (svg == null) throw new ArgumentNullException(nameof(svg));
+        return "data:image/svg+xml;charset=utf-8," + Uri.EscapeDataString(svg);
+    }
 }

--- a/ChartForgeX/ChartForgeX.csproj
+++ b/ChartForgeX/ChartForgeX.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(PublishAot)' == 'true'">net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>latest</LangVersion>

--- a/ChartForgeX/Raster/RgbaCanvas.cs
+++ b/ChartForgeX/Raster/RgbaCanvas.cs
@@ -180,9 +180,17 @@ internal sealed partial class RgbaCanvas {
         if (rgba == null) throw new ArgumentNullException(nameof(rgba));
         if (destinationWidth <= 0 || destinationHeight <= 0 || sourceWidth <= 0 || sourceHeight <= 0) return;
         if (rgba.Length < sourceWidth * sourceHeight * 4) throw new ArgumentException("RGBA buffer is smaller than the requested source dimensions.", nameof(rgba));
+        DrawImageScaled(x, y, destinationWidth, destinationHeight, sourceWidth, sourceHeight, rgba, 0, 0, sourceWidth, sourceHeight);
+    }
+
+    public void DrawImageScaled(int x, int y, int destinationWidth, int destinationHeight, int sourceWidth, int sourceHeight, byte[] rgba, double sourceX, double sourceY, double sourceRectWidth, double sourceRectHeight) {
+        if (rgba == null) throw new ArgumentNullException(nameof(rgba));
+        if (destinationWidth <= 0 || destinationHeight <= 0 || sourceWidth <= 0 || sourceHeight <= 0 || sourceRectWidth <= 0 || sourceRectHeight <= 0) return;
+        if (rgba.Length < sourceWidth * sourceHeight * 4) throw new ArgumentException("RGBA buffer is smaller than the requested source dimensions.", nameof(rgba));
         var scaledDestinationWidth = destinationWidth * _scale;
         var scaledDestinationHeight = destinationHeight * _scale;
-        if (scaledDestinationWidth == sourceWidth && scaledDestinationHeight == sourceHeight) {
+        if (sourceX == 0 && sourceY == 0 && Math.Abs(sourceRectWidth - sourceWidth) < 0.000001 && Math.Abs(sourceRectHeight - sourceHeight) < 0.000001 &&
+            scaledDestinationWidth == sourceWidth && scaledDestinationHeight == sourceHeight) {
             DrawImage(x, y, sourceWidth, sourceHeight, rgba);
             return;
         }
@@ -197,8 +205,8 @@ internal sealed partial class RgbaCanvas {
                 rgba,
                 sourceWidth,
                 sourceHeight,
-                (dx + 0.5) * sourceWidth / scaledDestinationWidth - 0.5,
-                (dy + 0.5) * sourceHeight / scaledDestinationHeight - 0.5);
+                sourceX + (dx + 0.5) * sourceRectWidth / scaledDestinationWidth - 0.5,
+                sourceY + (dy + 0.5) * sourceRectHeight / scaledDestinationHeight - 0.5);
             if (color.A == 0) continue;
             BlendPixel(targetX, targetY, color);
         }

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -323,6 +323,9 @@ public sealed class PngVisualCanvasRenderer {
 
     private static void DrawImage(RgbaCanvas canvas, VisualCanvasImageLayer image, VisualCanvasTheme theme) {
         VisualCanvas.ValidateEnum(image.Fit, nameof(image.Fit));
+        if (image.Rgba != null && (image.SourceWidth <= 0 || image.SourceHeight <= 0)) {
+            throw new ArgumentOutOfRangeException(nameof(image.SourceWidth), "RGBA image layers require positive source dimensions.");
+        }
         if (image.Rgba != null && image.SourceWidth > 0 && image.SourceHeight > 0) {
             var rgba = image.Opacity >= 0.999 ? image.Rgba : ApplyOpacity(image.Rgba, image.Opacity);
             DrawFittedImage(canvas, image, rgba);

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -105,32 +105,19 @@ public sealed class PngVisualCanvasRenderer {
         var isRaised = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Raised;
         var isFilled = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass || isRaised;
         if (isRaised) {
-            var depthX = Math.Max(14, Math.Min(24, width * 0.042));
-            var depthY = Math.Max(14, Math.Min(24, height * 0.22));
-            var shadow = ChartColor.Black.WithOpacity(0.58);
-            canvas.FillRoundedRect(x + depthX + 4, y + depthY + 5, width, height, radius + 2, shadow);
-            canvas.FillRoundedRect(x + depthX, y + depthY, width, height, radius + 1, tile.Accent.WithOpacity(0.20));
-            canvas.FillPolygon(new[] {
-                new ChartPoint(x + width, y + radius * 0.7),
-                new ChartPoint(x + width + depthX, y + depthY + radius * 0.7),
-                new ChartPoint(x + width + depthX, y + height + depthY - radius * 0.7),
-                new ChartPoint(x + width, y + height - radius * 0.7)
-            }, tile.Accent.WithOpacity(0.32));
-            canvas.FillPolygon(new[] {
-                new ChartPoint(x + radius * 0.7, y + height),
-                new ChartPoint(x + width - radius * 0.7, y + height),
-                new ChartPoint(x + width + depthX - radius * 0.7, y + height + depthY),
-                new ChartPoint(x + depthX + radius * 0.7, y + height + depthY)
-            }, ChartColor.Black.WithOpacity(0.42));
-            canvas.DrawLine(x + width - 1, y + radius, x + width + depthX - 1, y + depthY + radius, tile.Accent.WithOpacity(0.62), 2.0);
-            canvas.DrawLine(x + radius, y + height - 1, x + depthX + radius, y + height + depthY - 1, tile.Accent.WithOpacity(0.48), 1.7);
+            canvas.FillRoundedRect(x + 10, y + 13, width, height, radius + 2, ChartColor.Black.WithOpacity(0.42));
+            canvas.FillRoundedRect(x + 4, y + 6, width, height, radius + 1, ChartColor.Black.WithOpacity(0.24));
+            canvas.FillRoundedRect(x - 5, y - 5, width + 10, height + 10, radius + 5, tile.Accent.WithOpacity(0.11));
+            canvas.FillRoundedRect(x - 2, y - 2, width + 4, height + 4, radius + 2, tile.Accent.WithOpacity(0.13));
         }
         if (isFilled) {
             canvas.FillRoundedRectVerticalGradient(x, y, width, height, radius, theme.TileGlassTop, theme.TileGlassBottom);
         }
         if (isRaised) {
             canvas.FillRoundedRectVerticalGradient(x + 2, y + 2, Math.Max(1, width - 4), Math.Max(1, height * 0.52), Math.Max(1, radius - 2), ChartColor.White.WithOpacity(0.20), ChartColor.White.WithOpacity(0.03));
-            canvas.StrokeRoundedRect(x - 2, y - 2, width + 4, height + 4, radius + 2, tile.Accent.WithOpacity(0.48), 4.4);
+            canvas.StrokeRoundedRect(x - 2, y - 2, width + 4, height + 4, radius + 2, tile.Accent.WithOpacity(0.42), 3.2);
+            canvas.DrawLine(x + radius, y + 3, x + width - radius, y + 3, ChartColor.White.WithOpacity(0.28), 1.4);
+            canvas.DrawLine(x + radius, y + height - 2, x + width - radius, y + height - 2, tile.Accent.WithOpacity(0.48), 1.6);
         }
         canvas.StrokeRoundedRect(x + 0.5, y + 0.5, Math.Max(1, width - 1), Math.Max(1, height - 1), radius, tile.Accent.WithOpacity(isRaised ? 0.92 : 0.72), isRaised ? 2.2 : 1.4);
         if (isFilled) {

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -104,22 +104,23 @@ public sealed class PngVisualCanvasRenderer {
         var radius = Math.Min(16, height * 0.18);
         var isRaised = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Raised;
         var isFilled = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass || isRaised;
+        var accent = tile.AccentOverride ?? theme.Accent;
         if (isRaised) {
             canvas.FillRoundedRect(x + 10, y + 13, width, height, radius + 2, ChartColor.Black.WithOpacity(0.42));
             canvas.FillRoundedRect(x + 4, y + 6, width, height, radius + 1, ChartColor.Black.WithOpacity(0.24));
-            canvas.FillRoundedRect(x - 5, y - 5, width + 10, height + 10, radius + 5, tile.Accent.WithOpacity(0.11));
-            canvas.FillRoundedRect(x - 2, y - 2, width + 4, height + 4, radius + 2, tile.Accent.WithOpacity(0.13));
+            canvas.FillRoundedRect(x - 5, y - 5, width + 10, height + 10, radius + 5, accent.WithOpacity(0.11));
+            canvas.FillRoundedRect(x - 2, y - 2, width + 4, height + 4, radius + 2, accent.WithOpacity(0.13));
         }
         if (isFilled) {
             canvas.FillRoundedRectVerticalGradient(x, y, width, height, radius, theme.TileGlassTop, theme.TileGlassBottom);
         }
         if (isRaised) {
             canvas.FillRoundedRectVerticalGradient(x + 2, y + 2, Math.Max(1, width - 4), Math.Max(1, height * 0.52), Math.Max(1, radius - 2), ChartColor.White.WithOpacity(0.20), ChartColor.White.WithOpacity(0.03));
-            canvas.StrokeRoundedRect(x - 2, y - 2, width + 4, height + 4, radius + 2, tile.Accent.WithOpacity(0.42), 3.2);
+            canvas.StrokeRoundedRect(x - 2, y - 2, width + 4, height + 4, radius + 2, accent.WithOpacity(0.42), 3.2);
             canvas.DrawLine(x + radius, y + 3, x + width - radius, y + 3, ChartColor.White.WithOpacity(0.28), 1.4);
-            canvas.DrawLine(x + radius, y + height - 2, x + width - radius, y + height - 2, tile.Accent.WithOpacity(0.48), 1.6);
+            canvas.DrawLine(x + radius, y + height - 2, x + width - radius, y + height - 2, accent.WithOpacity(0.48), 1.6);
         }
-        canvas.StrokeRoundedRect(x + 0.5, y + 0.5, Math.Max(1, width - 1), Math.Max(1, height - 1), radius, tile.Accent.WithOpacity(isRaised ? 0.92 : 0.72), isRaised ? 2.2 : 1.4);
+        canvas.StrokeRoundedRect(x + 0.5, y + 0.5, Math.Max(1, width - 1), Math.Max(1, height - 1), radius, accent.WithOpacity(isRaised ? 0.92 : 0.72), isRaised ? 2.2 : 1.4);
         if (isFilled) {
             canvas.StrokeRoundedRect(x + 2.5, y + 2.5, Math.Max(1, width - 5), Math.Max(1, height - 5), Math.Max(1, radius - 2), theme.TileInnerStroke, 1);
         }
@@ -129,12 +130,12 @@ public sealed class PngVisualCanvasRenderer {
         var iconY = y + (height - iconBox) / 2;
         var iconRadius = Math.Min(13, iconBox * 0.25);
         if (isFilled) {
-            canvas.FillRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, tile.Accent.WithOpacity(isRaised ? 0.25 : 0.18));
-            if (isRaised) canvas.StrokeRoundedRect(iconX + 0.5, iconY + 0.5, iconBox - 1, iconBox - 1, iconRadius, tile.Accent.WithOpacity(0.32), 1);
+            canvas.FillRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, accent.WithOpacity(isRaised ? 0.25 : 0.18));
+            if (isRaised) canvas.StrokeRoundedRect(iconX + 0.5, iconY + 0.5, iconBox - 1, iconBox - 1, iconRadius, accent.WithOpacity(0.32), 1);
         } else {
-            canvas.StrokeRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, tile.Accent.WithOpacity(0.38), 1);
+            canvas.StrokeRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, accent.WithOpacity(0.38), 1);
         }
-        DrawTileIcon(canvas, tile.IconKind, tile.Icon, iconX, iconY, iconBox, tile.Accent);
+        DrawTileIcon(canvas, tile.IconKind, tile.Icon, iconX, iconY, iconBox, accent);
         var textX = iconX + iconBox + 22;
         var hasMiniChart = tile.MiniChartKind != VisualCanvasInfoTileMiniChartKind.None && tile.MiniChartValues.Count > 0;
         var chartW = hasMiniChart ? Math.Min(width * 0.24, Math.Max(82, width * 0.20)) : 0;
@@ -157,14 +158,14 @@ public sealed class PngVisualCanvasRenderer {
             var railY = y + height - 16;
             var railW = hasMiniChart ? Math.Max(24, chartX - railX - 16) : Math.Max(24, width - (railX - x) - padX);
             canvas.FillRoundedRect(railX, railY, railW, 8, 4, theme.TileProgressTrackColor);
-            canvas.FillRoundedRect(railX, railY, railW * tile.Progress.Value, 8, 4, tile.Accent);
+            canvas.FillRoundedRect(railX, railY, railW * tile.Progress.Value, 8, 4, accent);
         }
         if (hasMiniChart) {
-            DrawTileMiniChart(canvas, tile, theme, chartX, chartY, chartW, chartH);
+            DrawTileMiniChart(canvas, tile, theme, accent, chartX, chartY, chartW, chartH);
         }
     }
 
-    private static void DrawTileMiniChart(RgbaCanvas canvas, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme, double x, double y, double width, double height) {
+    private static void DrawTileMiniChart(RgbaCanvas canvas, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme, ChartColor accent, double x, double y, double width, double height) {
         canvas.FillRoundedRect(x, y, width, height, Math.Min(8, height * 0.24), theme.TileMiniChartTrackColor.WithOpacity(0.20));
         canvas.DrawLine(x + 4, y + height * 0.72, x + width - 4, y + height * 0.72, theme.TileMiniChartTrackColor, 1);
         canvas.DrawLine(x + 4, y + height * 0.38, x + width - 4, y + height * 0.38, theme.TileMiniChartTrackColor.WithOpacity(0.62), 1);
@@ -176,7 +177,7 @@ public sealed class PngVisualCanvasRenderer {
         var max = tile.MiniChartMaximum ?? 0.0;
         for (var i = 0; i < values.Count; i++) {
             if (values[i] < min) min = values[i];
-            if (values[i] > max) max = values[i];
+            if (!tile.MiniChartMaximum.HasValue && values[i] > max) max = values[i];
         }
         if (max <= min) max = min + 1;
 
@@ -186,12 +187,12 @@ public sealed class PngVisualCanvasRenderer {
         var plotH = Math.Max(1, height - 12);
         var baseY = plotY + plotH;
         if (tile.MiniChartKind == VisualCanvasInfoTileMiniChartKind.Bars) {
-            var gap = Math.Max(1, plotW * 0.035);
-            var barW = Math.Max(2, (plotW - gap * (values.Count - 1)) / values.Count);
+            var gap = values.Count > 1 ? Math.Min(Math.Max(1, plotW * 0.035), plotW / (values.Count * 3.0)) : 0;
+            var barW = Math.Max(0.5, (plotW - gap * (values.Count - 1)) / values.Count);
             for (var i = 0; i < values.Count; i++) {
                 var ratio = Math.Max(0, Math.Min(1, (values[i] - min) / (max - min)));
                 var barH = Math.Max(2, plotH * ratio);
-                canvas.FillRoundedRect(plotX + i * (barW + gap), baseY - barH, barW, barH, Math.Min(4, barW * 0.42), tile.Accent.WithOpacity(0.82));
+                canvas.FillRoundedRect(plotX + i * (barW + gap), baseY - barH, barW, barH, Math.Min(4, barW * 0.42), accent.WithOpacity(0.82));
             }
             return;
         }
@@ -213,7 +214,7 @@ public sealed class PngVisualCanvasRenderer {
         }
 
         for (var i = 1; i < points.Length; i++) {
-            canvas.DrawLine(points[i - 1].X, points[i - 1].Y, points[i].X, points[i].Y, tile.Accent, 2.2);
+            canvas.DrawLine(points[i - 1].X, points[i - 1].Y, points[i].X, points[i].Y, accent, 2.2);
         }
     }
 
@@ -314,19 +315,68 @@ public sealed class PngVisualCanvasRenderer {
         var radius = Math.Min(22, badge.Height * 0.20);
         canvas.FillRoundedRect(badge.X - 6, badge.Y - 6, badge.Width + 12, badge.Height + 12, radius + 4, theme.HeroBadgeGlowColor);
         canvas.FillRoundedRectVerticalGradient(badge.X, badge.Y, badge.Width, badge.Height, radius, theme.HeroBadgeTop, theme.HeroBadgeBottom);
-        canvas.StrokeRoundedRect(badge.X, badge.Y, badge.Width, badge.Height, radius, badge.Accent, 2.4);
+        var accent = badge.AccentOverride ?? theme.SecondaryAccent;
+        canvas.StrokeRoundedRect(badge.X, badge.Y, badge.Width, badge.Height, radius, accent, 2.4);
         var fontSize = Math.Max(24, badge.Height * 0.42);
         DrawText(canvas, badge.X, badge.Y + badge.Height / 2 - fontSize * 0.40, badge.Width, badge.Symbol, fontSize, theme.HeroBadgeTextColor, VisualCanvasTextAlignment.Center, true);
     }
 
     private static void DrawImage(RgbaCanvas canvas, VisualCanvasImageLayer image, VisualCanvasTheme theme) {
+        VisualCanvas.ValidateEnum(image.Fit, nameof(image.Fit));
         if (image.Rgba != null && image.SourceWidth > 0 && image.SourceHeight > 0) {
             var rgba = image.Opacity >= 0.999 ? image.Rgba : ApplyOpacity(image.Rgba, image.Opacity);
-            canvas.DrawImageScaled((int)Math.Round(image.X), (int)Math.Round(image.Y), (int)Math.Round(image.Width), (int)Math.Round(image.Height), image.SourceWidth, image.SourceHeight, rgba);
+            DrawFittedImage(canvas, image, rgba);
         } else {
             canvas.FillRoundedRect(image.X, image.Y, image.Width, image.Height, 12, theme.ImagePlaceholderFill);
             canvas.StrokeRoundedRect(image.X, image.Y, image.Width, image.Height, 12, theme.ImagePlaceholderStroke, 1);
         }
+    }
+
+    private static void DrawFittedImage(RgbaCanvas canvas, VisualCanvasImageLayer image, byte[] rgba) {
+        var destinationWidth = Math.Max(1, (int)Math.Round(image.Width));
+        var destinationHeight = Math.Max(1, (int)Math.Round(image.Height));
+        var destinationX = (int)Math.Round(image.X);
+        var destinationY = (int)Math.Round(image.Y);
+        var sourceWidth = image.SourceWidth;
+        var sourceHeight = image.SourceHeight;
+
+        switch (image.Fit) {
+            case VisualCanvasImageFit.Contain:
+                {
+                    var scale = Math.Min(destinationWidth / (double)sourceWidth, destinationHeight / (double)sourceHeight);
+                    var width = Math.Max(1, (int)Math.Round(sourceWidth * scale));
+                    var height = Math.Max(1, (int)Math.Round(sourceHeight * scale));
+                    canvas.DrawImageScaled(destinationX + (destinationWidth - width) / 2, destinationY + (destinationHeight - height) / 2, width, height, sourceWidth, sourceHeight, rgba);
+                    return;
+                }
+            case VisualCanvasImageFit.Cover:
+                {
+                    var scale = Math.Max(destinationWidth / (double)sourceWidth, destinationHeight / (double)sourceHeight);
+                    var cropWidth = Math.Min(sourceWidth, destinationWidth / scale);
+                    var cropHeight = Math.Min(sourceHeight, destinationHeight / scale);
+                    canvas.DrawImageScaled(destinationX, destinationY, destinationWidth, destinationHeight, sourceWidth, sourceHeight, rgba, (sourceWidth - cropWidth) / 2, (sourceHeight - cropHeight) / 2, cropWidth, cropHeight);
+                    return;
+                }
+            case VisualCanvasImageFit.Center:
+                DrawCenteredImage(canvas, destinationX, destinationY, destinationWidth, destinationHeight, sourceWidth, sourceHeight, rgba);
+                return;
+            default:
+                canvas.DrawImageScaled(destinationX, destinationY, destinationWidth, destinationHeight, sourceWidth, sourceHeight, rgba);
+                return;
+        }
+    }
+
+    private static void DrawCenteredImage(RgbaCanvas canvas, int destinationX, int destinationY, int destinationWidth, int destinationHeight, int sourceWidth, int sourceHeight, byte[] rgba) {
+        var centeredX = destinationX + (destinationWidth - sourceWidth) / 2;
+        var centeredY = destinationY + (destinationHeight - sourceHeight) / 2;
+        var drawX = Math.Max(destinationX, centeredX);
+        var drawY = Math.Max(destinationY, centeredY);
+        var drawRight = Math.Min(destinationX + destinationWidth, centeredX + sourceWidth);
+        var drawBottom = Math.Min(destinationY + destinationHeight, centeredY + sourceHeight);
+        var drawWidth = drawRight - drawX;
+        var drawHeight = drawBottom - drawY;
+        if (drawWidth <= 0 || drawHeight <= 0) return;
+        canvas.DrawImageScaled(drawX, drawY, drawWidth, drawHeight, sourceWidth, sourceHeight, rgba, drawX - centeredX, drawY - centeredY, drawWidth, drawHeight);
     }
 
     private static void DrawFeatureStrip(RgbaCanvas canvas, VisualCanvasFeatureStripLayer strip, VisualCanvasTheme theme) {

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -96,6 +96,7 @@ public sealed class PngVisualCanvasRenderer {
     private static void DrawInfoTile(RgbaCanvas canvas, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme) {
         VisualCanvas.ValidateEnum(tile.SurfaceStyle, nameof(tile.SurfaceStyle));
         VisualCanvas.ValidateEnum(tile.IconKind, nameof(tile.IconKind));
+        VisualCanvas.ValidateEnum(tile.MiniChartKind, nameof(tile.MiniChartKind));
         var x = Math.Round(tile.X);
         var y = Math.Round(tile.Y);
         var width = Math.Round(tile.Width);
@@ -120,7 +121,12 @@ public sealed class PngVisualCanvasRenderer {
         }
         DrawTileIcon(canvas, tile.IconKind, tile.Icon, iconX, iconY, iconBox, tile.Accent);
         var textX = iconX + iconBox + 22;
-        var textMax = Math.Max(24, width - (textX - x) - padX);
+        var hasMiniChart = tile.MiniChartKind != VisualCanvasInfoTileMiniChartKind.None && tile.MiniChartValues.Count > 0;
+        var chartW = hasMiniChart ? Math.Min(width * 0.24, Math.Max(82, width * 0.20)) : 0;
+        var chartX = x + width - padX - chartW;
+        var chartY = y + Math.Max(24, height * 0.30);
+        var chartH = Math.Max(28, Math.Min(46, height * 0.42));
+        var textMax = hasMiniChart ? Math.Max(24, chartX - textX - 16) : Math.Max(24, width - (textX - x) - padX);
         var labelFont = 14.0;
         var valueFont = height < 92 ? 21.0 : 22.0;
         var detailFont = 13.0;
@@ -134,9 +140,65 @@ public sealed class PngVisualCanvasRenderer {
         if (tile.Progress.HasValue) {
             var railX = textX;
             var railY = y + height - 16;
-            var railW = Math.Max(24, width - (railX - x) - padX);
+            var railW = hasMiniChart ? Math.Max(24, chartX - railX - 16) : Math.Max(24, width - (railX - x) - padX);
             canvas.FillRoundedRect(railX, railY, railW, 8, 4, theme.TileProgressTrackColor);
             canvas.FillRoundedRect(railX, railY, railW * tile.Progress.Value, 8, 4, tile.Accent);
+        }
+        if (hasMiniChart) {
+            DrawTileMiniChart(canvas, tile, theme, chartX, chartY, chartW, chartH);
+        }
+    }
+
+    private static void DrawTileMiniChart(RgbaCanvas canvas, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme, double x, double y, double width, double height) {
+        canvas.FillRoundedRect(x, y, width, height, Math.Min(8, height * 0.24), theme.TileMiniChartTrackColor.WithOpacity(0.20));
+        canvas.DrawLine(x + 4, y + height * 0.72, x + width - 4, y + height * 0.72, theme.TileMiniChartTrackColor, 1);
+        canvas.DrawLine(x + 4, y + height * 0.38, x + width - 4, y + height * 0.38, theme.TileMiniChartTrackColor.WithOpacity(0.62), 1);
+
+        var values = tile.MiniChartValues;
+        if (values.Count == 0) return;
+
+        var min = 0.0;
+        var max = tile.MiniChartMaximum ?? 0.0;
+        for (var i = 0; i < values.Count; i++) {
+            if (values[i] < min) min = values[i];
+            if (values[i] > max) max = values[i];
+        }
+        if (max <= min) max = min + 1;
+
+        var plotX = x + 7;
+        var plotY = y + 6;
+        var plotW = Math.Max(1, width - 14);
+        var plotH = Math.Max(1, height - 12);
+        var baseY = plotY + plotH;
+        if (tile.MiniChartKind == VisualCanvasInfoTileMiniChartKind.Bars) {
+            var gap = Math.Max(1, plotW * 0.035);
+            var barW = Math.Max(2, (plotW - gap * (values.Count - 1)) / values.Count);
+            for (var i = 0; i < values.Count; i++) {
+                var ratio = Math.Max(0, Math.Min(1, (values[i] - min) / (max - min)));
+                var barH = Math.Max(2, plotH * ratio);
+                canvas.FillRoundedRect(plotX + i * (barW + gap), baseY - barH, barW, barH, Math.Min(4, barW * 0.42), tile.Accent.WithOpacity(0.82));
+            }
+            return;
+        }
+
+        var points = new ChartPoint[values.Count];
+        for (var i = 0; i < values.Count; i++) {
+            var px = values.Count == 1 ? plotX + plotW / 2 : plotX + plotW * i / (values.Count - 1);
+            var ratio = Math.Max(0, Math.Min(1, (values[i] - min) / (max - min)));
+            var py = plotY + plotH - plotH * ratio;
+            points[i] = new ChartPoint(px, py);
+        }
+
+        if (tile.MiniChartKind == VisualCanvasInfoTileMiniChartKind.Area && points.Length > 1) {
+            var polygon = new ChartPoint[points.Length + 2];
+            polygon[0] = new ChartPoint(points[0].X, baseY);
+            for (var i = 0; i < points.Length; i++) polygon[i + 1] = points[i];
+            polygon[polygon.Length - 1] = new ChartPoint(points[points.Length - 1].X, baseY);
+            canvas.FillPolygon(polygon, theme.TileMiniChartFillColor);
+        }
+
+        for (var i = 1; i < points.Length; i++) {
+            canvas.DrawLine(points[i - 1].X, points[i - 1].Y, points[i].X, points[i].Y, tile.Accent, 2.2);
         }
     }
 

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -105,15 +105,32 @@ public sealed class PngVisualCanvasRenderer {
         var isRaised = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Raised;
         var isFilled = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass || isRaised;
         if (isRaised) {
-            canvas.FillRoundedRect(x + 10, y + 12, width, height, radius + 1, ChartColor.Black.WithOpacity(0.34));
-            canvas.FillRoundedRect(x + 4, y + 5, width, height, radius, tile.Accent.WithOpacity(0.13));
+            var depthX = Math.Max(14, Math.Min(24, width * 0.042));
+            var depthY = Math.Max(14, Math.Min(24, height * 0.22));
+            var shadow = ChartColor.Black.WithOpacity(0.58);
+            canvas.FillRoundedRect(x + depthX + 4, y + depthY + 5, width, height, radius + 2, shadow);
+            canvas.FillRoundedRect(x + depthX, y + depthY, width, height, radius + 1, tile.Accent.WithOpacity(0.20));
+            canvas.FillPolygon(new[] {
+                new ChartPoint(x + width, y + radius * 0.7),
+                new ChartPoint(x + width + depthX, y + depthY + radius * 0.7),
+                new ChartPoint(x + width + depthX, y + height + depthY - radius * 0.7),
+                new ChartPoint(x + width, y + height - radius * 0.7)
+            }, tile.Accent.WithOpacity(0.32));
+            canvas.FillPolygon(new[] {
+                new ChartPoint(x + radius * 0.7, y + height),
+                new ChartPoint(x + width - radius * 0.7, y + height),
+                new ChartPoint(x + width + depthX - radius * 0.7, y + height + depthY),
+                new ChartPoint(x + depthX + radius * 0.7, y + height + depthY)
+            }, ChartColor.Black.WithOpacity(0.42));
+            canvas.DrawLine(x + width - 1, y + radius, x + width + depthX - 1, y + depthY + radius, tile.Accent.WithOpacity(0.62), 2.0);
+            canvas.DrawLine(x + radius, y + height - 1, x + depthX + radius, y + height + depthY - 1, tile.Accent.WithOpacity(0.48), 1.7);
         }
         if (isFilled) {
             canvas.FillRoundedRectVerticalGradient(x, y, width, height, radius, theme.TileGlassTop, theme.TileGlassBottom);
         }
         if (isRaised) {
-            canvas.FillRoundedRectVerticalGradient(x + 2, y + 2, Math.Max(1, width - 4), Math.Max(1, height * 0.46), Math.Max(1, radius - 2), ChartColor.White.WithOpacity(0.10), ChartColor.White.WithOpacity(0.01));
-            canvas.StrokeRoundedRect(x - 1, y - 1, width + 2, height + 2, radius + 1, tile.Accent.WithOpacity(0.26), 3.2);
+            canvas.FillRoundedRectVerticalGradient(x + 2, y + 2, Math.Max(1, width - 4), Math.Max(1, height * 0.52), Math.Max(1, radius - 2), ChartColor.White.WithOpacity(0.20), ChartColor.White.WithOpacity(0.03));
+            canvas.StrokeRoundedRect(x - 2, y - 2, width + 4, height + 4, radius + 2, tile.Accent.WithOpacity(0.48), 4.4);
         }
         canvas.StrokeRoundedRect(x + 0.5, y + 0.5, Math.Max(1, width - 1), Math.Max(1, height - 1), radius, tile.Accent.WithOpacity(isRaised ? 0.92 : 0.72), isRaised ? 2.2 : 1.4);
         if (isFilled) {

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -1,0 +1,314 @@
+using System;
+using ChartForgeX.Primitives;
+using ChartForgeX.Raster;
+
+namespace ChartForgeX.Composition;
+
+/// <summary>
+/// Renders visual canvases to dependency-free PNG images.
+/// </summary>
+public sealed class PngVisualCanvasRenderer {
+    /// <summary>Renders a visual canvas to PNG bytes.</summary>
+    public byte[] Render(VisualCanvas canvas) => PngWriter.WriteRgba(RenderImage(canvas));
+
+    internal RgbaImage RenderImage(VisualCanvas canvas) => RenderCanvas(canvas).ToImage();
+
+    internal RgbaCanvas RenderCanvas(VisualCanvas canvas) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        VisualCanvas.ValidateEnum(canvas.BackdropStyle, nameof(canvas.BackdropStyle));
+        var output = new RgbaCanvas(canvas.Width, canvas.Height, 2, null, canvas.PngOutputScale);
+        output.Clear(ChartColor.Transparent);
+        if (canvas.BackdropStyle != VisualCanvasBackdropStyle.Transparent) {
+            output.FillRoundedRectVerticalGradient(0, 0, canvas.Width, canvas.Height, 0, canvas.BackgroundTop, canvas.BackgroundBottom);
+        }
+        var theme = canvas.Theme ?? new VisualCanvasTheme();
+        if (canvas.BackdropStyle == VisualCanvasBackdropStyle.TechHorizon) RenderTechBackdrop(output, canvas, theme);
+        foreach (var layer in canvas.Layers) RenderLayer(output, layer, theme);
+        return output;
+    }
+
+    private static void RenderLayer(RgbaCanvas canvas, VisualCanvasLayer layer, VisualCanvasTheme theme) {
+        if (layer is VisualCanvasTextLayer text) {
+            DrawText(canvas, text.X, text.Y, text.Width, text.Text, text.FontSize, text.Color, text.Alignment, text.Emphasized);
+        } else if (layer is VisualCanvasHeroTitleLayer hero) {
+            DrawHeroTitle(canvas, hero);
+        } else if (layer is VisualCanvasInfoTileLayer tile) {
+            DrawInfoTile(canvas, tile, theme);
+        } else if (layer is VisualCanvasHeroBadgeLayer badge) {
+            DrawHeroBadge(canvas, badge, theme);
+        } else if (layer is VisualCanvasImageLayer image) {
+            DrawImage(canvas, image, theme);
+        } else if (layer is VisualCanvasFeatureStripLayer strip) {
+            DrawFeatureStrip(canvas, strip, theme);
+        } else {
+            throw new NotSupportedException("Unsupported visual canvas layer: " + layer.GetType().FullName);
+        }
+    }
+
+    private static void RenderTechBackdrop(RgbaCanvas canvas, VisualCanvas visual, VisualCanvasTheme theme) {
+        var accent = theme.SecondaryAccent;
+        for (var i = 0; i < 56; i++) {
+            var x = (visual.Width * ((i * 37) % 101)) / 100.0;
+            var y = visual.Height * (0.05 + (((i * 19) % 67) / 100.0) * 0.44);
+            var opacity = 0.14 + ((i % 5) * 0.035);
+            canvas.DrawCircle(x, y, i % 11 == 0 ? 4.2 : 1.8, accent.WithOpacity(opacity));
+        }
+
+        for (var i = 0; i < 10; i++) {
+            var y = visual.Height * (0.18 + i * 0.045);
+            DrawCurve(canvas, visual.Width * 0.08, y, visual.Width * 0.28, y - 80, visual.Width * 0.48, y + 120, visual.Width * 0.68, y - 10, accent.WithOpacity(0.11), 1.1);
+        }
+
+        var horizon = new[] {
+            new ChartPoint(0, visual.Height),
+            new ChartPoint(0, visual.Height * 0.78),
+            new ChartPoint(visual.Width * 0.20, visual.Height * 0.72),
+            new ChartPoint(visual.Width * 0.38, visual.Height * 0.82),
+            new ChartPoint(visual.Width * 0.55, visual.Height * 0.76),
+            new ChartPoint(visual.Width * 0.74, visual.Height * 0.70),
+            new ChartPoint(visual.Width * 0.84, visual.Height * 0.85),
+            new ChartPoint(visual.Width, visual.Height * 0.73),
+            new ChartPoint(visual.Width, visual.Height)
+        };
+        canvas.FillPolygon(horizon, theme.TechHorizonFill);
+        DrawCurve(canvas, visual.Width * 0.50, visual.Height * 0.82, visual.Width * 0.72, visual.Height * 0.86, visual.Width * 0.80, visual.Height * 0.93, visual.Width * 0.92, visual.Height, accent.WithOpacity(0.48), 9);
+        DrawCurve(canvas, visual.Width * 0.50, visual.Height * 0.82, visual.Width * 0.72, visual.Height * 0.86, visual.Width * 0.80, visual.Height * 0.93, visual.Width * 0.92, visual.Height, accent.WithOpacity(0.88), 3.5);
+    }
+
+    private static void DrawText(RgbaCanvas canvas, double x, double y, double width, string text, double fontSize, ChartColor color, VisualCanvasTextAlignment alignment, bool emphasized) {
+        var fitted = FitText(text, fontSize, Math.Max(4, width), emphasized);
+        var textWidth = emphasized ? RgbaCanvas.MeasureTextEmphasizedWidth(fitted, fontSize, null) : RgbaCanvas.MeasureTextWidth(fitted, fontSize, null);
+        var drawX = AlignedX(x, width, textWidth, alignment);
+        if (emphasized) canvas.DrawTextEmphasized(drawX, y, fitted, color, fontSize);
+        else canvas.DrawText(drawX, y, fitted, color, fontSize);
+    }
+
+    private static void DrawHeroTitle(RgbaCanvas canvas, VisualCanvasHeroTitleLayer hero) {
+        var totalWidth = 0.0;
+        foreach (var run in hero.Runs) totalWidth += RgbaCanvas.MeasureTextEmphasizedWidth(run.Text, hero.FontSize, null);
+        var x = AlignedX(hero.X, hero.Width, totalWidth, hero.Alignment);
+        foreach (var run in hero.Runs) {
+            canvas.DrawTextEmphasized(x, hero.Y, run.Text, run.Color, hero.FontSize);
+            x += RgbaCanvas.MeasureTextEmphasizedWidth(run.Text, hero.FontSize, null);
+        }
+    }
+
+    private static void DrawInfoTile(RgbaCanvas canvas, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme) {
+        VisualCanvas.ValidateEnum(tile.SurfaceStyle, nameof(tile.SurfaceStyle));
+        VisualCanvas.ValidateEnum(tile.IconKind, nameof(tile.IconKind));
+        var x = Math.Round(tile.X);
+        var y = Math.Round(tile.Y);
+        var width = Math.Round(tile.Width);
+        var height = Math.Round(tile.Height);
+        var radius = Math.Min(16, height * 0.18);
+        if (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass) {
+            canvas.FillRoundedRectVerticalGradient(x, y, width, height, radius, theme.TileGlassTop, theme.TileGlassBottom);
+        }
+        canvas.StrokeRoundedRect(x + 0.5, y + 0.5, Math.Max(1, width - 1), Math.Max(1, height - 1), radius, tile.Accent.WithOpacity(0.72), 1.4);
+        if (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass) {
+            canvas.StrokeRoundedRect(x + 2.5, y + 2.5, Math.Max(1, width - 5), Math.Max(1, height - 5), Math.Max(1, radius - 2), theme.TileInnerStroke, 1);
+        }
+        var padX = Math.Max(20, Math.Min(28, width * 0.06));
+        var iconBox = Math.Max(44, Math.Min(54, height - 34));
+        var iconX = x + padX;
+        var iconY = y + (height - iconBox) / 2;
+        var iconRadius = Math.Min(13, iconBox * 0.25);
+        if (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass) {
+            canvas.FillRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, tile.Accent.WithOpacity(0.18));
+        } else {
+            canvas.StrokeRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, tile.Accent.WithOpacity(0.38), 1);
+        }
+        DrawTileIcon(canvas, tile.IconKind, tile.Icon, iconX, iconY, iconBox, tile.Accent);
+        var textX = iconX + iconBox + 22;
+        var textMax = Math.Max(24, width - (textX - x) - padX);
+        var labelFont = 14.0;
+        var valueFont = height < 92 ? 21.0 : 22.0;
+        var detailFont = 13.0;
+        var hasDetail = tile.Detail.Length > 0;
+        var labelY = y + (hasDetail ? 17 : Math.Max(18, (height - 52) / 2));
+        var valueY = labelY + 25;
+        var detailY = valueY + 25;
+        canvas.DrawTextEmphasized(textX, labelY, FitText(tile.Label, labelFont, textMax, true), theme.TileLabelColor, labelFont);
+        canvas.DrawTextEmphasized(textX, valueY, FitText(tile.Value, valueFont, textMax, true), theme.TileValueColor, valueFont);
+        if (hasDetail) canvas.DrawText(textX, detailY, FitText(tile.Detail, detailFont, textMax, false), theme.TileDetailColor, detailFont);
+        if (tile.Progress.HasValue) {
+            var railX = textX;
+            var railY = y + height - 16;
+            var railW = Math.Max(24, width - (railX - x) - padX);
+            canvas.FillRoundedRect(railX, railY, railW, 8, 4, theme.TileProgressTrackColor);
+            canvas.FillRoundedRect(railX, railY, railW * tile.Progress.Value, 8, 4, tile.Accent);
+        }
+    }
+
+    private static void DrawTileIcon(RgbaCanvas canvas, VisualCanvasInfoTileIconKind kind, string text, double x, double y, double size, ChartColor color) {
+        if (kind == VisualCanvasInfoTileIconKind.Text) {
+            var iconFont = Math.Min(25, size * (text.Length > 3 ? 0.34 : 0.42));
+            DrawText(canvas, x, y + (size - iconFont) / 2 - 1, size, text, iconFont, color, VisualCanvasTextAlignment.Center, true);
+            return;
+        }
+
+        var cx = x + size / 2;
+        var cy = y + size / 2;
+        var left = x + size * 0.24;
+        var right = x + size * 0.76;
+        var top = y + size * 0.24;
+        var bottom = y + size * 0.76;
+        var thick = Math.Max(1.6, size * 0.045);
+        switch (kind) {
+            case VisualCanvasInfoTileIconKind.Computer:
+            case VisualCanvasInfoTileIconKind.OperatingSystem:
+                canvas.StrokeRoundedRect(left, top, size * 0.52, size * 0.36, 3, color, thick);
+                canvas.DrawLine(cx, top + size * 0.36, cx, bottom - size * 0.08, color, thick);
+                canvas.DrawLine(cx - size * 0.16, bottom - size * 0.08, cx + size * 0.16, bottom - size * 0.08, color, thick);
+                if (kind == VisualCanvasInfoTileIconKind.OperatingSystem) {
+                    canvas.DrawLine(cx, top, cx, top + size * 0.36, color.WithOpacity(0.75), 1);
+                    canvas.DrawLine(left, top + size * 0.18, right, top + size * 0.18, color.WithOpacity(0.75), 1);
+                }
+                break;
+            case VisualCanvasInfoTileIconKind.Network:
+                canvas.DrawCircleOutline(cx, cy, size * 0.27, color, thick);
+                canvas.DrawLine(cx - size * 0.27, cy, cx + size * 0.27, cy, color, thick);
+                canvas.DrawLine(cx, cy - size * 0.27, cx, cy + size * 0.27, color, thick);
+                canvas.DrawCircleOutline(cx, cy, size * 0.12, color.WithOpacity(0.65), 1);
+                break;
+            case VisualCanvasInfoTileIconKind.Cpu:
+                canvas.StrokeRoundedRect(x + size * 0.31, y + size * 0.31, size * 0.38, size * 0.38, 4, color, thick);
+                for (var i = 0; i < 4; i++) {
+                    var p = y + size * (0.24 + i * 0.17);
+                    canvas.DrawLine(x + size * 0.22, p, x + size * 0.31, p, color, thick);
+                    canvas.DrawLine(x + size * 0.69, p, x + size * 0.78, p, color, thick);
+                    var q = x + size * (0.24 + i * 0.17);
+                    canvas.DrawLine(q, y + size * 0.22, q, y + size * 0.31, color, thick);
+                    canvas.DrawLine(q, y + size * 0.69, q, y + size * 0.78, color, thick);
+                }
+                break;
+            case VisualCanvasInfoTileIconKind.Memory:
+                canvas.StrokeRoundedRect(left, y + size * 0.35, size * 0.52, size * 0.30, 3, color, thick);
+                for (var i = 0; i < 4; i++) canvas.DrawLine(x + size * (0.31 + i * 0.10), y + size * 0.43, x + size * (0.31 + i * 0.10), y + size * 0.57, color.WithOpacity(0.75), 1.2);
+                for (var i = 0; i < 5; i++) canvas.DrawLine(x + size * (0.28 + i * 0.10), y + size * 0.65, x + size * (0.28 + i * 0.10), y + size * 0.72, color, thick);
+                break;
+            case VisualCanvasInfoTileIconKind.User:
+                canvas.DrawCircleOutline(cx, y + size * 0.38, size * 0.11, color, thick);
+                canvas.DrawLine(cx - size * 0.22, bottom, cx - size * 0.12, y + size * 0.58, color, thick);
+                canvas.DrawLine(cx + size * 0.22, bottom, cx + size * 0.12, y + size * 0.58, color, thick);
+                canvas.DrawLine(cx - size * 0.12, y + size * 0.58, cx + size * 0.12, y + size * 0.58, color, thick);
+                break;
+            case VisualCanvasInfoTileIconKind.Domain:
+                canvas.StrokeRoundedRect(x + size * 0.32, top, size * 0.28, size * 0.52, 2, color, thick);
+                canvas.DrawLine(x + size * 0.22, bottom, x + size * 0.78, bottom, color, thick);
+                canvas.DrawLine(x + size * 0.60, y + size * 0.44, x + size * 0.74, y + size * 0.44, color, thick);
+                canvas.DrawLine(x + size * 0.74, y + size * 0.44, x + size * 0.74, bottom, color, thick);
+                for (var i = 0; i < 3; i++) canvas.DrawLine(x + size * 0.39, y + size * (0.34 + i * 0.13), x + size * 0.51, y + size * (0.34 + i * 0.13), color.WithOpacity(0.75), 1.2);
+                break;
+            case VisualCanvasInfoTileIconKind.Terminal:
+                canvas.DrawLine(x + size * 0.30, y + size * 0.36, x + size * 0.44, cy, color, thick);
+                canvas.DrawLine(x + size * 0.44, cy, x + size * 0.30, y + size * 0.64, color, thick);
+                canvas.DrawLine(x + size * 0.52, y + size * 0.64, x + size * 0.72, y + size * 0.64, color, thick);
+                break;
+            case VisualCanvasInfoTileIconKind.Storage:
+                canvas.DrawCircleOutline(cx, y + size * 0.34, size * 0.22, color, thick);
+                canvas.DrawLine(cx - size * 0.22, y + size * 0.34, cx - size * 0.22, y + size * 0.66, color, thick);
+                canvas.DrawLine(cx + size * 0.22, y + size * 0.34, cx + size * 0.22, y + size * 0.66, color, thick);
+                canvas.DrawCircleOutline(cx, y + size * 0.66, size * 0.22, color, thick);
+                break;
+            case VisualCanvasInfoTileIconKind.Shield:
+                canvas.FillPolygon(new[] {
+                    new ChartPoint(cx, top),
+                    new ChartPoint(right, y + size * 0.36),
+                    new ChartPoint(x + size * 0.68, bottom),
+                    new ChartPoint(cx, y + size * 0.82),
+                    new ChartPoint(x + size * 0.32, bottom),
+                    new ChartPoint(left, y + size * 0.36)
+                }, color.WithOpacity(0.24));
+                canvas.DrawLine(cx, top, right, y + size * 0.36, color, thick);
+                canvas.DrawLine(right, y + size * 0.36, x + size * 0.68, bottom, color, thick);
+                canvas.DrawLine(x + size * 0.68, bottom, cx, y + size * 0.82, color, thick);
+                canvas.DrawLine(cx, y + size * 0.82, x + size * 0.32, bottom, color, thick);
+                canvas.DrawLine(x + size * 0.32, bottom, left, y + size * 0.36, color, thick);
+                canvas.DrawLine(left, y + size * 0.36, cx, top, color, thick);
+                break;
+            default:
+                DrawTileIcon(canvas, VisualCanvasInfoTileIconKind.Text, text, x, y, size, color);
+                break;
+        }
+    }
+
+    private static void DrawHeroBadge(RgbaCanvas canvas, VisualCanvasHeroBadgeLayer badge, VisualCanvasTheme theme) {
+        var radius = Math.Min(22, badge.Height * 0.20);
+        canvas.FillRoundedRect(badge.X - 6, badge.Y - 6, badge.Width + 12, badge.Height + 12, radius + 4, theme.HeroBadgeGlowColor);
+        canvas.FillRoundedRectVerticalGradient(badge.X, badge.Y, badge.Width, badge.Height, radius, theme.HeroBadgeTop, theme.HeroBadgeBottom);
+        canvas.StrokeRoundedRect(badge.X, badge.Y, badge.Width, badge.Height, radius, badge.Accent, 2.4);
+        var fontSize = Math.Max(24, badge.Height * 0.42);
+        DrawText(canvas, badge.X, badge.Y + badge.Height / 2 - fontSize * 0.40, badge.Width, badge.Symbol, fontSize, theme.HeroBadgeTextColor, VisualCanvasTextAlignment.Center, true);
+    }
+
+    private static void DrawImage(RgbaCanvas canvas, VisualCanvasImageLayer image, VisualCanvasTheme theme) {
+        if (image.Rgba != null && image.SourceWidth > 0 && image.SourceHeight > 0) {
+            var rgba = image.Opacity >= 0.999 ? image.Rgba : ApplyOpacity(image.Rgba, image.Opacity);
+            canvas.DrawImageScaled((int)Math.Round(image.X), (int)Math.Round(image.Y), (int)Math.Round(image.Width), (int)Math.Round(image.Height), image.SourceWidth, image.SourceHeight, rgba);
+        } else {
+            canvas.FillRoundedRect(image.X, image.Y, image.Width, image.Height, 12, theme.ImagePlaceholderFill);
+            canvas.StrokeRoundedRect(image.X, image.Y, image.Width, image.Height, 12, theme.ImagePlaceholderStroke, 1);
+        }
+    }
+
+    private static void DrawFeatureStrip(RgbaCanvas canvas, VisualCanvasFeatureStripLayer strip, VisualCanvasTheme theme) {
+        var slot = strip.Width / strip.Items.Count;
+        for (var i = 0; i < strip.Items.Count; i++) {
+            var item = strip.Items[i];
+            var slotX = strip.X + slot * i;
+            if (i > 0) canvas.DrawLine(slotX, strip.Y + 4, slotX, strip.Y + strip.Height - 4, theme.FeatureDividerColor, 1);
+            DrawText(canvas, slotX, strip.Y + 2, slot, item.Icon, 22, strip.Accent, VisualCanvasTextAlignment.Center, true);
+            DrawText(canvas, slotX + 6, strip.Y + 38, slot - 12, item.Label, 15, theme.FeatureLabelColor, VisualCanvasTextAlignment.Center, true);
+        }
+    }
+
+    private static void DrawCurve(RgbaCanvas canvas, double x0, double y0, double x1, double y1, double x2, double y2, double x3, double y3, ChartColor color, double thickness) {
+        var previousX = x0;
+        var previousY = y0;
+        const int steps = 40;
+        for (var i = 1; i <= steps; i++) {
+            var t = i / (double)steps;
+            var inv = 1 - t;
+            var x = inv * inv * inv * x0 + 3 * inv * inv * t * x1 + 3 * inv * t * t * x2 + t * t * t * x3;
+            var y = inv * inv * inv * y0 + 3 * inv * inv * t * y1 + 3 * inv * t * t * y2 + t * t * t * y3;
+            canvas.DrawLine(previousX, previousY, x, y, color, thickness);
+            previousX = x;
+            previousY = y;
+        }
+    }
+
+    private static string FitText(string value, double fontSize, double maxWidth, bool emphasized) {
+        if (string.IsNullOrEmpty(value) || Measure(value, fontSize, emphasized) <= maxWidth) return value;
+        const string suffix = "...";
+        if (Measure(suffix, fontSize, emphasized) > maxWidth) return string.Empty;
+        var low = 0;
+        var high = value.Length;
+        while (low < high) {
+            var mid = (low + high + 1) / 2;
+            if (Measure(value.Substring(0, mid) + suffix, fontSize, emphasized) <= maxWidth) low = mid;
+            else high = mid - 1;
+        }
+
+        return value.Substring(0, low) + suffix;
+    }
+
+    private static double Measure(string value, double fontSize, bool emphasized) =>
+        emphasized ? RgbaCanvas.MeasureTextEmphasizedWidth(value, fontSize, null) : RgbaCanvas.MeasureTextWidth(value, fontSize, null);
+
+    private static double AlignedX(double x, double width, double textWidth, VisualCanvasTextAlignment alignment) {
+        VisualCanvas.ValidateEnum(alignment, nameof(alignment));
+        switch (alignment) {
+            case VisualCanvasTextAlignment.Center: return x + (width - textWidth) / 2;
+            case VisualCanvasTextAlignment.Right: return x + width - textWidth;
+            default: return x;
+        }
+    }
+
+    private static byte[] ApplyOpacity(byte[] rgba, double opacity) {
+        var copy = new byte[rgba.Length];
+        Buffer.BlockCopy(rgba, 0, copy, 0, rgba.Length);
+        for (var i = 3; i < copy.Length; i += 4) copy[i] = (byte)Math.Round(copy[i] * opacity);
+        return copy;
+    }
+}

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -102,11 +102,21 @@ public sealed class PngVisualCanvasRenderer {
         var width = Math.Round(tile.Width);
         var height = Math.Round(tile.Height);
         var radius = Math.Min(16, height * 0.18);
-        if (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass) {
+        var isRaised = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Raised;
+        var isFilled = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass || isRaised;
+        if (isRaised) {
+            canvas.FillRoundedRect(x + 10, y + 12, width, height, radius + 1, ChartColor.Black.WithOpacity(0.34));
+            canvas.FillRoundedRect(x + 4, y + 5, width, height, radius, tile.Accent.WithOpacity(0.13));
+        }
+        if (isFilled) {
             canvas.FillRoundedRectVerticalGradient(x, y, width, height, radius, theme.TileGlassTop, theme.TileGlassBottom);
         }
-        canvas.StrokeRoundedRect(x + 0.5, y + 0.5, Math.Max(1, width - 1), Math.Max(1, height - 1), radius, tile.Accent.WithOpacity(0.72), 1.4);
-        if (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass) {
+        if (isRaised) {
+            canvas.FillRoundedRectVerticalGradient(x + 2, y + 2, Math.Max(1, width - 4), Math.Max(1, height * 0.46), Math.Max(1, radius - 2), ChartColor.White.WithOpacity(0.10), ChartColor.White.WithOpacity(0.01));
+            canvas.StrokeRoundedRect(x - 1, y - 1, width + 2, height + 2, radius + 1, tile.Accent.WithOpacity(0.26), 3.2);
+        }
+        canvas.StrokeRoundedRect(x + 0.5, y + 0.5, Math.Max(1, width - 1), Math.Max(1, height - 1), radius, tile.Accent.WithOpacity(isRaised ? 0.92 : 0.72), isRaised ? 2.2 : 1.4);
+        if (isFilled) {
             canvas.StrokeRoundedRect(x + 2.5, y + 2.5, Math.Max(1, width - 5), Math.Max(1, height - 5), Math.Max(1, radius - 2), theme.TileInnerStroke, 1);
         }
         var padX = Math.Max(20, Math.Min(28, width * 0.06));
@@ -114,8 +124,9 @@ public sealed class PngVisualCanvasRenderer {
         var iconX = x + padX;
         var iconY = y + (height - iconBox) / 2;
         var iconRadius = Math.Min(13, iconBox * 0.25);
-        if (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass) {
-            canvas.FillRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, tile.Accent.WithOpacity(0.18));
+        if (isFilled) {
+            canvas.FillRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, tile.Accent.WithOpacity(isRaised ? 0.25 : 0.18));
+            if (isRaised) canvas.StrokeRoundedRect(iconX + 0.5, iconY + 0.5, iconBox - 1, iconBox - 1, iconRadius, tile.Accent.WithOpacity(0.32), 1);
         } else {
             canvas.StrokeRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, tile.Accent.WithOpacity(0.38), 1);
         }

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using ChartForgeX.Primitives;
+using ChartForgeX.Svg;
+
+namespace ChartForgeX.Composition;
+
+/// <summary>
+/// Renders visual canvases to self-contained SVG.
+/// </summary>
+public sealed class SvgVisualCanvasRenderer {
+    private static long ScopeCounter;
+
+    /// <summary>Renders a visual canvas to SVG markup.</summary>
+    public string Render(VisualCanvas canvas) => Render(canvas, NextScope());
+
+    /// <summary>Renders a visual canvas to SVG markup with a caller-provided ID scope.</summary>
+    public string Render(VisualCanvas canvas, string idScope) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        VisualCanvas.ValidateEnum(canvas.BackdropStyle, nameof(canvas.BackdropStyle));
+        var id = "cfx-visual-canvas-" + StableHash(idScope ?? string.Empty, canvas.Title, canvas.Width.ToString(CultureInfo.InvariantCulture), canvas.Height.ToString(CultureInfo.InvariantCulture));
+        var writer = new SvgMarkupWriter(8192);
+        writer.StartElement("svg")
+            .Attribute("xmlns", "http://www.w3.org/2000/svg")
+            .Attribute("id", id)
+            .Attribute("width", canvas.Width)
+            .Attribute("height", canvas.Height)
+            .Attribute("viewBox", "0 0 " + canvas.Width.ToString(CultureInfo.InvariantCulture) + " " + canvas.Height.ToString(CultureInfo.InvariantCulture))
+            .Attribute("role", "img")
+            .Attribute("aria-labelledby", id + "-title " + id + "-desc")
+            .Attribute("preserveAspectRatio", "xMidYMid meet")
+            .Attribute("shape-rendering", "geometricPrecision")
+            .Attribute("text-rendering", "geometricPrecision")
+            .Attribute("style", "max-width:100%;height:auto;display:block")
+            .EndStartElement()
+            .Line()
+            .StartElement("title").Attribute("id", id + "-title").Text(canvas.Title).EndElement()
+            .Line()
+            .StartElement("desc").Attribute("id", id + "-desc").Text("Layered static visual canvas.").EndElement()
+            .Line();
+        writer.StartElement("defs").EndStartElement().Line();
+        writer.StartElement("linearGradient").Attribute("id", id + "-background").Attribute("x1", "0").Attribute("y1", "0").Attribute("x2", "0").Attribute("y2", "1").EndStartElement().Line();
+        writer.StartElement("stop").Attribute("offset", "0%").Attribute("stop-color", canvas.BackgroundTop.ToCss()).EndEmptyElement().Line();
+        writer.StartElement("stop").Attribute("offset", "100%").Attribute("stop-color", canvas.BackgroundBottom.ToCss()).EndEmptyElement().Line();
+        writer.EndElement().Line();
+        var theme = canvas.Theme ?? new VisualCanvasTheme();
+        writer.StartElement("filter").Attribute("id", id + "-soft-glow").Attribute("x", "-30%").Attribute("y", "-30%").Attribute("width", "160%").Attribute("height", "160%").EndStartElement().Line();
+        writer.StartElement("feGaussianBlur").Attribute("stdDeviation", 5).Attribute("result", "blur").EndEmptyElement().Line();
+        writer.StartElement("feMerge").EndStartElement()
+            .StartElement("feMergeNode").Attribute("in", "blur").EndEmptyElement()
+            .StartElement("feMergeNode").Attribute("in", "SourceGraphic").EndEmptyElement()
+            .EndElement().Line();
+        writer.EndElement().Line();
+        writer.EndElement().Line();
+        if (canvas.BackdropStyle != VisualCanvasBackdropStyle.Transparent) {
+            writer.StartElement("rect").Attribute("data-cfx-role", "visual-canvas-background").Attribute("width", "100%").Attribute("height", "100%").Attribute("fill", "url(#" + id + "-background)").EndEmptyElement().Line();
+        }
+        if (canvas.BackdropStyle == VisualCanvasBackdropStyle.TechHorizon) RenderTechBackdrop(writer, canvas, id, theme);
+        foreach (var layer in canvas.Layers) RenderLayer(writer, layer, id, theme);
+        writer.EndElement().Line();
+        return writer.Build();
+    }
+
+    private static void RenderLayer(SvgMarkupWriter writer, VisualCanvasLayer layer, string id, VisualCanvasTheme theme) {
+        if (layer is VisualCanvasTextLayer text) {
+            RenderText(writer, text);
+        } else if (layer is VisualCanvasHeroTitleLayer hero) {
+            RenderHeroTitle(writer, hero);
+        } else if (layer is VisualCanvasInfoTileLayer tile) {
+            RenderInfoTile(writer, tile, theme);
+        } else if (layer is VisualCanvasHeroBadgeLayer badge) {
+            RenderHeroBadge(writer, badge, id, theme);
+        } else if (layer is VisualCanvasImageLayer image) {
+            RenderImage(writer, image, theme);
+        } else if (layer is VisualCanvasFeatureStripLayer strip) {
+            RenderFeatureStrip(writer, strip, theme);
+        } else {
+            throw new NotSupportedException("Unsupported visual canvas layer: " + layer.GetType().FullName);
+        }
+    }
+
+    private static void RenderTechBackdrop(SvgMarkupWriter writer, VisualCanvas canvas, string id, VisualCanvasTheme theme) {
+        var accent = theme.SecondaryAccent;
+        writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-tech-backdrop").EndStartElement().Line();
+        for (var i = 0; i < 56; i++) {
+            var x = (canvas.Width * ((i * 37) % 101)) / 100.0;
+            var y = canvas.Height * (0.05 + (((i * 19) % 67) / 100.0) * 0.44);
+            var opacity = 0.14 + ((i % 5) * 0.035);
+            writer.StartElement("circle").Attribute("cx", x).Attribute("cy", y).Attribute("r", i % 11 == 0 ? 4.2 : 1.8).Attribute("fill", accent.WithOpacity(opacity).ToCss()).EndEmptyElement().Line();
+        }
+
+        for (var i = 0; i < 10; i++) {
+            var y = canvas.Height * (0.18 + i * 0.045);
+            writer.StartElement("path")
+                .Attribute("d", "M " + F(canvas.Width * 0.08) + " " + F(y) + " C " + F(canvas.Width * 0.28) + " " + F(y - 80) + ", " + F(canvas.Width * 0.48) + " " + F(y + 120) + ", " + F(canvas.Width * 0.68) + " " + F(y - 10))
+                .Attribute("fill", "none")
+                .Attribute("stroke", accent.WithOpacity(0.11).ToCss())
+                .Attribute("stroke-width", 1.1)
+                .EndEmptyElement().Line();
+        }
+
+        writer.StartElement("path")
+            .Attribute("data-cfx-role", "visual-canvas-horizon")
+            .Attribute("d", "M 0 " + F(canvas.Height * 0.78) + " C " + F(canvas.Width * 0.20) + " " + F(canvas.Height * 0.72) + ", " + F(canvas.Width * 0.38) + " " + F(canvas.Height * 0.82) + ", " + F(canvas.Width * 0.55) + " " + F(canvas.Height * 0.76) + " C " + F(canvas.Width * 0.74) + " " + F(canvas.Height * 0.70) + ", " + F(canvas.Width * 0.84) + " " + F(canvas.Height * 0.85) + ", " + F(canvas.Width) + " " + F(canvas.Height * 0.73) + " L " + F(canvas.Width) + " " + F(canvas.Height) + " L 0 " + F(canvas.Height) + " Z")
+            .Attribute("fill", theme.TechHorizonFill.ToCss())
+            .EndEmptyElement().Line();
+        writer.StartElement("path")
+            .Attribute("data-cfx-role", "visual-canvas-road-glow")
+            .Attribute("d", "M " + F(canvas.Width * 0.50) + " " + F(canvas.Height * 0.82) + " C " + F(canvas.Width * 0.72) + " " + F(canvas.Height * 0.86) + ", " + F(canvas.Width * 0.80) + " " + F(canvas.Height * 0.93) + ", " + F(canvas.Width * 0.92) + " " + F(canvas.Height))
+            .Attribute("fill", "none")
+            .Attribute("stroke", accent.ToCss())
+            .Attribute("stroke-opacity", 0.76)
+            .Attribute("stroke-width", 5)
+            .Attribute("filter", "url(#" + id + "-soft-glow)")
+            .EndEmptyElement().Line();
+        writer.EndElement().Line();
+    }
+
+    private static void RenderText(SvgMarkupWriter writer, VisualCanvasTextLayer text) {
+        var anchor = Anchor(text.Alignment);
+        var x = AlignedX(text.X, text.Width, text.Alignment);
+        writer.StartElement("text")
+            .Attribute("data-cfx-role", "visual-canvas-text")
+            .Attribute("x", x)
+            .Attribute("y", text.Y + text.FontSize)
+            .Attribute("text-anchor", anchor)
+            .Attribute("fill", text.Color.ToCss())
+            .Attribute("font-family", "Segoe UI, Arial, sans-serif")
+            .Attribute("font-size", text.FontSize)
+            .Attribute("font-weight", text.Emphasized ? "800" : "500")
+            .Text(text.Text)
+            .EndElement()
+            .Line();
+    }
+
+    private static void RenderHeroTitle(SvgMarkupWriter writer, VisualCanvasHeroTitleLayer hero) {
+        var anchor = Anchor(hero.Alignment);
+        var x = AlignedX(hero.X, hero.Width, hero.Alignment);
+        writer.StartElement("text")
+            .Attribute("data-cfx-role", "visual-canvas-hero-title")
+            .Attribute("x", x)
+            .Attribute("y", hero.Y + hero.FontSize)
+            .Attribute("text-anchor", anchor)
+            .Attribute("font-family", "Segoe UI, Arial, sans-serif")
+            .Attribute("font-size", hero.FontSize)
+            .Attribute("font-weight", "850")
+            .Attribute("letter-spacing", "0")
+            .EndStartElement();
+        foreach (var run in hero.Runs) writer.StartElement("tspan").Attribute("fill", run.Color.ToCss()).Text(run.Text).EndElement();
+        writer.EndElement().Line();
+    }
+
+    private static void RenderInfoTile(SvgMarkupWriter writer, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme) {
+        VisualCanvas.ValidateEnum(tile.SurfaceStyle, nameof(tile.SurfaceStyle));
+        VisualCanvas.ValidateEnum(tile.IconKind, nameof(tile.IconKind));
+        var x = Math.Round(tile.X);
+        var y = Math.Round(tile.Y);
+        var width = Math.Round(tile.Width);
+        var height = Math.Round(tile.Height);
+        var fill = theme.TileGlassTop;
+        var border = tile.Accent.WithOpacity(0.72);
+        var radius = Math.Min(16, height * 0.18);
+        writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-info-tile").EndStartElement().Line();
+        writer.StartElement("rect").Attribute("x", x + 0.5).Attribute("y", y + 0.5).Attribute("width", Math.Max(1, width - 1)).Attribute("height", Math.Max(1, height - 1)).Attribute("rx", radius).Attribute("fill", tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass ? fill.ToCss() : "none").Attribute("stroke", border.ToCss()).Attribute("stroke-width", 1.4).EndEmptyElement().Line();
+        if (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass) {
+            writer.StartElement("rect").Attribute("x", x + 2.5).Attribute("y", y + 2.5).Attribute("width", Math.Max(1, width - 5)).Attribute("height", Math.Max(1, height - 5)).Attribute("rx", Math.Max(1, radius - 2)).Attribute("fill", "none").Attribute("stroke", theme.TileInnerStroke.ToCss()).EndEmptyElement().Line();
+        }
+        var padX = Math.Max(20, Math.Min(28, width * 0.06));
+        var iconBox = Math.Max(44, Math.Min(54, height - 34));
+        var iconX = x + padX;
+        var iconY = y + (height - iconBox) / 2;
+        var iconFont = Math.Min(25, iconBox * (tile.Icon.Length > 3 ? 0.34 : 0.42));
+        writer.StartElement("rect").Attribute("x", iconX).Attribute("y", iconY).Attribute("width", iconBox).Attribute("height", iconBox).Attribute("rx", Math.Min(13, iconBox * 0.25)).Attribute("fill", tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass ? tile.Accent.WithOpacity(0.18).ToCss() : "none").Attribute("stroke", tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Outline ? tile.Accent.WithOpacity(0.38).ToCss() : "none").EndEmptyElement().Line();
+        RenderTileIcon(writer, tile.IconKind, tile.Icon, iconX, iconY, iconBox, iconFont, tile.Accent);
+        var textX = iconX + iconBox + 22;
+        var hasDetail = tile.Detail.Length > 0;
+        var labelY = y + (hasDetail ? 30 : Math.Max(32, (height - 52) / 2 + 14));
+        var valueY = labelY + 28;
+        var detailY = valueY + 25;
+        writer.StartElement("text").Attribute("x", textX).Attribute("y", labelY).Attribute("fill", theme.TileLabelColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 14).Attribute("font-weight", "700").Text(tile.Label).EndElement().Line();
+        writer.StartElement("text").Attribute("x", textX).Attribute("y", valueY).Attribute("fill", theme.TileValueColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", height < 92 ? 21 : 22).Attribute("font-weight", "650").Text(tile.Value).EndElement().Line();
+        if (hasDetail) writer.StartElement("text").Attribute("x", textX).Attribute("y", detailY).Attribute("fill", theme.TileDetailColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 13).Text(tile.Detail).EndElement().Line();
+        if (tile.Progress.HasValue) {
+            var railX = textX;
+            var railY = y + height - 16;
+            var railW = Math.Max(24, width - (railX - x) - padX);
+            writer.StartElement("rect").Attribute("x", railX).Attribute("y", railY).Attribute("width", railW).Attribute("height", 8).Attribute("rx", 4).Attribute("fill", theme.TileProgressTrackColor.ToCss()).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", railX).Attribute("y", railY).Attribute("width", railW * tile.Progress.Value).Attribute("height", 8).Attribute("rx", 4).Attribute("fill", tile.Accent.ToCss()).EndEmptyElement().Line();
+        }
+
+        writer.EndElement().Line();
+    }
+
+    private static void RenderTileIcon(SvgMarkupWriter writer, VisualCanvasInfoTileIconKind kind, string text, double x, double y, double size, double iconFont, ChartColor color) {
+        var stroke = color.ToCss();
+        var thick = Math.Max(1.6, size * 0.045);
+        var cx = x + size / 2;
+        var cy = y + size / 2;
+        var left = x + size * 0.24;
+        var right = x + size * 0.76;
+        var top = y + size * 0.24;
+        var bottom = y + size * 0.76;
+        if (kind == VisualCanvasInfoTileIconKind.Text) {
+            writer.StartElement("text").Attribute("x", cx).Attribute("y", cy + iconFont * 0.36).Attribute("text-anchor", "middle").Attribute("fill", stroke).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", iconFont).Attribute("font-weight", "800").Text(text).EndElement().Line();
+            return;
+        }
+
+        writer.StartElement("g").Attribute("fill", "none").Attribute("stroke", stroke).Attribute("stroke-width", thick).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndStartElement().Line();
+        switch (kind) {
+            case VisualCanvasInfoTileIconKind.Computer:
+            case VisualCanvasInfoTileIconKind.OperatingSystem:
+                writer.StartElement("rect").Attribute("x", left).Attribute("y", top).Attribute("width", size * 0.52).Attribute("height", size * 0.36).Attribute("rx", 3).EndEmptyElement().Line();
+                writer.StartElement("path").Attribute("d", "M " + F(cx) + " " + F(top + size * 0.36) + " L " + F(cx) + " " + F(bottom - size * 0.08) + " M " + F(cx - size * 0.16) + " " + F(bottom - size * 0.08) + " L " + F(cx + size * 0.16) + " " + F(bottom - size * 0.08)).EndEmptyElement().Line();
+                if (kind == VisualCanvasInfoTileIconKind.OperatingSystem) writer.StartElement("path").Attribute("d", "M " + F(cx) + " " + F(top) + " L " + F(cx) + " " + F(top + size * 0.36) + " M " + F(left) + " " + F(top + size * 0.18) + " L " + F(right) + " " + F(top + size * 0.18)).Attribute("opacity", 0.75).EndEmptyElement().Line();
+                break;
+            case VisualCanvasInfoTileIconKind.Network:
+                writer.StartElement("circle").Attribute("cx", cx).Attribute("cy", cy).Attribute("r", size * 0.27).EndEmptyElement().Line();
+                writer.StartElement("path").Attribute("d", "M " + F(cx - size * 0.27) + " " + F(cy) + " L " + F(cx + size * 0.27) + " " + F(cy) + " M " + F(cx) + " " + F(cy - size * 0.27) + " L " + F(cx) + " " + F(cy + size * 0.27)).EndEmptyElement().Line();
+                writer.StartElement("circle").Attribute("cx", cx).Attribute("cy", cy).Attribute("r", size * 0.12).Attribute("opacity", 0.65).EndEmptyElement().Line();
+                break;
+            case VisualCanvasInfoTileIconKind.Cpu:
+                writer.StartElement("rect").Attribute("x", x + size * 0.31).Attribute("y", y + size * 0.31).Attribute("width", size * 0.38).Attribute("height", size * 0.38).Attribute("rx", 4).EndEmptyElement().Line();
+                for (var i = 0; i < 4; i++) {
+                    var p = y + size * (0.24 + i * 0.17);
+                    var q = x + size * (0.24 + i * 0.17);
+                    writer.StartElement("path").Attribute("d", "M " + F(x + size * 0.22) + " " + F(p) + " L " + F(x + size * 0.31) + " " + F(p) + " M " + F(x + size * 0.69) + " " + F(p) + " L " + F(x + size * 0.78) + " " + F(p) + " M " + F(q) + " " + F(y + size * 0.22) + " L " + F(q) + " " + F(y + size * 0.31) + " M " + F(q) + " " + F(y + size * 0.69) + " L " + F(q) + " " + F(y + size * 0.78)).EndEmptyElement().Line();
+                }
+                break;
+            case VisualCanvasInfoTileIconKind.Memory:
+                writer.StartElement("rect").Attribute("x", left).Attribute("y", y + size * 0.35).Attribute("width", size * 0.52).Attribute("height", size * 0.30).Attribute("rx", 3).EndEmptyElement().Line();
+                for (var i = 0; i < 5; i++) writer.StartElement("path").Attribute("d", "M " + F(x + size * (0.28 + i * 0.10)) + " " + F(y + size * 0.65) + " L " + F(x + size * (0.28 + i * 0.10)) + " " + F(y + size * 0.72)).EndEmptyElement().Line();
+                break;
+            case VisualCanvasInfoTileIconKind.User:
+                writer.StartElement("circle").Attribute("cx", cx).Attribute("cy", y + size * 0.38).Attribute("r", size * 0.11).EndEmptyElement().Line();
+                writer.StartElement("path").Attribute("d", "M " + F(cx - size * 0.22) + " " + F(bottom) + " L " + F(cx - size * 0.12) + " " + F(y + size * 0.58) + " L " + F(cx + size * 0.12) + " " + F(y + size * 0.58) + " L " + F(cx + size * 0.22) + " " + F(bottom)).EndEmptyElement().Line();
+                break;
+            case VisualCanvasInfoTileIconKind.Domain:
+                writer.StartElement("path").Attribute("d", "M " + F(x + size * 0.22) + " " + F(bottom) + " L " + F(x + size * 0.78) + " " + F(bottom) + " M " + F(x + size * 0.32) + " " + F(bottom) + " L " + F(x + size * 0.32) + " " + F(top) + " L " + F(x + size * 0.60) + " " + F(top) + " L " + F(x + size * 0.60) + " " + F(bottom) + " M " + F(x + size * 0.60) + " " + F(y + size * 0.44) + " L " + F(x + size * 0.74) + " " + F(y + size * 0.44) + " L " + F(x + size * 0.74) + " " + F(bottom)).EndEmptyElement().Line();
+                break;
+            case VisualCanvasInfoTileIconKind.Terminal:
+                writer.StartElement("path").Attribute("d", "M " + F(x + size * 0.30) + " " + F(y + size * 0.36) + " L " + F(x + size * 0.44) + " " + F(cy) + " L " + F(x + size * 0.30) + " " + F(y + size * 0.64) + " M " + F(x + size * 0.52) + " " + F(y + size * 0.64) + " L " + F(x + size * 0.72) + " " + F(y + size * 0.64)).EndEmptyElement().Line();
+                break;
+            default:
+                writer.EndElement().Line();
+                RenderTileIcon(writer, VisualCanvasInfoTileIconKind.Text, text, x, y, size, iconFont, color);
+                return;
+        }
+        writer.EndElement().Line();
+    }
+
+    private static void RenderHeroBadge(SvgMarkupWriter writer, VisualCanvasHeroBadgeLayer badge, string id, VisualCanvasTheme theme) {
+        writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-hero-badge").EndStartElement().Line();
+        writer.StartElement("rect").Attribute("x", badge.X).Attribute("y", badge.Y).Attribute("width", badge.Width).Attribute("height", badge.Height).Attribute("rx", Math.Min(22, badge.Height * 0.20)).Attribute("fill", theme.HeroBadgeTop.ToCss()).Attribute("stroke", badge.Accent.ToCss()).Attribute("stroke-width", 2.4).Attribute("filter", "url(#" + id + "-soft-glow)").EndEmptyElement().Line();
+        writer.StartElement("text").Attribute("x", badge.X + badge.Width / 2).Attribute("y", badge.Y + badge.Height / 2 + badge.Height * 0.17).Attribute("text-anchor", "middle").Attribute("fill", theme.HeroBadgeTextColor.ToCss()).Attribute("font-family", "Cascadia Mono, Consolas, monospace").Attribute("font-size", Math.Max(24, badge.Height * 0.42)).Attribute("font-weight", "850").Text(badge.Symbol).EndElement().Line();
+        writer.EndElement().Line();
+    }
+
+    private static void RenderImage(SvgMarkupWriter writer, VisualCanvasImageLayer image, VisualCanvasTheme theme) {
+        writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-image").EndStartElement().Line();
+        if (image.Href.Length > 0) {
+            writer.StartElement("image").Attribute("x", image.X).Attribute("y", image.Y).Attribute("width", image.Width).Attribute("height", image.Height).Attribute("href", image.Href).Attribute("preserveAspectRatio", "xMidYMid meet").Attribute("opacity", image.Opacity).EndEmptyElement().Line();
+        } else {
+            writer.StartElement("rect").Attribute("x", image.X).Attribute("y", image.Y).Attribute("width", image.Width).Attribute("height", image.Height).Attribute("rx", 12).Attribute("fill", theme.ImagePlaceholderFill.ToCss()).Attribute("stroke", theme.ImagePlaceholderStroke.ToCss()).EndEmptyElement().Line();
+        }
+
+        writer.EndElement().Line();
+    }
+
+    private static void RenderFeatureStrip(SvgMarkupWriter writer, VisualCanvasFeatureStripLayer strip, VisualCanvasTheme theme) {
+        writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-feature-strip").EndStartElement().Line();
+        var slot = strip.Width / strip.Items.Count;
+        for (var i = 0; i < strip.Items.Count; i++) {
+            var item = strip.Items[i];
+            var cx = strip.X + slot * i + slot / 2;
+            if (i > 0) writer.StartElement("line").Attribute("x1", strip.X + slot * i).Attribute("y1", strip.Y + 4).Attribute("x2", strip.X + slot * i).Attribute("y2", strip.Y + strip.Height - 4).Attribute("stroke", theme.FeatureDividerColor.ToCss()).EndEmptyElement().Line();
+            writer.StartElement("text").Attribute("x", cx).Attribute("y", strip.Y + 26).Attribute("text-anchor", "middle").Attribute("fill", strip.Accent.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 22).Attribute("font-weight", "800").Text(item.Icon).EndElement().Line();
+            writer.StartElement("text").Attribute("x", cx).Attribute("y", strip.Y + 58).Attribute("text-anchor", "middle").Attribute("fill", theme.FeatureLabelColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 15).Attribute("font-weight", "700").Text(item.Label).EndElement().Line();
+        }
+
+        writer.EndElement().Line();
+    }
+
+    private static string Anchor(VisualCanvasTextAlignment alignment) {
+        VisualCanvas.ValidateEnum(alignment, nameof(alignment));
+        switch (alignment) {
+            case VisualCanvasTextAlignment.Center: return "middle";
+            case VisualCanvasTextAlignment.Right: return "end";
+            default: return "start";
+        }
+    }
+
+    private static double AlignedX(double x, double width, VisualCanvasTextAlignment alignment) {
+        switch (alignment) {
+            case VisualCanvasTextAlignment.Center: return x + width / 2;
+            case VisualCanvasTextAlignment.Right: return x + width;
+            default: return x;
+        }
+    }
+
+    private static string F(double value) => SvgMarkupWriter.FormatNumber(value);
+
+    private static string NextScope() {
+        var value = Interlocked.Increment(ref ScopeCounter);
+        return "visual-canvas-" + value.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string StableHash(params string[] values) {
+        unchecked {
+            var hash = 2166136261u;
+            foreach (var value in values) {
+                for (var i = 0; i < value.Length; i++) {
+                    hash ^= value[i];
+                    hash *= 16777619;
+                }
+
+                hash ^= 31;
+                hash *= 16777619;
+            }
+
+            var bytes = BitConverter.GetBytes(hash);
+            var builder = new StringBuilder(bytes.Length * 2);
+            for (var i = 0; i < bytes.Length; i++) builder.Append(bytes[i].ToString("x2", CultureInfo.InvariantCulture));
+            return builder.ToString();
+        }
+    }
+}

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -54,8 +54,8 @@ public sealed class SvgVisualCanvasRenderer {
             .EndElement().Line();
         writer.EndElement().Line();
         writer.StartElement("filter").Attribute("id", id + "-raised-depth").Attribute("x", "-18%").Attribute("y", "-18%").Attribute("width", "136%").Attribute("height", "148%").EndStartElement().Line();
-        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 10).Attribute("stdDeviation", 7).Attribute("flood-color", "#000000").Attribute("flood-opacity", 0.42).EndEmptyElement().Line();
-        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 0).Attribute("stdDeviation", 4).Attribute("flood-color", theme.SecondaryAccent.ToCss()).Attribute("flood-opacity", 0.22).EndEmptyElement().Line();
+        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 14).Attribute("stdDeviation", 9).Attribute("flood-color", "#000000").Attribute("flood-opacity", 0.56).EndEmptyElement().Line();
+        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 0).Attribute("stdDeviation", 5).Attribute("flood-color", theme.SecondaryAccent.ToCss()).Attribute("flood-opacity", 0.30).EndEmptyElement().Line();
         writer.EndElement().Line();
         writer.EndElement().Line();
         if (canvas.BackdropStyle != VisualCanvasBackdropStyle.Transparent) {
@@ -171,9 +171,14 @@ public sealed class SvgVisualCanvasRenderer {
         var isFilled = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass || isRaised;
         writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-info-tile").EndStartElement().Line();
         if (isRaised) {
-            writer.StartElement("rect").Attribute("x", x).Attribute("y", y).Attribute("width", width).Attribute("height", height).Attribute("rx", radius).Attribute("fill", theme.TileGlassBottom.ToCss()).Attribute("filter", "url(#" + id + "-raised-depth)").EndEmptyElement().Line();
-            writer.StartElement("rect").Attribute("x", x + 2).Attribute("y", y + 2).Attribute("width", Math.Max(1, width - 4)).Attribute("height", Math.Max(1, height * 0.46)).Attribute("rx", Math.Max(1, radius - 2)).Attribute("fill", ChartColor.White.WithOpacity(0.10).ToCss()).EndEmptyElement().Line();
-            writer.StartElement("rect").Attribute("x", x - 1).Attribute("y", y - 1).Attribute("width", width + 2).Attribute("height", height + 2).Attribute("rx", radius + 1).Attribute("fill", "none").Attribute("stroke", tile.Accent.WithOpacity(0.26).ToCss()).Attribute("stroke-width", 3.2).EndEmptyElement().Line();
+            var depthX = Math.Max(14, Math.Min(24, width * 0.042));
+            var depthY = Math.Max(14, Math.Min(24, height * 0.22));
+            writer.StartElement("rect").Attribute("x", x + depthX).Attribute("y", y + depthY).Attribute("width", width).Attribute("height", height).Attribute("rx", radius + 1).Attribute("fill", tile.Accent.WithOpacity(0.20).ToCss()).Attribute("filter", "url(#" + id + "-raised-depth)").EndEmptyElement().Line();
+            writer.StartElement("polygon").Attribute("points", Points(x + width, y + radius * 0.7, x + width + depthX, y + depthY + radius * 0.7, x + width + depthX, y + height + depthY - radius * 0.7, x + width, y + height - radius * 0.7)).Attribute("fill", tile.Accent.WithOpacity(0.32).ToCss()).EndEmptyElement().Line();
+            writer.StartElement("polygon").Attribute("points", Points(x + radius * 0.7, y + height, x + width - radius * 0.7, y + height, x + width + depthX - radius * 0.7, y + height + depthY, x + depthX + radius * 0.7, y + height + depthY)).Attribute("fill", ChartColor.Black.WithOpacity(0.42).ToCss()).EndEmptyElement().Line();
+            writer.StartElement("path").Attribute("d", "M " + F(x + width - 1) + " " + F(y + radius) + " L " + F(x + width + depthX - 1) + " " + F(y + depthY + radius) + " M " + F(x + radius) + " " + F(y + height - 1) + " L " + F(x + depthX + radius) + " " + F(y + height + depthY - 1)).Attribute("fill", "none").Attribute("stroke", tile.Accent.WithOpacity(0.56).ToCss()).Attribute("stroke-width", 1.9).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x + 2).Attribute("y", y + 2).Attribute("width", Math.Max(1, width - 4)).Attribute("height", Math.Max(1, height * 0.52)).Attribute("rx", Math.Max(1, radius - 2)).Attribute("fill", ChartColor.White.WithOpacity(0.20).ToCss()).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x - 2).Attribute("y", y - 2).Attribute("width", width + 4).Attribute("height", height + 4).Attribute("rx", radius + 2).Attribute("fill", "none").Attribute("stroke", tile.Accent.WithOpacity(0.48).ToCss()).Attribute("stroke-width", 4.4).EndEmptyElement().Line();
         }
         writer.StartElement("rect").Attribute("x", x + 0.5).Attribute("y", y + 0.5).Attribute("width", Math.Max(1, width - 1)).Attribute("height", Math.Max(1, height - 1)).Attribute("rx", radius).Attribute("fill", isFilled ? fill.ToCss() : "none").Attribute("stroke", tile.Accent.WithOpacity(isRaised ? 0.92 : 0.72).ToCss()).Attribute("stroke-width", isRaised ? 2.2 : 1.4).EndEmptyElement().Line();
         if (isFilled) {
@@ -264,6 +269,15 @@ public sealed class SvgVisualCanvasRenderer {
         }
         writer.StartElement("path").Attribute("d", line.ToString()).Attribute("fill", "none").Attribute("stroke", tile.Accent.ToCss()).Attribute("stroke-width", 2.2).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement().Line();
         writer.EndElement().Line();
+    }
+
+    private static string Points(params double[] values) {
+        var builder = new StringBuilder();
+        for (var i = 0; i + 1 < values.Length; i += 2) {
+            if (builder.Length > 0) builder.Append(' ');
+            builder.Append(F(values[i])).Append(',').Append(F(values[i + 1]));
+        }
+        return builder.ToString();
     }
 
     private static void RenderTileIcon(SvgMarkupWriter writer, VisualCanvasInfoTileIconKind kind, string text, double x, double y, double size, double iconFont, ChartColor color) {

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text;
 using System.Threading;
 using ChartForgeX.Primitives;
+using ChartForgeX.Raster;
 using ChartForgeX.Svg;
 
 namespace ChartForgeX.Composition;
@@ -46,6 +47,14 @@ public sealed class SvgVisualCanvasRenderer {
         writer.StartElement("stop").Attribute("offset", "100%").Attribute("stop-color", canvas.BackgroundBottom.ToCss()).EndEmptyElement().Line();
         writer.EndElement().Line();
         var theme = canvas.Theme ?? new VisualCanvasTheme();
+        writer.StartElement("linearGradient").Attribute("id", id + "-tile-glass").Attribute("x1", "0").Attribute("y1", "0").Attribute("x2", "0").Attribute("y2", "1").EndStartElement().Line();
+        writer.StartElement("stop").Attribute("offset", "0%").Attribute("stop-color", theme.TileGlassTop.ToCss()).EndEmptyElement().Line();
+        writer.StartElement("stop").Attribute("offset", "100%").Attribute("stop-color", theme.TileGlassBottom.ToCss()).EndEmptyElement().Line();
+        writer.EndElement().Line();
+        writer.StartElement("linearGradient").Attribute("id", id + "-hero-badge").Attribute("x1", "0").Attribute("y1", "0").Attribute("x2", "0").Attribute("y2", "1").EndStartElement().Line();
+        writer.StartElement("stop").Attribute("offset", "0%").Attribute("stop-color", theme.HeroBadgeTop.ToCss()).EndEmptyElement().Line();
+        writer.StartElement("stop").Attribute("offset", "100%").Attribute("stop-color", theme.HeroBadgeBottom.ToCss()).EndEmptyElement().Line();
+        writer.EndElement().Line();
         writer.StartElement("filter").Attribute("id", id + "-soft-glow").Attribute("x", "-30%").Attribute("y", "-30%").Attribute("width", "160%").Attribute("height", "160%").EndStartElement().Line();
         writer.StartElement("feGaussianBlur").Attribute("stdDeviation", 5).Attribute("result", "blur").EndEmptyElement().Line();
         writer.StartElement("feMerge").EndStartElement()
@@ -125,6 +134,7 @@ public sealed class SvgVisualCanvasRenderer {
     private static void RenderText(SvgMarkupWriter writer, VisualCanvasTextLayer text) {
         var anchor = Anchor(text.Alignment);
         var x = AlignedX(text.X, text.Width, text.Alignment);
+        var fitted = FitText(text.Text, text.FontSize, Math.Max(4, text.Width), text.Emphasized);
         writer.StartElement("text")
             .Attribute("data-cfx-role", "visual-canvas-text")
             .Attribute("x", x)
@@ -134,7 +144,7 @@ public sealed class SvgVisualCanvasRenderer {
             .Attribute("font-family", "Segoe UI, Arial, sans-serif")
             .Attribute("font-size", text.FontSize)
             .Attribute("font-weight", text.Emphasized ? "800" : "500")
-            .Text(text.Text)
+            .Text(fitted)
             .EndElement()
             .Line();
     }
@@ -164,21 +174,20 @@ public sealed class SvgVisualCanvasRenderer {
         var y = Math.Round(tile.Y);
         var width = Math.Round(tile.Width);
         var height = Math.Round(tile.Height);
-        var fill = theme.TileGlassTop;
-        var border = tile.Accent.WithOpacity(0.72);
+        var accent = tile.AccentOverride ?? theme.Accent;
         var radius = Math.Min(16, height * 0.18);
         var isRaised = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Raised;
         var isFilled = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass || isRaised;
         writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-info-tile").EndStartElement().Line();
         if (isRaised) {
             writer.StartElement("rect").Attribute("x", x + 6).Attribute("y", y + 8).Attribute("width", width).Attribute("height", height).Attribute("rx", radius + 2).Attribute("fill", ChartColor.Black.WithOpacity(0.34).ToCss()).Attribute("filter", "url(#" + id + "-raised-depth)").EndEmptyElement().Line();
-            writer.StartElement("rect").Attribute("x", x - 5).Attribute("y", y - 5).Attribute("width", width + 10).Attribute("height", height + 10).Attribute("rx", radius + 5).Attribute("fill", tile.Accent.WithOpacity(0.11).ToCss()).EndEmptyElement().Line();
-            writer.StartElement("rect").Attribute("x", x - 2).Attribute("y", y - 2).Attribute("width", width + 4).Attribute("height", height + 4).Attribute("rx", radius + 2).Attribute("fill", tile.Accent.WithOpacity(0.13).ToCss()).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x - 5).Attribute("y", y - 5).Attribute("width", width + 10).Attribute("height", height + 10).Attribute("rx", radius + 5).Attribute("fill", accent.WithOpacity(0.11).ToCss()).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x - 2).Attribute("y", y - 2).Attribute("width", width + 4).Attribute("height", height + 4).Attribute("rx", radius + 2).Attribute("fill", accent.WithOpacity(0.13).ToCss()).EndEmptyElement().Line();
             writer.StartElement("rect").Attribute("x", x + 2).Attribute("y", y + 2).Attribute("width", Math.Max(1, width - 4)).Attribute("height", Math.Max(1, height * 0.52)).Attribute("rx", Math.Max(1, radius - 2)).Attribute("fill", ChartColor.White.WithOpacity(0.20).ToCss()).EndEmptyElement().Line();
-            writer.StartElement("rect").Attribute("x", x - 2).Attribute("y", y - 2).Attribute("width", width + 4).Attribute("height", height + 4).Attribute("rx", radius + 2).Attribute("fill", "none").Attribute("stroke", tile.Accent.WithOpacity(0.42).ToCss()).Attribute("stroke-width", 3.2).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x - 2).Attribute("y", y - 2).Attribute("width", width + 4).Attribute("height", height + 4).Attribute("rx", radius + 2).Attribute("fill", "none").Attribute("stroke", accent.WithOpacity(0.42).ToCss()).Attribute("stroke-width", 3.2).EndEmptyElement().Line();
             writer.StartElement("path").Attribute("d", "M " + F(x + radius) + " " + F(y + 3) + " L " + F(x + width - radius) + " " + F(y + 3) + " M " + F(x + radius) + " " + F(y + height - 2) + " L " + F(x + width - radius) + " " + F(y + height - 2)).Attribute("fill", "none").Attribute("stroke", ChartColor.White.WithOpacity(0.26).ToCss()).Attribute("stroke-width", 1.4).EndEmptyElement().Line();
         }
-        writer.StartElement("rect").Attribute("x", x + 0.5).Attribute("y", y + 0.5).Attribute("width", Math.Max(1, width - 1)).Attribute("height", Math.Max(1, height - 1)).Attribute("rx", radius).Attribute("fill", isFilled ? fill.ToCss() : "none").Attribute("stroke", tile.Accent.WithOpacity(isRaised ? 0.92 : 0.72).ToCss()).Attribute("stroke-width", isRaised ? 2.2 : 1.4).EndEmptyElement().Line();
+        writer.StartElement("rect").Attribute("x", x + 0.5).Attribute("y", y + 0.5).Attribute("width", Math.Max(1, width - 1)).Attribute("height", Math.Max(1, height - 1)).Attribute("rx", radius).Attribute("fill", isFilled ? "url(#" + id + "-tile-glass)" : "none").Attribute("stroke", accent.WithOpacity(isRaised ? 0.92 : 0.72).ToCss()).Attribute("stroke-width", isRaised ? 2.2 : 1.4).EndEmptyElement().Line();
         if (isFilled) {
             writer.StartElement("rect").Attribute("x", x + 2.5).Attribute("y", y + 2.5).Attribute("width", Math.Max(1, width - 5)).Attribute("height", Math.Max(1, height - 5)).Attribute("rx", Math.Max(1, radius - 2)).Attribute("fill", "none").Attribute("stroke", theme.TileInnerStroke.ToCss()).EndEmptyElement().Line();
         }
@@ -187,8 +196,8 @@ public sealed class SvgVisualCanvasRenderer {
         var iconX = x + padX;
         var iconY = y + (height - iconBox) / 2;
         var iconFont = Math.Min(25, iconBox * (tile.Icon.Length > 3 ? 0.34 : 0.42));
-        writer.StartElement("rect").Attribute("x", iconX).Attribute("y", iconY).Attribute("width", iconBox).Attribute("height", iconBox).Attribute("rx", Math.Min(13, iconBox * 0.25)).Attribute("fill", isFilled ? tile.Accent.WithOpacity(isRaised ? 0.25 : 0.18).ToCss() : "none").Attribute("stroke", isRaised ? tile.Accent.WithOpacity(0.32).ToCss() : (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Outline ? tile.Accent.WithOpacity(0.38).ToCss() : "none")).EndEmptyElement().Line();
-        RenderTileIcon(writer, tile.IconKind, tile.Icon, iconX, iconY, iconBox, iconFont, tile.Accent);
+        writer.StartElement("rect").Attribute("x", iconX).Attribute("y", iconY).Attribute("width", iconBox).Attribute("height", iconBox).Attribute("rx", Math.Min(13, iconBox * 0.25)).Attribute("fill", isFilled ? accent.WithOpacity(isRaised ? 0.25 : 0.18).ToCss() : "none").Attribute("stroke", isRaised ? accent.WithOpacity(0.32).ToCss() : (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Outline ? accent.WithOpacity(0.38).ToCss() : "none")).EndEmptyElement().Line();
+        RenderTileIcon(writer, tile.IconKind, tile.Icon, iconX, iconY, iconBox, iconFont, accent);
         var textX = iconX + iconBox + 22;
         var hasMiniChart = tile.MiniChartKind != VisualCanvasInfoTileMiniChartKind.None && tile.MiniChartValues.Count > 0;
         var chartW = hasMiniChart ? Math.Min(width * 0.24, Math.Max(82, width * 0.20)) : 0;
@@ -199,24 +208,25 @@ public sealed class SvgVisualCanvasRenderer {
         var labelY = y + (hasDetail ? 30 : Math.Max(32, (height - 52) / 2 + 14));
         var valueY = labelY + 28;
         var detailY = valueY + 25;
-        writer.StartElement("text").Attribute("x", textX).Attribute("y", labelY).Attribute("fill", theme.TileLabelColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 14).Attribute("font-weight", "700").Text(tile.Label).EndElement().Line();
-        writer.StartElement("text").Attribute("x", textX).Attribute("y", valueY).Attribute("fill", theme.TileValueColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", height < 92 ? 21 : 22).Attribute("font-weight", "650").Text(tile.Value).EndElement().Line();
-        if (hasDetail) writer.StartElement("text").Attribute("x", textX).Attribute("y", detailY).Attribute("fill", theme.TileDetailColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 13).Text(tile.Detail).EndElement().Line();
+        var textMax = hasMiniChart ? Math.Max(24, chartX - textX - 16) : Math.Max(24, width - (textX - x) - padX);
+        writer.StartElement("text").Attribute("x", textX).Attribute("y", labelY).Attribute("fill", theme.TileLabelColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 14).Attribute("font-weight", "700").Text(FitText(tile.Label, 14, textMax, true)).EndElement().Line();
+        writer.StartElement("text").Attribute("x", textX).Attribute("y", valueY).Attribute("fill", theme.TileValueColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", height < 92 ? 21 : 22).Attribute("font-weight", "650").Text(FitText(tile.Value, height < 92 ? 21 : 22, textMax, true)).EndElement().Line();
+        if (hasDetail) writer.StartElement("text").Attribute("x", textX).Attribute("y", detailY).Attribute("fill", theme.TileDetailColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 13).Text(FitText(tile.Detail, 13, textMax, false)).EndElement().Line();
         if (tile.Progress.HasValue) {
             var railX = textX;
             var railY = y + height - 16;
             var railW = hasMiniChart ? Math.Max(24, chartX - railX - 16) : Math.Max(24, width - (railX - x) - padX);
             writer.StartElement("rect").Attribute("x", railX).Attribute("y", railY).Attribute("width", railW).Attribute("height", 8).Attribute("rx", 4).Attribute("fill", theme.TileProgressTrackColor.ToCss()).EndEmptyElement().Line();
-            writer.StartElement("rect").Attribute("x", railX).Attribute("y", railY).Attribute("width", railW * tile.Progress.Value).Attribute("height", 8).Attribute("rx", 4).Attribute("fill", tile.Accent.ToCss()).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", railX).Attribute("y", railY).Attribute("width", railW * tile.Progress.Value).Attribute("height", 8).Attribute("rx", 4).Attribute("fill", accent.ToCss()).EndEmptyElement().Line();
         }
         if (hasMiniChart) {
-            RenderTileMiniChart(writer, tile, theme, chartX, chartY, chartW, chartH);
+            RenderTileMiniChart(writer, tile, theme, accent, chartX, chartY, chartW, chartH);
         }
 
         writer.EndElement().Line();
     }
 
-    private static void RenderTileMiniChart(SvgMarkupWriter writer, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme, double x, double y, double width, double height) {
+    private static void RenderTileMiniChart(SvgMarkupWriter writer, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme, ChartColor accent, double x, double y, double width, double height) {
         writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-info-tile-mini-chart").EndStartElement().Line();
         writer.StartElement("rect").Attribute("x", x).Attribute("y", y).Attribute("width", width).Attribute("height", height).Attribute("rx", Math.Min(8, height * 0.24)).Attribute("fill", theme.TileMiniChartTrackColor.WithOpacity(0.20).ToCss()).EndEmptyElement().Line();
         writer.StartElement("path").Attribute("d", "M " + F(x + 4) + " " + F(y + height * 0.72) + " L " + F(x + width - 4) + " " + F(y + height * 0.72) + " M " + F(x + 4) + " " + F(y + height * 0.38) + " L " + F(x + width - 4) + " " + F(y + height * 0.38)).Attribute("fill", "none").Attribute("stroke", theme.TileMiniChartTrackColor.ToCss()).Attribute("stroke-width", 1).EndEmptyElement().Line();
@@ -226,7 +236,7 @@ public sealed class SvgVisualCanvasRenderer {
         var max = tile.MiniChartMaximum ?? 0.0;
         for (var i = 0; i < values.Count; i++) {
             if (values[i] < min) min = values[i];
-            if (values[i] > max) max = values[i];
+            if (!tile.MiniChartMaximum.HasValue && values[i] > max) max = values[i];
         }
         if (max <= min) max = min + 1;
 
@@ -236,12 +246,12 @@ public sealed class SvgVisualCanvasRenderer {
         var plotH = Math.Max(1, height - 12);
         var baseY = plotY + plotH;
         if (tile.MiniChartKind == VisualCanvasInfoTileMiniChartKind.Bars) {
-            var gap = Math.Max(1, plotW * 0.035);
-            var barW = Math.Max(2, (plotW - gap * (values.Count - 1)) / values.Count);
+            var gap = values.Count > 1 ? Math.Min(Math.Max(1, plotW * 0.035), plotW / (values.Count * 3.0)) : 0;
+            var barW = Math.Max(0.5, (plotW - gap * (values.Count - 1)) / values.Count);
             for (var i = 0; i < values.Count; i++) {
                 var ratio = Math.Max(0, Math.Min(1, (values[i] - min) / (max - min)));
                 var barH = Math.Max(2, plotH * ratio);
-                writer.StartElement("rect").Attribute("x", plotX + i * (barW + gap)).Attribute("y", baseY - barH).Attribute("width", barW).Attribute("height", barH).Attribute("rx", Math.Min(4, barW * 0.42)).Attribute("fill", tile.Accent.WithOpacity(0.82).ToCss()).EndEmptyElement().Line();
+                writer.StartElement("rect").Attribute("x", plotX + i * (barW + gap)).Attribute("y", baseY - barH).Attribute("width", barW).Attribute("height", barH).Attribute("rx", Math.Min(4, barW * 0.42)).Attribute("fill", accent.WithOpacity(0.82).ToCss()).EndEmptyElement().Line();
             }
             writer.EndElement().Line();
             return;
@@ -265,7 +275,7 @@ public sealed class SvgVisualCanvasRenderer {
         if (tile.MiniChartKind == VisualCanvasInfoTileMiniChartKind.Area && values.Count > 1) {
             writer.StartElement("path").Attribute("d", area.ToString()).Attribute("fill", theme.TileMiniChartFillColor.ToCss()).EndEmptyElement().Line();
         }
-        writer.StartElement("path").Attribute("d", line.ToString()).Attribute("fill", "none").Attribute("stroke", tile.Accent.ToCss()).Attribute("stroke-width", 2.2).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement().Line();
+        writer.StartElement("path").Attribute("d", line.ToString()).Attribute("fill", "none").Attribute("stroke", accent.ToCss()).Attribute("stroke-width", 2.2).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement().Line();
         writer.EndElement().Line();
     }
 
@@ -318,6 +328,14 @@ public sealed class SvgVisualCanvasRenderer {
             case VisualCanvasInfoTileIconKind.Terminal:
                 writer.StartElement("path").Attribute("d", "M " + F(x + size * 0.30) + " " + F(y + size * 0.36) + " L " + F(x + size * 0.44) + " " + F(cy) + " L " + F(x + size * 0.30) + " " + F(y + size * 0.64) + " M " + F(x + size * 0.52) + " " + F(y + size * 0.64) + " L " + F(x + size * 0.72) + " " + F(y + size * 0.64)).EndEmptyElement().Line();
                 break;
+            case VisualCanvasInfoTileIconKind.Storage:
+                writer.StartElement("ellipse").Attribute("cx", cx).Attribute("cy", y + size * 0.32).Attribute("rx", size * 0.19).Attribute("ry", size * 0.09).EndEmptyElement().Line();
+                writer.StartElement("path").Attribute("d", "M " + F(cx - size * 0.19) + " " + F(y + size * 0.32) + " L " + F(cx - size * 0.19) + " " + F(y + size * 0.68) + " C " + F(cx - size * 0.19) + " " + F(y + size * 0.80) + ", " + F(cx + size * 0.19) + " " + F(y + size * 0.80) + ", " + F(cx + size * 0.19) + " " + F(y + size * 0.68) + " L " + F(cx + size * 0.19) + " " + F(y + size * 0.32)).EndEmptyElement().Line();
+                writer.StartElement("path").Attribute("d", "M " + F(cx - size * 0.19) + " " + F(y + size * 0.50) + " C " + F(cx - size * 0.19) + " " + F(y + size * 0.62) + ", " + F(cx + size * 0.19) + " " + F(y + size * 0.62) + ", " + F(cx + size * 0.19) + " " + F(y + size * 0.50)).Attribute("opacity", 0.72).EndEmptyElement().Line();
+                break;
+            case VisualCanvasInfoTileIconKind.Shield:
+                writer.StartElement("path").Attribute("d", "M " + F(cx) + " " + F(top) + " L " + F(right) + " " + F(y + size * 0.36) + " L " + F(x + size * 0.68) + " " + F(bottom) + " L " + F(cx) + " " + F(y + size * 0.82) + " L " + F(x + size * 0.32) + " " + F(bottom) + " L " + F(left) + " " + F(y + size * 0.36) + " Z").EndEmptyElement().Line();
+                break;
             default:
                 writer.EndElement().Line();
                 RenderTileIcon(writer, VisualCanvasInfoTileIconKind.Text, text, x, y, size, iconFont, color);
@@ -327,21 +345,54 @@ public sealed class SvgVisualCanvasRenderer {
     }
 
     private static void RenderHeroBadge(SvgMarkupWriter writer, VisualCanvasHeroBadgeLayer badge, string id, VisualCanvasTheme theme) {
+        var accent = badge.AccentOverride ?? theme.SecondaryAccent;
         writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-hero-badge").EndStartElement().Line();
-        writer.StartElement("rect").Attribute("x", badge.X).Attribute("y", badge.Y).Attribute("width", badge.Width).Attribute("height", badge.Height).Attribute("rx", Math.Min(22, badge.Height * 0.20)).Attribute("fill", theme.HeroBadgeTop.ToCss()).Attribute("stroke", badge.Accent.ToCss()).Attribute("stroke-width", 2.4).Attribute("filter", "url(#" + id + "-soft-glow)").EndEmptyElement().Line();
+        writer.StartElement("rect").Attribute("x", badge.X).Attribute("y", badge.Y).Attribute("width", badge.Width).Attribute("height", badge.Height).Attribute("rx", Math.Min(22, badge.Height * 0.20)).Attribute("fill", "url(#" + id + "-hero-badge)").Attribute("stroke", accent.ToCss()).Attribute("stroke-width", 2.4).Attribute("filter", "url(#" + id + "-soft-glow)").EndEmptyElement().Line();
         writer.StartElement("text").Attribute("x", badge.X + badge.Width / 2).Attribute("y", badge.Y + badge.Height / 2 + badge.Height * 0.17).Attribute("text-anchor", "middle").Attribute("fill", theme.HeroBadgeTextColor.ToCss()).Attribute("font-family", "Cascadia Mono, Consolas, monospace").Attribute("font-size", Math.Max(24, badge.Height * 0.42)).Attribute("font-weight", "850").Text(badge.Symbol).EndElement().Line();
         writer.EndElement().Line();
     }
 
     private static void RenderImage(SvgMarkupWriter writer, VisualCanvasImageLayer image, VisualCanvasTheme theme) {
+        VisualCanvas.ValidateEnum(image.Fit, nameof(image.Fit));
         writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-image").EndStartElement().Line();
         if (image.Href.Length > 0) {
-            writer.StartElement("image").Attribute("x", image.X).Attribute("y", image.Y).Attribute("width", image.Width).Attribute("height", image.Height).Attribute("href", image.Href).Attribute("preserveAspectRatio", "xMidYMid meet").Attribute("opacity", image.Opacity).EndEmptyElement().Line();
+            var preserveAspectRatio = PreserveAspectRatio(image.Fit);
+            if (image.Fit == VisualCanvasImageFit.Center && image.SourceWidth > 0 && image.SourceHeight > 0) {
+                var clipId = NextScope() + "-image-clip";
+                writer.StartElement("clipPath").Attribute("id", clipId).EndStartElement()
+                    .StartElement("rect").Attribute("x", image.X).Attribute("y", image.Y).Attribute("width", image.Width).Attribute("height", image.Height).EndEmptyElement()
+                    .EndElement().Line();
+                writer.StartElement("image")
+                    .Attribute("x", image.X + (image.Width - image.SourceWidth) / 2)
+                    .Attribute("y", image.Y + (image.Height - image.SourceHeight) / 2)
+                    .Attribute("width", image.SourceWidth)
+                    .Attribute("height", image.SourceHeight)
+                    .Attribute("href", image.Href)
+                    .Attribute("preserveAspectRatio", "none")
+                    .Attribute("opacity", image.Opacity)
+                    .Attribute("clip-path", "url(#" + clipId + ")")
+                    .EndEmptyElement().Line();
+            } else {
+                writer.StartElement("image").Attribute("x", image.X).Attribute("y", image.Y).Attribute("width", image.Width).Attribute("height", image.Height).Attribute("href", image.Href).Attribute("preserveAspectRatio", preserveAspectRatio).Attribute("opacity", image.Opacity).EndEmptyElement().Line();
+            }
         } else {
             writer.StartElement("rect").Attribute("x", image.X).Attribute("y", image.Y).Attribute("width", image.Width).Attribute("height", image.Height).Attribute("rx", 12).Attribute("fill", theme.ImagePlaceholderFill.ToCss()).Attribute("stroke", theme.ImagePlaceholderStroke.ToCss()).EndEmptyElement().Line();
         }
 
         writer.EndElement().Line();
+    }
+
+    private static string PreserveAspectRatio(VisualCanvasImageFit fit) {
+        switch (fit) {
+            case VisualCanvasImageFit.Contain:
+                return "xMidYMid meet";
+            case VisualCanvasImageFit.Cover:
+                return "xMidYMid slice";
+            case VisualCanvasImageFit.Center:
+            case VisualCanvasImageFit.Stretch:
+            default:
+                return "none";
+        }
     }
 
     private static void RenderFeatureStrip(SvgMarkupWriter writer, VisualCanvasFeatureStripLayer strip, VisualCanvasTheme theme) {
@@ -351,8 +402,8 @@ public sealed class SvgVisualCanvasRenderer {
             var item = strip.Items[i];
             var cx = strip.X + slot * i + slot / 2;
             if (i > 0) writer.StartElement("line").Attribute("x1", strip.X + slot * i).Attribute("y1", strip.Y + 4).Attribute("x2", strip.X + slot * i).Attribute("y2", strip.Y + strip.Height - 4).Attribute("stroke", theme.FeatureDividerColor.ToCss()).EndEmptyElement().Line();
-            writer.StartElement("text").Attribute("x", cx).Attribute("y", strip.Y + 26).Attribute("text-anchor", "middle").Attribute("fill", strip.Accent.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 22).Attribute("font-weight", "800").Text(item.Icon).EndElement().Line();
-            writer.StartElement("text").Attribute("x", cx).Attribute("y", strip.Y + 58).Attribute("text-anchor", "middle").Attribute("fill", theme.FeatureLabelColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 15).Attribute("font-weight", "700").Text(item.Label).EndElement().Line();
+            writer.StartElement("text").Attribute("x", cx).Attribute("y", strip.Y + 26).Attribute("text-anchor", "middle").Attribute("fill", strip.Accent.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 22).Attribute("font-weight", "800").Text(FitText(item.Icon, 22, Math.Max(8, slot - 12), true)).EndElement().Line();
+            writer.StartElement("text").Attribute("x", cx).Attribute("y", strip.Y + 58).Attribute("text-anchor", "middle").Attribute("fill", theme.FeatureLabelColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 15).Attribute("font-weight", "700").Text(FitText(item.Label, 15, Math.Max(8, slot - 12), true)).EndElement().Line();
         }
 
         writer.EndElement().Line();
@@ -376,6 +427,24 @@ public sealed class SvgVisualCanvasRenderer {
     }
 
     private static string F(double value) => SvgMarkupWriter.FormatNumber(value);
+
+    private static string FitText(string value, double fontSize, double maxWidth, bool emphasized) {
+        if (string.IsNullOrEmpty(value) || Measure(value, fontSize, emphasized) <= maxWidth) return value;
+        const string suffix = "...";
+        if (Measure(suffix, fontSize, emphasized) > maxWidth) return string.Empty;
+        var low = 0;
+        var high = value.Length;
+        while (low < high) {
+            var mid = (low + high + 1) / 2;
+            if (Measure(value.Substring(0, mid) + suffix, fontSize, emphasized) <= maxWidth) low = mid;
+            else high = mid - 1;
+        }
+
+        return value.Substring(0, low) + suffix;
+    }
+
+    private static double Measure(string value, double fontSize, bool emphasized) =>
+        emphasized ? RgbaCanvas.MeasureTextEmphasizedWidth(value, fontSize, null) : RgbaCanvas.MeasureTextWidth(value, fontSize, null);
 
     private static string NextScope() {
         var value = Interlocked.Increment(ref ScopeCounter);

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -54,8 +54,8 @@ public sealed class SvgVisualCanvasRenderer {
             .EndElement().Line();
         writer.EndElement().Line();
         writer.StartElement("filter").Attribute("id", id + "-raised-depth").Attribute("x", "-18%").Attribute("y", "-18%").Attribute("width", "136%").Attribute("height", "148%").EndStartElement().Line();
-        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 14).Attribute("stdDeviation", 9).Attribute("flood-color", "#000000").Attribute("flood-opacity", 0.56).EndEmptyElement().Line();
-        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 0).Attribute("stdDeviation", 5).Attribute("flood-color", theme.SecondaryAccent.ToCss()).Attribute("flood-opacity", 0.30).EndEmptyElement().Line();
+        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 11).Attribute("stdDeviation", 8).Attribute("flood-color", "#000000").Attribute("flood-opacity", 0.42).EndEmptyElement().Line();
+        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 0).Attribute("stdDeviation", 6).Attribute("flood-color", theme.SecondaryAccent.ToCss()).Attribute("flood-opacity", 0.24).EndEmptyElement().Line();
         writer.EndElement().Line();
         writer.EndElement().Line();
         if (canvas.BackdropStyle != VisualCanvasBackdropStyle.Transparent) {
@@ -171,14 +171,12 @@ public sealed class SvgVisualCanvasRenderer {
         var isFilled = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass || isRaised;
         writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-info-tile").EndStartElement().Line();
         if (isRaised) {
-            var depthX = Math.Max(14, Math.Min(24, width * 0.042));
-            var depthY = Math.Max(14, Math.Min(24, height * 0.22));
-            writer.StartElement("rect").Attribute("x", x + depthX).Attribute("y", y + depthY).Attribute("width", width).Attribute("height", height).Attribute("rx", radius + 1).Attribute("fill", tile.Accent.WithOpacity(0.20).ToCss()).Attribute("filter", "url(#" + id + "-raised-depth)").EndEmptyElement().Line();
-            writer.StartElement("polygon").Attribute("points", Points(x + width, y + radius * 0.7, x + width + depthX, y + depthY + radius * 0.7, x + width + depthX, y + height + depthY - radius * 0.7, x + width, y + height - radius * 0.7)).Attribute("fill", tile.Accent.WithOpacity(0.32).ToCss()).EndEmptyElement().Line();
-            writer.StartElement("polygon").Attribute("points", Points(x + radius * 0.7, y + height, x + width - radius * 0.7, y + height, x + width + depthX - radius * 0.7, y + height + depthY, x + depthX + radius * 0.7, y + height + depthY)).Attribute("fill", ChartColor.Black.WithOpacity(0.42).ToCss()).EndEmptyElement().Line();
-            writer.StartElement("path").Attribute("d", "M " + F(x + width - 1) + " " + F(y + radius) + " L " + F(x + width + depthX - 1) + " " + F(y + depthY + radius) + " M " + F(x + radius) + " " + F(y + height - 1) + " L " + F(x + depthX + radius) + " " + F(y + height + depthY - 1)).Attribute("fill", "none").Attribute("stroke", tile.Accent.WithOpacity(0.56).ToCss()).Attribute("stroke-width", 1.9).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x + 6).Attribute("y", y + 8).Attribute("width", width).Attribute("height", height).Attribute("rx", radius + 2).Attribute("fill", ChartColor.Black.WithOpacity(0.34).ToCss()).Attribute("filter", "url(#" + id + "-raised-depth)").EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x - 5).Attribute("y", y - 5).Attribute("width", width + 10).Attribute("height", height + 10).Attribute("rx", radius + 5).Attribute("fill", tile.Accent.WithOpacity(0.11).ToCss()).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x - 2).Attribute("y", y - 2).Attribute("width", width + 4).Attribute("height", height + 4).Attribute("rx", radius + 2).Attribute("fill", tile.Accent.WithOpacity(0.13).ToCss()).EndEmptyElement().Line();
             writer.StartElement("rect").Attribute("x", x + 2).Attribute("y", y + 2).Attribute("width", Math.Max(1, width - 4)).Attribute("height", Math.Max(1, height * 0.52)).Attribute("rx", Math.Max(1, radius - 2)).Attribute("fill", ChartColor.White.WithOpacity(0.20).ToCss()).EndEmptyElement().Line();
-            writer.StartElement("rect").Attribute("x", x - 2).Attribute("y", y - 2).Attribute("width", width + 4).Attribute("height", height + 4).Attribute("rx", radius + 2).Attribute("fill", "none").Attribute("stroke", tile.Accent.WithOpacity(0.48).ToCss()).Attribute("stroke-width", 4.4).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x - 2).Attribute("y", y - 2).Attribute("width", width + 4).Attribute("height", height + 4).Attribute("rx", radius + 2).Attribute("fill", "none").Attribute("stroke", tile.Accent.WithOpacity(0.42).ToCss()).Attribute("stroke-width", 3.2).EndEmptyElement().Line();
+            writer.StartElement("path").Attribute("d", "M " + F(x + radius) + " " + F(y + 3) + " L " + F(x + width - radius) + " " + F(y + 3) + " M " + F(x + radius) + " " + F(y + height - 2) + " L " + F(x + width - radius) + " " + F(y + height - 2)).Attribute("fill", "none").Attribute("stroke", ChartColor.White.WithOpacity(0.26).ToCss()).Attribute("stroke-width", 1.4).EndEmptyElement().Line();
         }
         writer.StartElement("rect").Attribute("x", x + 0.5).Attribute("y", y + 0.5).Attribute("width", Math.Max(1, width - 1)).Attribute("height", Math.Max(1, height - 1)).Attribute("rx", radius).Attribute("fill", isFilled ? fill.ToCss() : "none").Attribute("stroke", tile.Accent.WithOpacity(isRaised ? 0.92 : 0.72).ToCss()).Attribute("stroke-width", isRaised ? 2.2 : 1.4).EndEmptyElement().Line();
         if (isFilled) {
@@ -269,15 +267,6 @@ public sealed class SvgVisualCanvasRenderer {
         }
         writer.StartElement("path").Attribute("d", line.ToString()).Attribute("fill", "none").Attribute("stroke", tile.Accent.ToCss()).Attribute("stroke-width", 2.2).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement().Line();
         writer.EndElement().Line();
-    }
-
-    private static string Points(params double[] values) {
-        var builder = new StringBuilder();
-        for (var i = 0; i + 1 < values.Length; i += 2) {
-            if (builder.Length > 0) builder.Append(' ');
-            builder.Append(F(values[i])).Append(',').Append(F(values[i + 1]));
-        }
-        return builder.ToString();
     }
 
     private static void RenderTileIcon(SvgMarkupWriter writer, VisualCanvasInfoTileIconKind kind, string text, double x, double y, double size, double iconFont, ChartColor color) {

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -53,6 +53,10 @@ public sealed class SvgVisualCanvasRenderer {
             .StartElement("feMergeNode").Attribute("in", "SourceGraphic").EndEmptyElement()
             .EndElement().Line();
         writer.EndElement().Line();
+        writer.StartElement("filter").Attribute("id", id + "-raised-depth").Attribute("x", "-18%").Attribute("y", "-18%").Attribute("width", "136%").Attribute("height", "148%").EndStartElement().Line();
+        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 10).Attribute("stdDeviation", 7).Attribute("flood-color", "#000000").Attribute("flood-opacity", 0.42).EndEmptyElement().Line();
+        writer.StartElement("feDropShadow").Attribute("dx", 0).Attribute("dy", 0).Attribute("stdDeviation", 4).Attribute("flood-color", theme.SecondaryAccent.ToCss()).Attribute("flood-opacity", 0.22).EndEmptyElement().Line();
+        writer.EndElement().Line();
         writer.EndElement().Line();
         if (canvas.BackdropStyle != VisualCanvasBackdropStyle.Transparent) {
             writer.StartElement("rect").Attribute("data-cfx-role", "visual-canvas-background").Attribute("width", "100%").Attribute("height", "100%").Attribute("fill", "url(#" + id + "-background)").EndEmptyElement().Line();
@@ -69,7 +73,7 @@ public sealed class SvgVisualCanvasRenderer {
         } else if (layer is VisualCanvasHeroTitleLayer hero) {
             RenderHeroTitle(writer, hero);
         } else if (layer is VisualCanvasInfoTileLayer tile) {
-            RenderInfoTile(writer, tile, theme);
+            RenderInfoTile(writer, tile, id, theme);
         } else if (layer is VisualCanvasHeroBadgeLayer badge) {
             RenderHeroBadge(writer, badge, id, theme);
         } else if (layer is VisualCanvasImageLayer image) {
@@ -152,7 +156,7 @@ public sealed class SvgVisualCanvasRenderer {
         writer.EndElement().Line();
     }
 
-    private static void RenderInfoTile(SvgMarkupWriter writer, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme) {
+    private static void RenderInfoTile(SvgMarkupWriter writer, VisualCanvasInfoTileLayer tile, string id, VisualCanvasTheme theme) {
         VisualCanvas.ValidateEnum(tile.SurfaceStyle, nameof(tile.SurfaceStyle));
         VisualCanvas.ValidateEnum(tile.IconKind, nameof(tile.IconKind));
         VisualCanvas.ValidateEnum(tile.MiniChartKind, nameof(tile.MiniChartKind));
@@ -163,9 +167,16 @@ public sealed class SvgVisualCanvasRenderer {
         var fill = theme.TileGlassTop;
         var border = tile.Accent.WithOpacity(0.72);
         var radius = Math.Min(16, height * 0.18);
+        var isRaised = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Raised;
+        var isFilled = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass || isRaised;
         writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-info-tile").EndStartElement().Line();
-        writer.StartElement("rect").Attribute("x", x + 0.5).Attribute("y", y + 0.5).Attribute("width", Math.Max(1, width - 1)).Attribute("height", Math.Max(1, height - 1)).Attribute("rx", radius).Attribute("fill", tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass ? fill.ToCss() : "none").Attribute("stroke", border.ToCss()).Attribute("stroke-width", 1.4).EndEmptyElement().Line();
-        if (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass) {
+        if (isRaised) {
+            writer.StartElement("rect").Attribute("x", x).Attribute("y", y).Attribute("width", width).Attribute("height", height).Attribute("rx", radius).Attribute("fill", theme.TileGlassBottom.ToCss()).Attribute("filter", "url(#" + id + "-raised-depth)").EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x + 2).Attribute("y", y + 2).Attribute("width", Math.Max(1, width - 4)).Attribute("height", Math.Max(1, height * 0.46)).Attribute("rx", Math.Max(1, radius - 2)).Attribute("fill", ChartColor.White.WithOpacity(0.10).ToCss()).EndEmptyElement().Line();
+            writer.StartElement("rect").Attribute("x", x - 1).Attribute("y", y - 1).Attribute("width", width + 2).Attribute("height", height + 2).Attribute("rx", radius + 1).Attribute("fill", "none").Attribute("stroke", tile.Accent.WithOpacity(0.26).ToCss()).Attribute("stroke-width", 3.2).EndEmptyElement().Line();
+        }
+        writer.StartElement("rect").Attribute("x", x + 0.5).Attribute("y", y + 0.5).Attribute("width", Math.Max(1, width - 1)).Attribute("height", Math.Max(1, height - 1)).Attribute("rx", radius).Attribute("fill", isFilled ? fill.ToCss() : "none").Attribute("stroke", tile.Accent.WithOpacity(isRaised ? 0.92 : 0.72).ToCss()).Attribute("stroke-width", isRaised ? 2.2 : 1.4).EndEmptyElement().Line();
+        if (isFilled) {
             writer.StartElement("rect").Attribute("x", x + 2.5).Attribute("y", y + 2.5).Attribute("width", Math.Max(1, width - 5)).Attribute("height", Math.Max(1, height - 5)).Attribute("rx", Math.Max(1, radius - 2)).Attribute("fill", "none").Attribute("stroke", theme.TileInnerStroke.ToCss()).EndEmptyElement().Line();
         }
         var padX = Math.Max(20, Math.Min(28, width * 0.06));
@@ -173,7 +184,7 @@ public sealed class SvgVisualCanvasRenderer {
         var iconX = x + padX;
         var iconY = y + (height - iconBox) / 2;
         var iconFont = Math.Min(25, iconBox * (tile.Icon.Length > 3 ? 0.34 : 0.42));
-        writer.StartElement("rect").Attribute("x", iconX).Attribute("y", iconY).Attribute("width", iconBox).Attribute("height", iconBox).Attribute("rx", Math.Min(13, iconBox * 0.25)).Attribute("fill", tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass ? tile.Accent.WithOpacity(0.18).ToCss() : "none").Attribute("stroke", tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Outline ? tile.Accent.WithOpacity(0.38).ToCss() : "none").EndEmptyElement().Line();
+        writer.StartElement("rect").Attribute("x", iconX).Attribute("y", iconY).Attribute("width", iconBox).Attribute("height", iconBox).Attribute("rx", Math.Min(13, iconBox * 0.25)).Attribute("fill", isFilled ? tile.Accent.WithOpacity(isRaised ? 0.25 : 0.18).ToCss() : "none").Attribute("stroke", isRaised ? tile.Accent.WithOpacity(0.32).ToCss() : (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Outline ? tile.Accent.WithOpacity(0.38).ToCss() : "none")).EndEmptyElement().Line();
         RenderTileIcon(writer, tile.IconKind, tile.Icon, iconX, iconY, iconBox, iconFont, tile.Accent);
         var textX = iconX + iconBox + 22;
         var hasMiniChart = tile.MiniChartKind != VisualCanvasInfoTileMiniChartKind.None && tile.MiniChartValues.Count > 0;

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -155,6 +155,7 @@ public sealed class SvgVisualCanvasRenderer {
     private static void RenderInfoTile(SvgMarkupWriter writer, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme) {
         VisualCanvas.ValidateEnum(tile.SurfaceStyle, nameof(tile.SurfaceStyle));
         VisualCanvas.ValidateEnum(tile.IconKind, nameof(tile.IconKind));
+        VisualCanvas.ValidateEnum(tile.MiniChartKind, nameof(tile.MiniChartKind));
         var x = Math.Round(tile.X);
         var y = Math.Round(tile.Y);
         var width = Math.Round(tile.Width);
@@ -175,6 +176,11 @@ public sealed class SvgVisualCanvasRenderer {
         writer.StartElement("rect").Attribute("x", iconX).Attribute("y", iconY).Attribute("width", iconBox).Attribute("height", iconBox).Attribute("rx", Math.Min(13, iconBox * 0.25)).Attribute("fill", tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass ? tile.Accent.WithOpacity(0.18).ToCss() : "none").Attribute("stroke", tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Outline ? tile.Accent.WithOpacity(0.38).ToCss() : "none").EndEmptyElement().Line();
         RenderTileIcon(writer, tile.IconKind, tile.Icon, iconX, iconY, iconBox, iconFont, tile.Accent);
         var textX = iconX + iconBox + 22;
+        var hasMiniChart = tile.MiniChartKind != VisualCanvasInfoTileMiniChartKind.None && tile.MiniChartValues.Count > 0;
+        var chartW = hasMiniChart ? Math.Min(width * 0.24, Math.Max(82, width * 0.20)) : 0;
+        var chartX = x + width - padX - chartW;
+        var chartY = y + Math.Max(24, height * 0.30);
+        var chartH = Math.Max(28, Math.Min(46, height * 0.42));
         var hasDetail = tile.Detail.Length > 0;
         var labelY = y + (hasDetail ? 30 : Math.Max(32, (height - 52) / 2 + 14));
         var valueY = labelY + 28;
@@ -185,11 +191,67 @@ public sealed class SvgVisualCanvasRenderer {
         if (tile.Progress.HasValue) {
             var railX = textX;
             var railY = y + height - 16;
-            var railW = Math.Max(24, width - (railX - x) - padX);
+            var railW = hasMiniChart ? Math.Max(24, chartX - railX - 16) : Math.Max(24, width - (railX - x) - padX);
             writer.StartElement("rect").Attribute("x", railX).Attribute("y", railY).Attribute("width", railW).Attribute("height", 8).Attribute("rx", 4).Attribute("fill", theme.TileProgressTrackColor.ToCss()).EndEmptyElement().Line();
             writer.StartElement("rect").Attribute("x", railX).Attribute("y", railY).Attribute("width", railW * tile.Progress.Value).Attribute("height", 8).Attribute("rx", 4).Attribute("fill", tile.Accent.ToCss()).EndEmptyElement().Line();
         }
+        if (hasMiniChart) {
+            RenderTileMiniChart(writer, tile, theme, chartX, chartY, chartW, chartH);
+        }
 
+        writer.EndElement().Line();
+    }
+
+    private static void RenderTileMiniChart(SvgMarkupWriter writer, VisualCanvasInfoTileLayer tile, VisualCanvasTheme theme, double x, double y, double width, double height) {
+        writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-info-tile-mini-chart").EndStartElement().Line();
+        writer.StartElement("rect").Attribute("x", x).Attribute("y", y).Attribute("width", width).Attribute("height", height).Attribute("rx", Math.Min(8, height * 0.24)).Attribute("fill", theme.TileMiniChartTrackColor.WithOpacity(0.20).ToCss()).EndEmptyElement().Line();
+        writer.StartElement("path").Attribute("d", "M " + F(x + 4) + " " + F(y + height * 0.72) + " L " + F(x + width - 4) + " " + F(y + height * 0.72) + " M " + F(x + 4) + " " + F(y + height * 0.38) + " L " + F(x + width - 4) + " " + F(y + height * 0.38)).Attribute("fill", "none").Attribute("stroke", theme.TileMiniChartTrackColor.ToCss()).Attribute("stroke-width", 1).EndEmptyElement().Line();
+
+        var values = tile.MiniChartValues;
+        var min = 0.0;
+        var max = tile.MiniChartMaximum ?? 0.0;
+        for (var i = 0; i < values.Count; i++) {
+            if (values[i] < min) min = values[i];
+            if (values[i] > max) max = values[i];
+        }
+        if (max <= min) max = min + 1;
+
+        var plotX = x + 7;
+        var plotY = y + 6;
+        var plotW = Math.Max(1, width - 14);
+        var plotH = Math.Max(1, height - 12);
+        var baseY = plotY + plotH;
+        if (tile.MiniChartKind == VisualCanvasInfoTileMiniChartKind.Bars) {
+            var gap = Math.Max(1, plotW * 0.035);
+            var barW = Math.Max(2, (plotW - gap * (values.Count - 1)) / values.Count);
+            for (var i = 0; i < values.Count; i++) {
+                var ratio = Math.Max(0, Math.Min(1, (values[i] - min) / (max - min)));
+                var barH = Math.Max(2, plotH * ratio);
+                writer.StartElement("rect").Attribute("x", plotX + i * (barW + gap)).Attribute("y", baseY - barH).Attribute("width", barW).Attribute("height", barH).Attribute("rx", Math.Min(4, barW * 0.42)).Attribute("fill", tile.Accent.WithOpacity(0.82).ToCss()).EndEmptyElement().Line();
+            }
+            writer.EndElement().Line();
+            return;
+        }
+
+        var line = new StringBuilder();
+        var area = new StringBuilder();
+        for (var i = 0; i < values.Count; i++) {
+            var px = values.Count == 1 ? plotX + plotW / 2 : plotX + plotW * i / (values.Count - 1);
+            var ratio = Math.Max(0, Math.Min(1, (values[i] - min) / (max - min)));
+            var py = plotY + plotH - plotH * ratio;
+            if (i == 0) {
+                line.Append("M ").Append(F(px)).Append(' ').Append(F(py));
+                area.Append("M ").Append(F(px)).Append(' ').Append(F(baseY)).Append(" L ").Append(F(px)).Append(' ').Append(F(py));
+            } else {
+                line.Append(" L ").Append(F(px)).Append(' ').Append(F(py));
+                area.Append(" L ").Append(F(px)).Append(' ').Append(F(py));
+            }
+            if (i == values.Count - 1) area.Append(" L ").Append(F(px)).Append(' ').Append(F(baseY)).Append(" Z");
+        }
+        if (tile.MiniChartKind == VisualCanvasInfoTileMiniChartKind.Area && values.Count > 1) {
+            writer.StartElement("path").Attribute("d", area.ToString()).Attribute("fill", theme.TileMiniChartFillColor.ToCss()).EndEmptyElement().Line();
+        }
+        writer.StartElement("path").Attribute("d", line.ToString()).Attribute("fill", "none").Attribute("stroke", tile.Accent.ToCss()).Attribute("stroke-width", 2.2).Attribute("stroke-linecap", "round").Attribute("stroke-linejoin", "round").EndEmptyElement().Line();
         writer.EndElement().Line();
     }
 

--- a/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
@@ -30,6 +30,20 @@ public enum VisualCanvasTextAlignment {
 }
 
 /// <summary>
+/// Defines how source images are placed inside a visual canvas image layer.
+/// </summary>
+public enum VisualCanvasImageFit {
+    /// <summary>Scale the image independently in both axes to fill the destination rectangle.</summary>
+    Stretch,
+    /// <summary>Scale the image uniformly so the entire source is visible inside the destination rectangle.</summary>
+    Contain,
+    /// <summary>Scale and crop the image uniformly so the destination rectangle is fully covered.</summary>
+    Cover,
+    /// <summary>Draw the image at its source pixel size, centered inside the destination rectangle.</summary>
+    Center
+}
+
+/// <summary>
 /// Surface treatment for visual canvas information tiles.
 /// </summary>
 public enum VisualCanvasInfoTileSurfaceStyle {
@@ -143,6 +157,7 @@ public sealed class VisualCanvasTheme {
 /// </summary>
 public sealed class VisualCanvas {
     private readonly List<VisualCanvasLayer> _layers = new();
+    private VisualCanvasTheme _theme = new();
     private int _width;
     private int _height;
     private int _pngOutputScale = 1;
@@ -184,7 +199,7 @@ public sealed class VisualCanvas {
     public VisualCanvasBackdropStyle BackdropStyle { get; set; } = VisualCanvasBackdropStyle.Plain;
 
     /// <summary>Gets or sets the theme used by built-in visual canvas layers.</summary>
-    public VisualCanvasTheme Theme { get; set; } = new();
+    public VisualCanvasTheme Theme { get => _theme; set => _theme = value ?? throw new ArgumentNullException(nameof(value)); }
 
     /// <summary>Gets or sets the PNG output pixel multiplier.</summary>
     public int PngOutputScale {
@@ -242,15 +257,18 @@ public sealed class VisualCanvas {
 
     /// <summary>Adds a reusable information tile.</summary>
     public VisualCanvas AddInfoTile(double x, double y, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text, VisualCanvasInfoTileMiniChartKind miniChartKind = VisualCanvasInfoTileMiniChartKind.None, IEnumerable<double>? miniChartValues = null, double? miniChartMaximum = null) =>
-        AddLayer(new VisualCanvasInfoTileLayer(x, y, width, height, icon, label, value) { Detail = detail ?? string.Empty, Accent = accent ?? Theme.Accent, Progress = progress, SurfaceStyle = surfaceStyle, IconKind = iconKind }.WithMiniChart(miniChartKind, miniChartValues, miniChartMaximum));
+        AddLayer(new VisualCanvasInfoTileLayer(x, y, width, height, icon, label, value) { Detail = detail ?? string.Empty, AccentOverride = accent, Progress = progress, SurfaceStyle = surfaceStyle, IconKind = iconKind }.WithMiniChart(miniChartKind, miniChartValues, miniChartMaximum));
 
     /// <summary>Adds a central icon or logo badge.</summary>
     public VisualCanvas AddHeroBadge(double x, double y, double width, double height, string symbol, ChartColor? accent = null) =>
-        AddLayer(new VisualCanvasHeroBadgeLayer(x, y, width, height, symbol) { Accent = accent ?? Theme.SecondaryAccent });
+        AddLayer(new VisualCanvasHeroBadgeLayer(x, y, width, height, symbol) { AccentOverride = accent });
 
     /// <summary>Adds an image layer. SVG output uses <paramref name="href"/>; PNG output uses <paramref name="rgba"/> when supplied.</summary>
-    public VisualCanvas AddImage(double x, double y, double width, double height, string? href = null, byte[]? rgba = null, int sourceWidth = 0, int sourceHeight = 0, double opacity = 1) =>
-        AddLayer(new VisualCanvasImageLayer(x, y, width, height) { Href = href ?? string.Empty, Rgba = rgba, SourceWidth = sourceWidth, SourceHeight = sourceHeight, Opacity = opacity });
+    public VisualCanvas AddImage(double x, double y, double width, double height, string? href = null, byte[]? rgba = null, int sourceWidth = 0, int sourceHeight = 0, double opacity = 1, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch) {
+        if (rgba != null && (sourceWidth <= 0 || sourceHeight <= 0)) throw new ArgumentOutOfRangeException(nameof(sourceWidth), "RGBA image layers require positive sourceWidth and sourceHeight.");
+        ValidateEnum(fit, nameof(fit));
+        return AddLayer(new VisualCanvasImageLayer(x, y, width, height) { Href = href ?? string.Empty, Rgba = rgba, SourceWidth = sourceWidth, SourceHeight = sourceHeight, Opacity = opacity, Fit = fit });
+    }
 
     /// <summary>Adds a compact feature strip.</summary>
     public VisualCanvas AddFeatureStrip(double x, double y, double width, double height, IEnumerable<VisualCanvasFeatureItem> items) =>
@@ -423,7 +441,9 @@ public sealed class VisualCanvasInfoTileLayer : VisualCanvasLayer {
     /// <summary>Gets or sets optional detail text.</summary>
     public string Detail { get => _detail; set => _detail = value ?? throw new ArgumentNullException(nameof(value)); }
     /// <summary>Gets or sets the accent color.</summary>
-    public ChartColor Accent { get; set; } = ChartColor.FromHex("#2F80FF");
+    public ChartColor Accent { get => AccentOverride ?? ChartColor.FromHex("#2F80FF"); set => AccentOverride = value; }
+    /// <summary>Gets or sets an explicit accent color. When empty, renderers use the current theme accent.</summary>
+    public ChartColor? AccentOverride { get; set; }
     /// <summary>Gets or sets the tile surface treatment.</summary>
     public VisualCanvasInfoTileSurfaceStyle SurfaceStyle { get; set; }
     /// <summary>Gets or sets the tile icon treatment.</summary>
@@ -484,7 +504,9 @@ public sealed class VisualCanvasHeroBadgeLayer : VisualCanvasLayer {
     /// <summary>Gets or sets the badge symbol.</summary>
     public string Symbol { get => _symbol; set => _symbol = value ?? throw new ArgumentNullException(nameof(value)); }
     /// <summary>Gets or sets the badge accent color.</summary>
-    public ChartColor Accent { get; set; } = ChartColor.FromHex("#22A7FF");
+    public ChartColor Accent { get => AccentOverride ?? ChartColor.FromHex("#22A7FF"); set => AccentOverride = value; }
+    /// <summary>Gets or sets an explicit badge accent color. When empty, renderers use the current theme secondary accent.</summary>
+    public ChartColor? AccentOverride { get; set; }
 }
 
 /// <summary>Image layer for host-provided bitmap or SVG-compatible image references.</summary>
@@ -507,6 +529,8 @@ public sealed class VisualCanvasImageLayer : VisualCanvasLayer {
     public int SourceWidth { get; set; }
     /// <summary>Gets or sets the source bitmap height for PNG output.</summary>
     public int SourceHeight { get; set; }
+    /// <summary>Gets or sets how the source image is placed inside the destination rectangle.</summary>
+    public VisualCanvasImageFit Fit { get; set; }
 
     /// <summary>Gets or sets image opacity from zero to one.</summary>
     public double Opacity {

--- a/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
@@ -36,7 +36,9 @@ public enum VisualCanvasInfoTileSurfaceStyle {
     /// <summary>Render a translucent filled panel with an accent border.</summary>
     Glass,
     /// <summary>Render only the tile border and contents over the underlying image.</summary>
-    Outline
+    Outline,
+    /// <summary>Render a raised panel with depth, glow, and stronger edge highlights.</summary>
+    Raised
 }
 
 /// <summary>

--- a/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
@@ -1,0 +1,510 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Composition;
+
+/// <summary>
+/// Built-in background treatment for fixed-size visual canvases.
+/// </summary>
+public enum VisualCanvasBackdropStyle {
+    /// <summary>Render no canvas background so layers can float over an external image.</summary>
+    Transparent,
+    /// <summary>Render only the configured background colors.</summary>
+    Plain,
+    /// <summary>Render a quiet technology-themed wallpaper backdrop.</summary>
+    TechHorizon
+}
+
+/// <summary>
+/// Horizontal text alignment used by visual canvas layers.
+/// </summary>
+public enum VisualCanvasTextAlignment {
+    /// <summary>Align text to the leading edge.</summary>
+    Left,
+    /// <summary>Center text in the available width.</summary>
+    Center,
+    /// <summary>Align text to the trailing edge.</summary>
+    Right
+}
+
+/// <summary>
+/// Surface treatment for visual canvas information tiles.
+/// </summary>
+public enum VisualCanvasInfoTileSurfaceStyle {
+    /// <summary>Render a translucent filled panel with an accent border.</summary>
+    Glass,
+    /// <summary>Render only the tile border and contents over the underlying image.</summary>
+    Outline
+}
+
+/// <summary>
+/// Built-in icon treatment for visual canvas information tiles.
+/// </summary>
+public enum VisualCanvasInfoTileIconKind {
+    /// <summary>Render the tile icon as text.</summary>
+    Text,
+    /// <summary>Render a computer monitor icon.</summary>
+    Computer,
+    /// <summary>Render a network/globe icon.</summary>
+    Network,
+    /// <summary>Render an operating system/window icon.</summary>
+    OperatingSystem,
+    /// <summary>Render a processor icon.</summary>
+    Cpu,
+    /// <summary>Render a memory module icon.</summary>
+    Memory,
+    /// <summary>Render a user icon.</summary>
+    User,
+    /// <summary>Render a domain/building icon.</summary>
+    Domain,
+    /// <summary>Render a terminal prompt icon.</summary>
+    Terminal,
+    /// <summary>Render a storage cylinder icon.</summary>
+    Storage,
+    /// <summary>Render a shield icon.</summary>
+    Shield
+}
+
+/// <summary>
+/// Theme colors for reusable visual canvas layers.
+/// </summary>
+public sealed class VisualCanvasTheme {
+    /// <summary>Gets or sets the primary accent used by built-in decorative elements.</summary>
+    public ChartColor Accent { get; set; } = ChartColor.FromHex("#2F80FF");
+    /// <summary>Gets or sets the secondary accent used by hero badges and backdrop highlights.</summary>
+    public ChartColor SecondaryAccent { get; set; } = ChartColor.FromHex("#22A7FF");
+    /// <summary>Gets or sets the first default hero title color.</summary>
+    public ChartColor HeroTitleColor { get; set; } = ChartColor.FromHex("#F8FAFC");
+    /// <summary>Gets or sets the secondary default hero title color.</summary>
+    public ChartColor HeroTitleAccentColor { get; set; } = ChartColor.FromHex("#2F80FF");
+    /// <summary>Gets or sets the subtitle text color.</summary>
+    public ChartColor SubtitleColor { get; set; } = ChartColor.FromHex("#D8E3F4");
+    /// <summary>Gets or sets the glass tile top color.</summary>
+    public ChartColor TileGlassTop { get; set; } = ChartColor.FromRgba(7, 21, 44, 232);
+    /// <summary>Gets or sets the glass tile bottom color.</summary>
+    public ChartColor TileGlassBottom { get; set; } = ChartColor.FromRgba(3, 10, 23, 224);
+    /// <summary>Gets or sets the tile inner highlight stroke color.</summary>
+    public ChartColor TileInnerStroke { get; set; } = ChartColor.White.WithOpacity(0.07);
+    /// <summary>Gets or sets the tile label text color.</summary>
+    public ChartColor TileLabelColor { get; set; } = ChartColor.FromHex("#C4D4EC");
+    /// <summary>Gets or sets the tile primary value color.</summary>
+    public ChartColor TileValueColor { get; set; } = ChartColor.FromHex("#F8FAFC");
+    /// <summary>Gets or sets the tile detail color.</summary>
+    public ChartColor TileDetailColor { get; set; } = ChartColor.FromHex("#A8BAD4");
+    /// <summary>Gets or sets the progress rail color.</summary>
+    public ChartColor TileProgressTrackColor { get; set; } = ChartColor.FromHex("#18345D").WithOpacity(0.92);
+    /// <summary>Gets or sets the hero badge glow color.</summary>
+    public ChartColor HeroBadgeGlowColor { get; set; } = ChartColor.FromHex("#22A7FF").WithOpacity(0.12);
+    /// <summary>Gets or sets the hero badge top fill color.</summary>
+    public ChartColor HeroBadgeTop { get; set; } = ChartColor.FromHex("#0B1C3A");
+    /// <summary>Gets or sets the hero badge bottom fill color.</summary>
+    public ChartColor HeroBadgeBottom { get; set; } = ChartColor.FromHex("#051021");
+    /// <summary>Gets or sets the hero badge symbol color.</summary>
+    public ChartColor HeroBadgeTextColor { get; set; } = ChartColor.FromHex("#E8F1FF");
+    /// <summary>Gets or sets the image placeholder fill color.</summary>
+    public ChartColor ImagePlaceholderFill { get; set; } = ChartColor.FromHex("#0B1B34").WithOpacity(0.68);
+    /// <summary>Gets or sets the image placeholder stroke color.</summary>
+    public ChartColor ImagePlaceholderStroke { get; set; } = ChartColor.FromHex("#2F80FF").WithOpacity(0.34);
+    /// <summary>Gets or sets the feature-strip divider color.</summary>
+    public ChartColor FeatureDividerColor { get; set; } = ChartColor.FromHex("#8AA9D6").WithOpacity(0.22);
+    /// <summary>Gets or sets the feature-strip label color.</summary>
+    public ChartColor FeatureLabelColor { get; set; } = ChartColor.FromHex("#D7E4F8");
+    /// <summary>Gets or sets the tech backdrop horizon fill color.</summary>
+    public ChartColor TechHorizonFill { get; set; } = ChartColor.FromRgba(6, 18, 37, 198);
+
+    /// <summary>Creates a shallow copy of this theme.</summary>
+    public VisualCanvasTheme Clone() => (VisualCanvasTheme)MemberwiseClone();
+}
+
+/// <summary>
+/// A fixed-size layered visual surface for wallpapers, social images, report covers, and hero graphics.
+/// </summary>
+public sealed class VisualCanvas {
+    private readonly List<VisualCanvasLayer> _layers = new();
+    private int _width;
+    private int _height;
+    private int _pngOutputScale = 1;
+    private string _title = "ChartForgeX visual canvas";
+
+    private VisualCanvas(int width, int height) {
+        Width = width;
+        Height = height;
+    }
+
+    /// <summary>Gets or sets the canvas width in pixels.</summary>
+    public int Width {
+        get => _width;
+        set {
+            if (value <= 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Visual canvas width must be positive.");
+            _width = value;
+        }
+    }
+
+    /// <summary>Gets or sets the canvas height in pixels.</summary>
+    public int Height {
+        get => _height;
+        set {
+            if (value <= 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Visual canvas height must be positive.");
+            _height = value;
+        }
+    }
+
+    /// <summary>Gets or sets the accessibility title used by SVG output.</summary>
+    public string Title { get => _title; set => _title = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets the top background color.</summary>
+    public ChartColor BackgroundTop { get; set; } = ChartColor.FromHex("#030712");
+
+    /// <summary>Gets or sets the bottom background color.</summary>
+    public ChartColor BackgroundBottom { get; set; } = ChartColor.FromHex("#07182F");
+
+    /// <summary>Gets or sets the optional backdrop decoration style.</summary>
+    public VisualCanvasBackdropStyle BackdropStyle { get; set; } = VisualCanvasBackdropStyle.Plain;
+
+    /// <summary>Gets or sets the theme used by built-in visual canvas layers.</summary>
+    public VisualCanvasTheme Theme { get; set; } = new();
+
+    /// <summary>Gets or sets the PNG output pixel multiplier.</summary>
+    public int PngOutputScale {
+        get => _pngOutputScale;
+        set {
+            if (value < 1 || value > 4) throw new ArgumentOutOfRangeException(nameof(value), value, "PNG output scale must be between one and four.");
+            _pngOutputScale = value;
+        }
+    }
+
+    /// <summary>Gets the ordered visual canvas layers.</summary>
+    public IReadOnlyList<VisualCanvasLayer> Layers => _layers;
+
+    /// <summary>Creates a fixed-size visual canvas.</summary>
+    public static VisualCanvas Create(int width, int height) => new(width, height);
+
+    /// <summary>Creates a 1200 by 630 social preview canvas.</summary>
+    public static VisualCanvas CreateSocialPreview() => new(1200, 630);
+
+    /// <summary>Creates a 1920 by 1080 desktop wallpaper canvas.</summary>
+    public static VisualCanvas CreateDesktopWallpaper() => new(1920, 1080);
+
+    /// <summary>Sets the accessibility title used by SVG output.</summary>
+    public VisualCanvas WithTitle(string title) { Title = title ?? throw new ArgumentNullException(nameof(title)); return this; }
+
+    /// <summary>Sets a solid background color.</summary>
+    public VisualCanvas WithBackground(ChartColor color) { BackgroundTop = color; BackgroundBottom = color; return this; }
+
+    /// <summary>Sets a vertical background gradient.</summary>
+    public VisualCanvas WithBackground(ChartColor top, ChartColor bottom) { BackgroundTop = top; BackgroundBottom = bottom; return this; }
+
+    /// <summary>Sets the built-in backdrop decoration style.</summary>
+    public VisualCanvas WithBackdrop(VisualCanvasBackdropStyle style) { ValidateEnum(style, nameof(style)); BackdropStyle = style; return this; }
+
+    /// <summary>Sets the theme used by built-in visual canvas layers.</summary>
+    public VisualCanvas WithTheme(VisualCanvasTheme theme) { Theme = theme ?? throw new ArgumentNullException(nameof(theme)); return this; }
+
+    /// <summary>Sets the PNG output pixel multiplier.</summary>
+    public VisualCanvas WithPngOutputScale(int scale) { PngOutputScale = scale; return this; }
+
+    /// <summary>Adds a layer to the canvas.</summary>
+    public VisualCanvas AddLayer(VisualCanvasLayer layer) {
+        if (layer == null) throw new ArgumentNullException(nameof(layer));
+        _layers.Add(layer);
+        return this;
+    }
+
+    /// <summary>Adds a plain text layer.</summary>
+    public VisualCanvas AddText(double x, double y, double width, string text, double fontSize, ChartColor color, VisualCanvasTextAlignment alignment = VisualCanvasTextAlignment.Left, bool emphasized = false) =>
+        AddLayer(new VisualCanvasTextLayer(x, y, width, text, fontSize, color) { Alignment = alignment, Emphasized = emphasized });
+
+    /// <summary>Adds a multi-color hero title layer.</summary>
+    public VisualCanvas AddHeroTitle(double x, double y, double width, double fontSize, IEnumerable<VisualCanvasTextRun> runs, VisualCanvasTextAlignment alignment = VisualCanvasTextAlignment.Center) =>
+        AddLayer(new VisualCanvasHeroTitleLayer(x, y, width, fontSize, runs) { Alignment = alignment });
+
+    /// <summary>Adds a reusable information tile.</summary>
+    public VisualCanvas AddInfoTile(double x, double y, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text) =>
+        AddLayer(new VisualCanvasInfoTileLayer(x, y, width, height, icon, label, value) { Detail = detail ?? string.Empty, Accent = accent ?? Theme.Accent, Progress = progress, SurfaceStyle = surfaceStyle, IconKind = iconKind });
+
+    /// <summary>Adds a central icon or logo badge.</summary>
+    public VisualCanvas AddHeroBadge(double x, double y, double width, double height, string symbol, ChartColor? accent = null) =>
+        AddLayer(new VisualCanvasHeroBadgeLayer(x, y, width, height, symbol) { Accent = accent ?? Theme.SecondaryAccent });
+
+    /// <summary>Adds an image layer. SVG output uses <paramref name="href"/>; PNG output uses <paramref name="rgba"/> when supplied.</summary>
+    public VisualCanvas AddImage(double x, double y, double width, double height, string? href = null, byte[]? rgba = null, int sourceWidth = 0, int sourceHeight = 0, double opacity = 1) =>
+        AddLayer(new VisualCanvasImageLayer(x, y, width, height) { Href = href ?? string.Empty, Rgba = rgba, SourceWidth = sourceWidth, SourceHeight = sourceHeight, Opacity = opacity });
+
+    /// <summary>Adds a compact feature strip.</summary>
+    public VisualCanvas AddFeatureStrip(double x, double y, double width, double height, IEnumerable<VisualCanvasFeatureItem> items) =>
+        AddLayer(new VisualCanvasFeatureStripLayer(x, y, width, height, items));
+
+    internal static void ValidateEnum<TEnum>(TEnum value, string parameterName) where TEnum : struct {
+        if (!Enum.IsDefined(typeof(TEnum), value)) throw new ArgumentOutOfRangeException(parameterName, value, "Unknown " + typeof(TEnum).Name + " value.");
+    }
+
+    internal static string FormatValue(object? value, string? format = null) {
+        if (value == null) return string.Empty;
+        if (value is IFormattable formattable && !string.IsNullOrEmpty(format)) return formattable.ToString(format, CultureInfo.InvariantCulture);
+        return Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+}
+
+/// <summary>
+/// Base type for visual canvas layers.
+/// </summary>
+public abstract class VisualCanvasLayer {
+    private double _x;
+    private double _y;
+    private double _width;
+    private double _height;
+
+    /// <summary>Initializes a new visual canvas layer.</summary>
+    /// <param name="x">The layer X coordinate.</param>
+    /// <param name="y">The layer Y coordinate.</param>
+    /// <param name="width">The layer width.</param>
+    /// <param name="height">The layer height.</param>
+    protected VisualCanvasLayer(double x, double y, double width, double height) {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+    }
+
+    /// <summary>Gets or sets the layer X coordinate.</summary>
+    public double X { get => _x; set { ValidateFinite(value, nameof(value)); _x = value; } }
+
+    /// <summary>Gets or sets the layer Y coordinate.</summary>
+    public double Y { get => _y; set { ValidateFinite(value, nameof(value)); _y = value; } }
+
+    /// <summary>Gets or sets the layer width.</summary>
+    public double Width { get => _width; set { ValidatePositive(value, nameof(value)); _width = value; } }
+
+    /// <summary>Gets or sets the layer height.</summary>
+    public double Height { get => _height; set { ValidatePositive(value, nameof(value)); _height = value; } }
+
+    /// <summary>Validates that a numeric value is finite.</summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="parameterName">The parameter name used when throwing.</param>
+    protected static void ValidateFinite(double value, string parameterName) {
+        if (double.IsNaN(value) || double.IsInfinity(value)) throw new ArgumentOutOfRangeException(parameterName, value, "Value must be finite.");
+    }
+
+    /// <summary>Validates that a numeric value is finite and positive.</summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="parameterName">The parameter name used when throwing.</param>
+    protected static void ValidatePositive(double value, string parameterName) {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) throw new ArgumentOutOfRangeException(parameterName, value, "Value must be finite and greater than zero.");
+    }
+}
+
+/// <summary>Single-color text run used by hero title layers.</summary>
+public sealed class VisualCanvasTextRun {
+    private string _text;
+
+    /// <summary>Initializes a hero title text run.</summary>
+    /// <param name="text">The text to render.</param>
+    /// <param name="color">The text color.</param>
+    public VisualCanvasTextRun(string text, ChartColor color) {
+        _text = text ?? throw new ArgumentNullException(nameof(text));
+        Color = color;
+    }
+
+    /// <summary>Gets or sets the run text.</summary>
+    public string Text { get => _text; set => _text = value ?? throw new ArgumentNullException(nameof(value)); }
+
+    /// <summary>Gets or sets the run color.</summary>
+    public ChartColor Color { get; set; }
+}
+
+/// <summary>Plain text layer.</summary>
+public sealed class VisualCanvasTextLayer : VisualCanvasLayer {
+    private string _text;
+    private double _fontSize;
+
+    /// <summary>Initializes a plain text layer.</summary>
+    /// <param name="x">The text X coordinate.</param>
+    /// <param name="y">The text Y coordinate.</param>
+    /// <param name="width">The text width used for alignment and clipping.</param>
+    /// <param name="text">The text to render.</param>
+    /// <param name="fontSize">The font size.</param>
+    /// <param name="color">The text color.</param>
+    public VisualCanvasTextLayer(double x, double y, double width, string text, double fontSize, ChartColor color) : base(x, y, width, Math.Max(1, fontSize * 1.25)) {
+        _text = text ?? throw new ArgumentNullException(nameof(text));
+        FontSize = fontSize;
+        Color = color;
+    }
+
+    /// <summary>Gets or sets the text.</summary>
+    public string Text { get => _text; set => _text = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets the font size.</summary>
+    public double FontSize { get => _fontSize; set { ValidatePositive(value, nameof(value)); _fontSize = value; Height = Math.Max(Height, value * 1.25); } }
+    /// <summary>Gets or sets the text color.</summary>
+    public ChartColor Color { get; set; }
+    /// <summary>Gets or sets the text alignment.</summary>
+    public VisualCanvasTextAlignment Alignment { get; set; }
+    /// <summary>Gets or sets whether the text should use the emphasized raster/SVG treatment.</summary>
+    public bool Emphasized { get; set; }
+}
+
+/// <summary>Large multi-color headline layer.</summary>
+public sealed class VisualCanvasHeroTitleLayer : VisualCanvasLayer {
+    private readonly List<VisualCanvasTextRun> _runs = new();
+    private double _fontSize;
+
+    /// <summary>Initializes a large multi-run hero title layer.</summary>
+    /// <param name="x">The title X coordinate.</param>
+    /// <param name="y">The title Y coordinate.</param>
+    /// <param name="width">The title width used for alignment.</param>
+    /// <param name="fontSize">The title font size.</param>
+    /// <param name="runs">The colored text runs.</param>
+    public VisualCanvasHeroTitleLayer(double x, double y, double width, double fontSize, IEnumerable<VisualCanvasTextRun> runs) : base(x, y, width, Math.Max(1, fontSize * 1.25)) {
+        FontSize = fontSize;
+        if (runs == null) throw new ArgumentNullException(nameof(runs));
+        foreach (var run in runs) _runs.Add(run ?? throw new ArgumentException("Hero title runs cannot contain null values.", nameof(runs)));
+        if (_runs.Count == 0) throw new ArgumentException("Hero title layers require at least one text run.", nameof(runs));
+    }
+
+    /// <summary>Gets the colored title runs.</summary>
+    public IReadOnlyList<VisualCanvasTextRun> Runs => _runs;
+    /// <summary>Gets or sets the title font size.</summary>
+    public double FontSize { get => _fontSize; set { ValidatePositive(value, nameof(value)); _fontSize = value; Height = Math.Max(Height, value * 1.25); } }
+    /// <summary>Gets or sets the title alignment.</summary>
+    public VisualCanvasTextAlignment Alignment { get; set; } = VisualCanvasTextAlignment.Center;
+}
+
+/// <summary>Reusable information tile layer.</summary>
+public sealed class VisualCanvasInfoTileLayer : VisualCanvasLayer {
+    private string _icon;
+    private string _label;
+    private string _value;
+    private string _detail = string.Empty;
+    private double? _progress;
+
+    /// <summary>Initializes a reusable information tile layer.</summary>
+    /// <param name="x">The tile X coordinate.</param>
+    /// <param name="y">The tile Y coordinate.</param>
+    /// <param name="width">The tile width.</param>
+    /// <param name="height">The tile height.</param>
+    /// <param name="icon">The compact icon or symbol.</param>
+    /// <param name="label">The tile label.</param>
+    /// <param name="value">The primary tile value.</param>
+    public VisualCanvasInfoTileLayer(double x, double y, double width, double height, string icon, string label, string value) : base(x, y, width, height) {
+        _icon = icon ?? throw new ArgumentNullException(nameof(icon));
+        _label = label ?? throw new ArgumentNullException(nameof(label));
+        _value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>Gets or sets the compact icon or symbol.</summary>
+    public string Icon { get => _icon; set => _icon = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets the tile label.</summary>
+    public string Label { get => _label; set => _label = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets the primary value.</summary>
+    public string Value { get => _value; set => _value = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets optional detail text.</summary>
+    public string Detail { get => _detail; set => _detail = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets the accent color.</summary>
+    public ChartColor Accent { get; set; } = ChartColor.FromHex("#2F80FF");
+    /// <summary>Gets or sets the tile surface treatment.</summary>
+    public VisualCanvasInfoTileSurfaceStyle SurfaceStyle { get; set; }
+    /// <summary>Gets or sets the tile icon treatment.</summary>
+    public VisualCanvasInfoTileIconKind IconKind { get; set; }
+
+    /// <summary>Gets or sets optional progress from zero to one.</summary>
+    public double? Progress {
+        get => _progress;
+        set {
+            if (value.HasValue && (double.IsNaN(value.Value) || double.IsInfinity(value.Value) || value.Value < 0 || value.Value > 1)) throw new ArgumentOutOfRangeException(nameof(value), value, "Progress must be between zero and one.");
+            _progress = value;
+        }
+    }
+}
+
+/// <summary>Central logo or icon badge layer.</summary>
+public sealed class VisualCanvasHeroBadgeLayer : VisualCanvasLayer {
+    private string _symbol;
+
+    /// <summary>Initializes a hero badge layer.</summary>
+    /// <param name="x">The badge X coordinate.</param>
+    /// <param name="y">The badge Y coordinate.</param>
+    /// <param name="width">The badge width.</param>
+    /// <param name="height">The badge height.</param>
+    /// <param name="symbol">The badge symbol.</param>
+    public VisualCanvasHeroBadgeLayer(double x, double y, double width, double height, string symbol) : base(x, y, width, height) {
+        _symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
+    }
+
+    /// <summary>Gets or sets the badge symbol.</summary>
+    public string Symbol { get => _symbol; set => _symbol = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets the badge accent color.</summary>
+    public ChartColor Accent { get; set; } = ChartColor.FromHex("#22A7FF");
+}
+
+/// <summary>Image layer for host-provided bitmap or SVG-compatible image references.</summary>
+public sealed class VisualCanvasImageLayer : VisualCanvasLayer {
+    private string _href = string.Empty;
+    private double _opacity = 1;
+
+    /// <summary>Initializes an image layer.</summary>
+    /// <param name="x">The image X coordinate.</param>
+    /// <param name="y">The image Y coordinate.</param>
+    /// <param name="width">The rendered image width.</param>
+    /// <param name="height">The rendered image height.</param>
+    public VisualCanvasImageLayer(double x, double y, double width, double height) : base(x, y, width, height) { }
+
+    /// <summary>Gets or sets the SVG image href.</summary>
+    public string Href { get => _href; set => _href = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets optional source RGBA pixels for PNG output.</summary>
+    public byte[]? Rgba { get; set; }
+    /// <summary>Gets or sets the source bitmap width for PNG output.</summary>
+    public int SourceWidth { get; set; }
+    /// <summary>Gets or sets the source bitmap height for PNG output.</summary>
+    public int SourceHeight { get; set; }
+
+    /// <summary>Gets or sets image opacity from zero to one.</summary>
+    public double Opacity {
+        get => _opacity;
+        set {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value < 0 || value > 1) throw new ArgumentOutOfRangeException(nameof(value), value, "Opacity must be between zero and one.");
+            _opacity = value;
+        }
+    }
+}
+
+/// <summary>Compact feature-strip item.</summary>
+public sealed class VisualCanvasFeatureItem {
+    private string _icon;
+    private string _label;
+
+    /// <summary>Initializes a feature strip item.</summary>
+    /// <param name="icon">The compact item icon or symbol.</param>
+    /// <param name="label">The item label.</param>
+    public VisualCanvasFeatureItem(string icon, string label) {
+        _icon = icon ?? throw new ArgumentNullException(nameof(icon));
+        _label = label ?? throw new ArgumentNullException(nameof(label));
+    }
+
+    /// <summary>Gets or sets the compact item icon or symbol.</summary>
+    public string Icon { get => _icon; set => _icon = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets the item label.</summary>
+    public string Label { get => _label; set => _label = value ?? throw new ArgumentNullException(nameof(value)); }
+}
+
+/// <summary>Feature-strip layer.</summary>
+public sealed class VisualCanvasFeatureStripLayer : VisualCanvasLayer {
+    private readonly List<VisualCanvasFeatureItem> _items = new();
+
+    /// <summary>Initializes a feature strip layer.</summary>
+    /// <param name="x">The strip X coordinate.</param>
+    /// <param name="y">The strip Y coordinate.</param>
+    /// <param name="width">The strip width.</param>
+    /// <param name="height">The strip height.</param>
+    /// <param name="items">The strip items.</param>
+    public VisualCanvasFeatureStripLayer(double x, double y, double width, double height, IEnumerable<VisualCanvasFeatureItem> items) : base(x, y, width, height) {
+        if (items == null) throw new ArgumentNullException(nameof(items));
+        foreach (var item in items) _items.Add(item ?? throw new ArgumentException("Feature strips cannot contain null items.", nameof(items)));
+        if (_items.Count == 0) throw new ArgumentException("Feature strips require at least one item.", nameof(items));
+    }
+
+    /// <summary>Gets the feature strip items.</summary>
+    public IReadOnlyList<VisualCanvasFeatureItem> Items => _items;
+    /// <summary>Gets or sets the feature strip accent color.</summary>
+    public ChartColor Accent { get; set; } = ChartColor.FromHex("#2F80FF");
+}

--- a/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
@@ -68,6 +68,20 @@ public enum VisualCanvasInfoTileIconKind {
 }
 
 /// <summary>
+/// Compact chart treatment for visual canvas information tiles.
+/// </summary>
+public enum VisualCanvasInfoTileMiniChartKind {
+    /// <summary>Render no mini chart.</summary>
+    None,
+    /// <summary>Render a compact sparkline on the right side of the tile.</summary>
+    Sparkline,
+    /// <summary>Render a compact area sparkline on the right side of the tile.</summary>
+    Area,
+    /// <summary>Render compact bars on the right side of the tile.</summary>
+    Bars
+}
+
+/// <summary>
 /// Theme colors for reusable visual canvas layers.
 /// </summary>
 public sealed class VisualCanvasTheme {
@@ -95,6 +109,10 @@ public sealed class VisualCanvasTheme {
     public ChartColor TileDetailColor { get; set; } = ChartColor.FromHex("#A8BAD4");
     /// <summary>Gets or sets the progress rail color.</summary>
     public ChartColor TileProgressTrackColor { get; set; } = ChartColor.FromHex("#18345D").WithOpacity(0.92);
+    /// <summary>Gets or sets the mini-chart plot fill color.</summary>
+    public ChartColor TileMiniChartFillColor { get; set; } = ChartColor.FromHex("#2F80FF").WithOpacity(0.18);
+    /// <summary>Gets or sets the mini-chart track/grid color.</summary>
+    public ChartColor TileMiniChartTrackColor { get; set; } = ChartColor.FromHex("#8AA9D6").WithOpacity(0.18);
     /// <summary>Gets or sets the hero badge glow color.</summary>
     public ChartColor HeroBadgeGlowColor { get; set; } = ChartColor.FromHex("#22A7FF").WithOpacity(0.12);
     /// <summary>Gets or sets the hero badge top fill color.</summary>
@@ -221,8 +239,8 @@ public sealed class VisualCanvas {
         AddLayer(new VisualCanvasHeroTitleLayer(x, y, width, fontSize, runs) { Alignment = alignment });
 
     /// <summary>Adds a reusable information tile.</summary>
-    public VisualCanvas AddInfoTile(double x, double y, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text) =>
-        AddLayer(new VisualCanvasInfoTileLayer(x, y, width, height, icon, label, value) { Detail = detail ?? string.Empty, Accent = accent ?? Theme.Accent, Progress = progress, SurfaceStyle = surfaceStyle, IconKind = iconKind });
+    public VisualCanvas AddInfoTile(double x, double y, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text, VisualCanvasInfoTileMiniChartKind miniChartKind = VisualCanvasInfoTileMiniChartKind.None, IEnumerable<double>? miniChartValues = null, double? miniChartMaximum = null) =>
+        AddLayer(new VisualCanvasInfoTileLayer(x, y, width, height, icon, label, value) { Detail = detail ?? string.Empty, Accent = accent ?? Theme.Accent, Progress = progress, SurfaceStyle = surfaceStyle, IconKind = iconKind }.WithMiniChart(miniChartKind, miniChartValues, miniChartMaximum));
 
     /// <summary>Adds a central icon or logo badge.</summary>
     public VisualCanvas AddHeroBadge(double x, double y, double width, double height, string symbol, ChartColor? accent = null) =>
@@ -372,11 +390,13 @@ public sealed class VisualCanvasHeroTitleLayer : VisualCanvasLayer {
 
 /// <summary>Reusable information tile layer.</summary>
 public sealed class VisualCanvasInfoTileLayer : VisualCanvasLayer {
+    private readonly List<double> _miniChartValues = new();
     private string _icon;
     private string _label;
     private string _value;
     private string _detail = string.Empty;
     private double? _progress;
+    private double? _miniChartMaximum;
 
     /// <summary>Initializes a reusable information tile layer.</summary>
     /// <param name="x">The tile X coordinate.</param>
@@ -406,6 +426,18 @@ public sealed class VisualCanvasInfoTileLayer : VisualCanvasLayer {
     public VisualCanvasInfoTileSurfaceStyle SurfaceStyle { get; set; }
     /// <summary>Gets or sets the tile icon treatment.</summary>
     public VisualCanvasInfoTileIconKind IconKind { get; set; }
+    /// <summary>Gets or sets the compact chart kind rendered inside the tile.</summary>
+    public VisualCanvasInfoTileMiniChartKind MiniChartKind { get; set; }
+    /// <summary>Gets compact chart values rendered inside the tile.</summary>
+    public IReadOnlyList<double> MiniChartValues => _miniChartValues;
+    /// <summary>Gets or sets the optional compact chart maximum. When empty, the values define the scale.</summary>
+    public double? MiniChartMaximum {
+        get => _miniChartMaximum;
+        set {
+            if (value.HasValue && (double.IsNaN(value.Value) || double.IsInfinity(value.Value) || value.Value <= 0)) throw new ArgumentOutOfRangeException(nameof(value), value, "Mini chart maximum must be finite and greater than zero.");
+            _miniChartMaximum = value;
+        }
+    }
 
     /// <summary>Gets or sets optional progress from zero to one.</summary>
     public double? Progress {
@@ -414,6 +446,22 @@ public sealed class VisualCanvasInfoTileLayer : VisualCanvasLayer {
             if (value.HasValue && (double.IsNaN(value.Value) || double.IsInfinity(value.Value) || value.Value < 0 || value.Value > 1)) throw new ArgumentOutOfRangeException(nameof(value), value, "Progress must be between zero and one.");
             _progress = value;
         }
+    }
+
+    /// <summary>Sets the compact chart rendered inside the tile.</summary>
+    public VisualCanvasInfoTileLayer WithMiniChart(VisualCanvasInfoTileMiniChartKind kind, IEnumerable<double>? values, double? maximum = null) {
+        VisualCanvas.ValidateEnum(kind, nameof(kind));
+        _miniChartValues.Clear();
+        if (values != null) {
+            foreach (var value in values) {
+                if (double.IsNaN(value) || double.IsInfinity(value)) throw new ArgumentOutOfRangeException(nameof(values), value, "Mini chart values must be finite.");
+                _miniChartValues.Add(value);
+            }
+        }
+
+        MiniChartKind = _miniChartValues.Count == 0 ? VisualCanvasInfoTileMiniChartKind.None : kind;
+        MiniChartMaximum = maximum;
+        return this;
     }
 }
 

--- a/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
@@ -30,6 +30,108 @@ public enum VisualCanvasTextAlignment {
 }
 
 /// <summary>
+/// Defines the reference point used when placing visual canvas layers.
+/// </summary>
+public enum VisualCanvasAnchor {
+    /// <summary>Place from the top-left edge.</summary>
+    TopLeft,
+    /// <summary>Place from the top-center edge.</summary>
+    TopCenter,
+    /// <summary>Place from the top-right edge.</summary>
+    TopRight,
+    /// <summary>Place from the middle-left edge.</summary>
+    MiddleLeft,
+    /// <summary>Place from the center of the container.</summary>
+    Center,
+    /// <summary>Place from the middle-right edge.</summary>
+    MiddleRight,
+    /// <summary>Place from the bottom-left edge.</summary>
+    BottomLeft,
+    /// <summary>Place from the bottom-center edge.</summary>
+    BottomCenter,
+    /// <summary>Place from the bottom-right edge.</summary>
+    BottomRight
+}
+
+/// <summary>
+/// Describes reusable anchor-based placement inside a canvas or another rectangular region.
+/// </summary>
+public readonly struct VisualCanvasPlacement {
+    /// <summary>Initializes an anchor placement.</summary>
+    public VisualCanvasPlacement(VisualCanvasAnchor anchor, double offsetX = 0, double offsetY = 0) {
+        VisualCanvas.ValidateEnum(anchor, nameof(anchor));
+        ValidateFinite(offsetX, nameof(offsetX));
+        ValidateFinite(offsetY, nameof(offsetY));
+        Anchor = anchor;
+        OffsetX = offsetX;
+        OffsetY = offsetY;
+    }
+
+    /// <summary>Gets the anchor used as the placement reference.</summary>
+    public VisualCanvasAnchor Anchor { get; }
+
+    /// <summary>Gets the horizontal offset. For right anchors, positive values inset from the right edge.</summary>
+    public double OffsetX { get; }
+
+    /// <summary>Gets the vertical offset. For bottom anchors, positive values inset from the bottom edge.</summary>
+    public double OffsetY { get; }
+
+    /// <summary>Creates an anchor placement.</summary>
+    public static VisualCanvasPlacement At(VisualCanvasAnchor anchor, double offsetX = 0, double offsetY = 0) => new(anchor, offsetX, offsetY);
+
+    /// <summary>Resolves this placement inside a zero-origin container.</summary>
+    public ChartRect Resolve(double containerWidth, double containerHeight, double width, double height) => Resolve(new ChartRect(0, 0, containerWidth, containerHeight), width, height);
+
+    /// <summary>Resolves this placement inside another rectangular region.</summary>
+    public ChartRect Resolve(ChartRect container, double width, double height) {
+        ValidatePositive(width, nameof(width));
+        ValidatePositive(height, nameof(height));
+        var x = ResolveX(container, width);
+        var y = ResolveY(container, height);
+        return new ChartRect(x, y, width, height);
+    }
+
+    private double ResolveX(ChartRect container, double width) {
+        switch (Anchor) {
+            case VisualCanvasAnchor.TopRight:
+            case VisualCanvasAnchor.MiddleRight:
+            case VisualCanvasAnchor.BottomRight:
+                return container.Right - width - OffsetX;
+            case VisualCanvasAnchor.TopCenter:
+            case VisualCanvasAnchor.Center:
+            case VisualCanvasAnchor.BottomCenter:
+                return container.X + (container.Width - width) / 2 + OffsetX;
+            default:
+                return container.X + OffsetX;
+        }
+    }
+
+    private double ResolveY(ChartRect container, double height) {
+        switch (Anchor) {
+            case VisualCanvasAnchor.BottomLeft:
+            case VisualCanvasAnchor.BottomCenter:
+            case VisualCanvasAnchor.BottomRight:
+                return container.Bottom - height - OffsetY;
+            case VisualCanvasAnchor.MiddleLeft:
+            case VisualCanvasAnchor.Center:
+            case VisualCanvasAnchor.MiddleRight:
+                return container.Y + (container.Height - height) / 2 + OffsetY;
+            default:
+                return container.Y + OffsetY;
+        }
+    }
+
+    private static void ValidateFinite(double value, string parameterName) {
+        if (double.IsNaN(value) || double.IsInfinity(value)) throw new ArgumentOutOfRangeException(parameterName, value, "Placement values must be finite.");
+    }
+
+    private static void ValidatePositive(double value, string parameterName) {
+        ValidateFinite(value, parameterName);
+        if (value <= 0) throw new ArgumentOutOfRangeException(parameterName, value, "Placement dimensions must be greater than zero.");
+    }
+}
+
+/// <summary>
 /// Defines how source images are placed inside a visual canvas image layer.
 /// </summary>
 public enum VisualCanvasImageFit {
@@ -247,21 +349,48 @@ public sealed class VisualCanvas {
         return this;
     }
 
+    /// <summary>Resolves anchor-based placement against the full canvas.</summary>
+    public ChartRect ResolvePlacement(VisualCanvasPlacement placement, double width, double height) => placement.Resolve(Width, Height, width, height);
+
     /// <summary>Adds a plain text layer.</summary>
     public VisualCanvas AddText(double x, double y, double width, string text, double fontSize, ChartColor color, VisualCanvasTextAlignment alignment = VisualCanvasTextAlignment.Left, bool emphasized = false) =>
         AddLayer(new VisualCanvasTextLayer(x, y, width, text, fontSize, color) { Alignment = alignment, Emphasized = emphasized });
+
+    /// <summary>Adds a plain text layer using anchor-based placement.</summary>
+    public VisualCanvas AddText(VisualCanvasPlacement placement, double width, string text, double fontSize, ChartColor color, VisualCanvasTextAlignment alignment = VisualCanvasTextAlignment.Left, bool emphasized = false) {
+        var bounds = ResolvePlacement(placement, width, Math.Max(1, fontSize * 1.25));
+        return AddText(bounds.X, bounds.Y, bounds.Width, text, fontSize, color, alignment, emphasized);
+    }
 
     /// <summary>Adds a multi-color hero title layer.</summary>
     public VisualCanvas AddHeroTitle(double x, double y, double width, double fontSize, IEnumerable<VisualCanvasTextRun> runs, VisualCanvasTextAlignment alignment = VisualCanvasTextAlignment.Center) =>
         AddLayer(new VisualCanvasHeroTitleLayer(x, y, width, fontSize, runs) { Alignment = alignment });
 
+    /// <summary>Adds a multi-color hero title layer using anchor-based placement.</summary>
+    public VisualCanvas AddHeroTitle(VisualCanvasPlacement placement, double width, double fontSize, IEnumerable<VisualCanvasTextRun> runs, VisualCanvasTextAlignment alignment = VisualCanvasTextAlignment.Center) {
+        var bounds = ResolvePlacement(placement, width, Math.Max(1, fontSize * 1.25));
+        return AddHeroTitle(bounds.X, bounds.Y, bounds.Width, fontSize, runs, alignment);
+    }
+
     /// <summary>Adds a reusable information tile.</summary>
     public VisualCanvas AddInfoTile(double x, double y, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text, VisualCanvasInfoTileMiniChartKind miniChartKind = VisualCanvasInfoTileMiniChartKind.None, IEnumerable<double>? miniChartValues = null, double? miniChartMaximum = null) =>
         AddLayer(new VisualCanvasInfoTileLayer(x, y, width, height, icon, label, value) { Detail = detail ?? string.Empty, AccentOverride = accent, Progress = progress, SurfaceStyle = surfaceStyle, IconKind = iconKind }.WithMiniChart(miniChartKind, miniChartValues, miniChartMaximum));
 
+    /// <summary>Adds a reusable information tile using anchor-based placement.</summary>
+    public VisualCanvas AddInfoTile(VisualCanvasPlacement placement, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text, VisualCanvasInfoTileMiniChartKind miniChartKind = VisualCanvasInfoTileMiniChartKind.None, IEnumerable<double>? miniChartValues = null, double? miniChartMaximum = null) {
+        var bounds = ResolvePlacement(placement, width, height);
+        return AddInfoTile(bounds.X, bounds.Y, bounds.Width, bounds.Height, icon, label, value, detail, accent, progress, surfaceStyle, iconKind, miniChartKind, miniChartValues, miniChartMaximum);
+    }
+
     /// <summary>Adds a central icon or logo badge.</summary>
     public VisualCanvas AddHeroBadge(double x, double y, double width, double height, string symbol, ChartColor? accent = null) =>
         AddLayer(new VisualCanvasHeroBadgeLayer(x, y, width, height, symbol) { AccentOverride = accent });
+
+    /// <summary>Adds a central icon or logo badge using anchor-based placement.</summary>
+    public VisualCanvas AddHeroBadge(VisualCanvasPlacement placement, double width, double height, string symbol, ChartColor? accent = null) {
+        var bounds = ResolvePlacement(placement, width, height);
+        return AddHeroBadge(bounds.X, bounds.Y, bounds.Width, bounds.Height, symbol, accent);
+    }
 
     /// <summary>Adds an image layer. SVG output uses <paramref name="href"/>; PNG output uses <paramref name="rgba"/> when supplied.</summary>
     public VisualCanvas AddImage(double x, double y, double width, double height, string? href = null, byte[]? rgba = null, int sourceWidth = 0, int sourceHeight = 0, double opacity = 1, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch) {
@@ -270,9 +399,21 @@ public sealed class VisualCanvas {
         return AddLayer(new VisualCanvasImageLayer(x, y, width, height) { Href = href ?? string.Empty, Rgba = rgba, SourceWidth = sourceWidth, SourceHeight = sourceHeight, Opacity = opacity, Fit = fit });
     }
 
+    /// <summary>Adds an image layer using anchor-based placement.</summary>
+    public VisualCanvas AddImage(VisualCanvasPlacement placement, double width, double height, string? href = null, byte[]? rgba = null, int sourceWidth = 0, int sourceHeight = 0, double opacity = 1, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch) {
+        var bounds = ResolvePlacement(placement, width, height);
+        return AddImage(bounds.X, bounds.Y, bounds.Width, bounds.Height, href, rgba, sourceWidth, sourceHeight, opacity, fit);
+    }
+
     /// <summary>Adds a compact feature strip.</summary>
     public VisualCanvas AddFeatureStrip(double x, double y, double width, double height, IEnumerable<VisualCanvasFeatureItem> items) =>
         AddLayer(new VisualCanvasFeatureStripLayer(x, y, width, height, items));
+
+    /// <summary>Adds a compact feature strip using anchor-based placement.</summary>
+    public VisualCanvas AddFeatureStrip(VisualCanvasPlacement placement, double width, double height, IEnumerable<VisualCanvasFeatureItem> items) {
+        var bounds = ResolvePlacement(placement, width, height);
+        return AddFeatureStrip(bounds.X, bounds.Y, bounds.Width, bounds.Height, items);
+    }
 
     internal static void ValidateEnum<TEnum>(TEnum value, string parameterName) where TEnum : struct {
         if (!Enum.IsDefined(typeof(TEnum), value)) throw new ArgumentOutOfRangeException(parameterName, value, "Unknown " + typeof(TEnum).Name + " value.");
@@ -317,6 +458,9 @@ public abstract class VisualCanvasLayer {
 
     /// <summary>Gets or sets the layer height.</summary>
     public double Height { get => _height; set { ValidatePositive(value, nameof(value)); _height = value; } }
+
+    /// <summary>Gets the current layer bounds.</summary>
+    public ChartRect Bounds => new(X, Y, Width, Height);
 
     /// <summary>Validates that a numeric value is finite.</summary>
     /// <param name="value">The value to validate.</param>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ChartForgeX renders polished charts, visual blocks, topology diagrams, and stati
 
 ## What It Does
 
-ChartForgeX turns .NET data into deterministic static visuals: charts, chart grids, visual blocks, topology diagrams, and map-backed report graphics. It is meant for generated reports, documentation, email, static websites, dashboards, wallpapers, Office-style generators, and other hosts that need polished output without a JavaScript chart dependency.
+ChartForgeX turns .NET data into deterministic static visuals: charts, chart grids, visual blocks, visual canvases, topology diagrams, and map-backed report graphics. It is meant for generated reports, documentation, email, static websites, dashboards, wallpapers, social preview images, Office-style generators, and other hosts that need polished output without a JavaScript chart dependency.
 
 The core package renders SVG, script-free static HTML, PNG, BMP, PPM, and TIFF without runtime package dependencies. Optional browser behavior lives in adapter packages, so a static report can stay static while a dashboard can opt into tooltips, selection, zoom, pan, brush ranges, synchronized charts, and export controls.
 
@@ -172,6 +172,7 @@ The output API follows one rule: `To*` returns content, `Save*` writes a file, a
 | SVG markup | `chart.ToSvg()` or `chart.SaveSvg("chart.svg")` |
 | Static HTML | `chart.ToHtmlFragment()`, `chart.ToHtmlPage()`, or `chart.SaveHtml("chart.html")` |
 | PNG bytes/file | `chart.ToPng()` or `chart.SavePng("chart.png")` |
+| Layered visual canvas | `VisualCanvas.CreateSocialPreview()`, `VisualCanvas.CreateDesktopWallpaper()`, `canvas.ToSvg()`, or `canvas.SavePng("social-preview.png")` for fixed-size wallpaper, social image, report cover, and hero compositions |
 | Topology animated raster | `topology.ToGif(options)`, `topology.ToApng(options)`, `topology.WriteGif(stream, options)`, `topology.WriteApng(stream, options)`, `topology.SaveGif("route.gif", options)`, or `topology.SaveApng("route.apng", options)` with `TopologyMotionOptions.RoutePulseForScenario(...)` or `.RoutePulseForEdges(...)` |
 | Extension-inferred file output | `chart.Save("chart.svg")`, `chart.Save("chart.html")`, `chart.Save("chart.png")`, `chart.Save("chart.tiff")`; topology also supports `topology.Save("route.gif", options)` and `topology.Save("route.apng", options)` |
 | Advanced opaque raster output | `ToBmp`, `ToPpm`, `ToTiff`, `ToRasterImage`, `WriteRasterImage`, and `SaveRasterImage` |

--- a/docs/visual-canvas.md
+++ b/docs/visual-canvas.md
@@ -11,7 +11,7 @@ The first canvas primitives are intentionally generic:
 - reusable `VisualCanvasTheme` colors for accents, tile text, glass fills, badge fills, feature strips, placeholders, and backdrop highlights
 - absolute text layers
 - multi-color hero title layers
-- information tiles for side rails, with glass or outline surfaces and text or built-in icons
+- information tiles for side rails, with glass or outline surfaces, text or built-in icons, progress rails, and compact right-side mini charts
 - hero badges for logos, terminal prompts, or product marks
 - image layers using SVG hrefs and host-provided RGBA pixels for PNG output
 - feature strips for compact bottom rows
@@ -34,7 +34,7 @@ var canvas = VisualCanvas.CreateSocialPreview()
     .WithBackground(ChartColor.FromHex("#020713"), ChartColor.FromHex("#071A35"))
     .WithBackdrop(VisualCanvasBackdropStyle.TechHorizon)
     .AddInfoTile(58, 92, 250, 82, "PC", "HOSTNAME", "DEV-Workstation", accent: ChartColor.FromHex("#2F80FF"), iconKind: VisualCanvasInfoTileIconKind.Computer)
-    .AddInfoTile(892, 70, 250, 96, "CPU", "CPU", "Intel Core i7-12700K", "23%", ChartColor.FromHex("#60A5FA"), 0.23, VisualCanvasInfoTileSurfaceStyle.Outline, VisualCanvasInfoTileIconKind.Cpu)
+    .AddInfoTile(892, 70, 250, 96, "CPU", "CPU", "Intel Core i7-12700K", "23%", ChartColor.FromHex("#60A5FA"), 0.23, VisualCanvasInfoTileSurfaceStyle.Outline, VisualCanvasInfoTileIconKind.Cpu, VisualCanvasInfoTileMiniChartKind.Area, new[] { 18d, 26d, 22d, 37d, 48d, 43d }, 100)
     .AddHeroBadge(538, 157, 124, 88, ">_", ChartColor.FromHex("#22A7FF"))
     .AddHeroTitle(312, 296, 576, 82, new[] {
         new VisualCanvasTextRun("Power", ChartColor.FromHex("#F8FAFC")),

--- a/docs/visual-canvas.md
+++ b/docs/visual-canvas.md
@@ -1,0 +1,49 @@
+# Visual Canvas
+
+`VisualCanvas` is a fixed-size layered composition surface for visuals that are not grids: desktop wallpapers, social preview images, report covers, kiosk screens, and product hero graphics.
+
+Use it when the output needs explicit placement, layered backgrounds, side rails, central hero typography, badges, or host-provided image slots. `VisualGrid` remains the right surface for rows and columns of charts or visual blocks.
+
+The first canvas primitives are intentionally generic:
+
+- vertical background color treatment
+- optional technology horizon backdrop
+- reusable `VisualCanvasTheme` colors for accents, tile text, glass fills, badge fills, feature strips, placeholders, and backdrop highlights
+- absolute text layers
+- multi-color hero title layers
+- information tiles for side rails, with glass or outline surfaces and text or built-in icons
+- hero badges for logos, terminal prompts, or product marks
+- image layers using SVG hrefs and host-provided RGBA pixels for PNG output
+- feature strips for compact bottom rows
+- SVG and PNG export
+
+Example:
+
+```csharp
+using ChartForgeX;
+using ChartForgeX.Composition;
+using ChartForgeX.Primitives;
+
+var canvas = VisualCanvas.CreateSocialPreview()
+    .WithTitle("PowerBGInfo social preview")
+    .WithTheme(new VisualCanvasTheme {
+        Accent = ChartColor.FromHex("#2F80FF"),
+        HeroTitleAccentColor = ChartColor.FromHex("#2F80FF"),
+        TileValueColor = ChartColor.FromHex("#F8FAFC")
+    })
+    .WithBackground(ChartColor.FromHex("#020713"), ChartColor.FromHex("#071A35"))
+    .WithBackdrop(VisualCanvasBackdropStyle.TechHorizon)
+    .AddInfoTile(58, 92, 250, 82, "PC", "HOSTNAME", "DEV-Workstation", accent: ChartColor.FromHex("#2F80FF"), iconKind: VisualCanvasInfoTileIconKind.Computer)
+    .AddInfoTile(892, 70, 250, 96, "CPU", "CPU", "Intel Core i7-12700K", "23%", ChartColor.FromHex("#60A5FA"), 0.23, VisualCanvasInfoTileSurfaceStyle.Outline, VisualCanvasInfoTileIconKind.Cpu)
+    .AddHeroBadge(538, 157, 124, 88, ">_", ChartColor.FromHex("#22A7FF"))
+    .AddHeroTitle(312, 296, 576, 82, new[] {
+        new VisualCanvasTextRun("Power", ChartColor.FromHex("#F8FAFC")),
+        new VisualCanvasTextRun("BGInfo", ChartColor.FromHex("#2F80FF"))
+    })
+    .AddText(330, 402, 540, "Desktop background insights for Windows and PowerShell", 24, ChartColor.FromHex("#C6D3EA"), VisualCanvasTextAlignment.Center);
+
+canvas.SaveSvg("powerbginfo-social-preview.svg");
+canvas.SavePng("powerbginfo-social-preview.png");
+```
+
+PowerBGInfo-style desktop generation should stay thin: resolve Windows facts in PowerBGInfo, then pass those strings into `VisualCanvas` templates or layers. Keep reusable layout, typography, image, and tile behavior in ChartForgeX so other hosts can reuse the same engine for OpenGraph images, generated documentation, and report covers.

--- a/docs/visual-canvas.md
+++ b/docs/visual-canvas.md
@@ -15,6 +15,7 @@ The first canvas primitives are intentionally generic:
 - hero badges for logos, terminal prompts, or product marks
 - image layers using SVG hrefs and host-provided RGBA pixels for raster output, with `Stretch`, `Contain`, `Cover`, and `Center` fit modes
 - rendered ChartForgeX layers for charts, chart grids, visual blocks, visual grids, and topology diagrams
+- anchor-based placement for all built-in canvas layers and rendered ChartForgeX layers
 - feature strips for compact bottom rows
 - SVG, HTML, PNG, BMP, PPM, and TIFF export
 
@@ -64,12 +65,21 @@ var canvas = VisualCanvas.CreateSocialPreview()
         new VisualCanvasTextRun("BGInfo", ChartColor.FromHex("#2F80FF"))
     })
     .AddText(330, 402, 540, "Desktop background insights for Windows and PowerShell", 24, ChartColor.FromHex("#C6D3EA"), VisualCanvasTextAlignment.Center)
-    .AddChart(66, 460, 220, 120, cpuChart, VisualCanvasImageFit.Contain)
-    .AddVisualBlock(914, 452, 180, 104, ramCard, VisualCanvasImageFit.Center);
+    .AddChart(VisualCanvasPlacement.At(VisualCanvasAnchor.BottomLeft, 66, 50), 220, 120, cpuChart, VisualCanvasImageFit.Contain)
+    .AddVisualBlock(VisualCanvasPlacement.At(VisualCanvasAnchor.BottomRight, 106, 74), 180, 104, ramCard, VisualCanvasImageFit.Center);
 
 canvas.SaveSvg("powerbginfo-social-preview.svg");
 canvas.SavePng("powerbginfo-social-preview.png");
 canvas.SaveBmp("powerbginfo-social-preview.bmp");
+```
+
+`VisualCanvasPlacement` resolves layer coordinates from a named anchor. For `TopLeft`, offsets move right and down from the top-left edge. For `BottomRight`, positive offsets are insets from the right and bottom edges, so `VisualCanvasPlacement.At(VisualCanvasAnchor.BottomRight, 20, 20)` places a layer 20 pixels from the bottom-right corner. Center anchors use offsets as signed nudges from the centered position.
+
+The same placement object can resolve against another region:
+
+```csharp
+var tile = new VisualCanvasInfoTileLayer(20, 20, 240, 90, "PC", "HOST", "WK01");
+var badgeBounds = VisualCanvasPlacement.At(VisualCanvasAnchor.TopRight, 8, 8).Resolve(tile.Bounds, 42, 24);
 ```
 
 PowerBGInfo-style desktop generation should stay thin: resolve Windows facts in PowerBGInfo, then pass those strings into `VisualCanvas` templates or layers. Keep reusable layout, typography, image, and tile behavior in ChartForgeX so other hosts can reuse the same engine for OpenGraph images, generated documentation, and report covers.

--- a/docs/visual-canvas.md
+++ b/docs/visual-canvas.md
@@ -13,16 +13,39 @@ The first canvas primitives are intentionally generic:
 - multi-color hero title layers
 - information tiles for side rails, with glass, outline, or raised surfaces, text or built-in icons, progress rails, and compact right-side mini charts
 - hero badges for logos, terminal prompts, or product marks
-- image layers using SVG hrefs and host-provided RGBA pixels for PNG output
+- image layers using SVG hrefs and host-provided RGBA pixels for raster output, with `Stretch`, `Contain`, `Cover`, and `Center` fit modes
+- rendered ChartForgeX layers for charts, chart grids, visual blocks, visual grids, and topology diagrams
 - feature strips for compact bottom rows
-- SVG and PNG export
+- SVG, HTML, PNG, BMP, PPM, and TIFF export
 
 Example:
 
 ```csharp
 using ChartForgeX;
 using ChartForgeX.Composition;
+using ChartForgeX.Core;
 using ChartForgeX.Primitives;
+using ChartForgeX.VisualBlocks;
+
+var cpuChart = Chart.Create()
+    .WithSize(220, 120)
+    .WithTransparentBackground()
+    .WithHeader(false)
+    .WithCard(false)
+    .AddLine("CPU", new[] {
+        new ChartPoint(1, 18),
+        new ChartPoint(2, 31),
+        new ChartPoint(3, 24),
+        new ChartPoint(4, 45),
+        new ChartPoint(5, 39)
+    });
+
+var ramCard = MetricCard.Create()
+    .WithSize(180, 104)
+    .WithTransparentBackground()
+    .WithCard(false)
+    .WithMetric("RAM", "41%")
+    .WithMiniSparkline(new[] { 32d, 36d, 41d, 38d, 43d });
 
 var canvas = VisualCanvas.CreateSocialPreview()
     .WithTitle("PowerBGInfo social preview")
@@ -40,10 +63,13 @@ var canvas = VisualCanvas.CreateSocialPreview()
         new VisualCanvasTextRun("Power", ChartColor.FromHex("#F8FAFC")),
         new VisualCanvasTextRun("BGInfo", ChartColor.FromHex("#2F80FF"))
     })
-    .AddText(330, 402, 540, "Desktop background insights for Windows and PowerShell", 24, ChartColor.FromHex("#C6D3EA"), VisualCanvasTextAlignment.Center);
+    .AddText(330, 402, 540, "Desktop background insights for Windows and PowerShell", 24, ChartColor.FromHex("#C6D3EA"), VisualCanvasTextAlignment.Center)
+    .AddChart(66, 460, 220, 120, cpuChart, VisualCanvasImageFit.Contain)
+    .AddVisualBlock(914, 452, 180, 104, ramCard, VisualCanvasImageFit.Center);
 
 canvas.SaveSvg("powerbginfo-social-preview.svg");
 canvas.SavePng("powerbginfo-social-preview.png");
+canvas.SaveBmp("powerbginfo-social-preview.bmp");
 ```
 
 PowerBGInfo-style desktop generation should stay thin: resolve Windows facts in PowerBGInfo, then pass those strings into `VisualCanvas` templates or layers. Keep reusable layout, typography, image, and tile behavior in ChartForgeX so other hosts can reuse the same engine for OpenGraph images, generated documentation, and report covers.

--- a/docs/visual-canvas.md
+++ b/docs/visual-canvas.md
@@ -11,7 +11,7 @@ The first canvas primitives are intentionally generic:
 - reusable `VisualCanvasTheme` colors for accents, tile text, glass fills, badge fills, feature strips, placeholders, and backdrop highlights
 - absolute text layers
 - multi-color hero title layers
-- information tiles for side rails, with glass or outline surfaces, text or built-in icons, progress rails, and compact right-side mini charts
+- information tiles for side rails, with glass, outline, or raised surfaces, text or built-in icons, progress rails, and compact right-side mini charts
 - hero badges for logos, terminal prompts, or product marks
 - image layers using SVG hrefs and host-provided RGBA pixels for PNG output
 - feature strips for compact bottom rows
@@ -34,7 +34,7 @@ var canvas = VisualCanvas.CreateSocialPreview()
     .WithBackground(ChartColor.FromHex("#020713"), ChartColor.FromHex("#071A35"))
     .WithBackdrop(VisualCanvasBackdropStyle.TechHorizon)
     .AddInfoTile(58, 92, 250, 82, "PC", "HOSTNAME", "DEV-Workstation", accent: ChartColor.FromHex("#2F80FF"), iconKind: VisualCanvasInfoTileIconKind.Computer)
-    .AddInfoTile(892, 70, 250, 96, "CPU", "CPU", "Intel Core i7-12700K", "23%", ChartColor.FromHex("#60A5FA"), 0.23, VisualCanvasInfoTileSurfaceStyle.Outline, VisualCanvasInfoTileIconKind.Cpu, VisualCanvasInfoTileMiniChartKind.Area, new[] { 18d, 26d, 22d, 37d, 48d, 43d }, 100)
+    .AddInfoTile(892, 70, 250, 96, "CPU", "CPU", "Intel Core i7-12700K", "23%", ChartColor.FromHex("#60A5FA"), 0.23, VisualCanvasInfoTileSurfaceStyle.Raised, VisualCanvasInfoTileIconKind.Cpu, VisualCanvasInfoTileMiniChartKind.Area, new[] { 18d, 26d, 22d, 37d, 48d, 43d }, 100)
     .AddHeroBadge(538, 157, 124, 88, ">_", ChartColor.FromHex("#22A7FF"))
     .AddHeroTitle(312, 296, 576, 82, new[] {
         new VisualCanvasTextRun("Power", ChartColor.FromHex("#F8FAFC")),


### PR DESCRIPTION
## Summary

Adds a reusable `ChartForgeX.Composition.VisualCanvas` surface for layered artboards and wallpaper/social-style visuals. The surface now supports transparent overlays, themed rendering, side-rail information tiles, hero badges, multi-run title text, image slots, feature strips, embedded ChartForgeX renderables, anchor-based placement, and SVG/HTML/PNG plus opaque raster exports.

## Details

- Adds `VisualCanvas`, layer models, `VisualCanvasTheme`, tile surface styles, built-in tile icon kinds, mini charts, and reusable image fit behavior.
- Adds SVG and PNG renderers for visual canvases, plus HTML, BMP, PPM, and TIFF export helpers through the existing in-repo raster stack.
- Adds composition helpers for embedding charts, chart grids, visual blocks, visual grids, and topology diagrams as canvas layers.
- Adds `VisualCanvasAnchor` / `VisualCanvasPlacement` so layers can be placed from canvas corners/edges/center, with the same model reusable against another layer's bounds.
- Adds PowerBGInfo-style example/docs coverage while keeping PowerBGInfo itself untouched.
- Adds smoke coverage for visual canvas rendering, embedded renderables, transparent overlays, validation, extension-inferred saves, raster output, and anchor placement.

## Validation

- `dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Debug --no-restore -f net8.0`

Result: `451/451` tests passed.

Note: a full `dotnet build ChartForgeX.sln -c Debug --no-restore` currently requires refreshed restore assets for non-net8 targets (`net472`, `netstandard2.0`, `net10.0`) before it can complete with `--no-restore`; the changed net8 path compiled and tested cleanly.