### PR TITLE
Add cross-platform visual canvas raster inputs

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/RealImageInputTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/RealImageInputTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using ChartForgeX.Composition;
+using ChartForgeX.Primitives;
+using ChartForgeX.Raster;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void RealImageInputsComposeAsVisualCanvasBackgrounds() {
+        var sources = RealImageSources().Take(4).ToArray();
+        if (sources.Length == 0) return;
+
+        foreach (var source in sources) {
+            var bytes = ReadRealImageBytes(source);
+            var image = RasterImageDecoder.Decode(bytes);
+            var width = Math.Min(360, image.Width);
+            var height = Math.Max(1, (int)Math.Round(width * image.Height / (double)image.Width));
+            var canvas = VisualCanvas.Create(width, height)
+                .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+                .AddRasterImage(0, 0, width, height, image, VisualCanvasImageFit.Cover)
+                .AddKeyValueBlock(
+                    VisualCanvasPlacement.At(VisualCanvasAnchor.BottomLeft, 10, 10),
+                    Math.Min(260, width - 20),
+                    new[] {
+                        VisualCanvasKeyValueItem.LabelRow("Real image input"),
+                        VisualCanvasKeyValueItem.Pair("Source", Path.GetFileName(source)),
+                        VisualCanvasKeyValueItem.Pair("Pixels", image.Width + "x" + image.Height)
+                    },
+                    labelFontSize: 10,
+                    valueFontSize: 10,
+                    columnGap: 12,
+                    rowGap: 3,
+                    labelColor: ChartColor.White,
+                    valueColor: ChartColor.White);
+
+            Assert(canvas.ToPng().Length > 64, "Real image inputs should decode and compose as visual canvas backgrounds: " + source);
+        }
+    }
+
+    private static IEnumerable<string> RealImageSources() {
+        var configured = Environment.GetEnvironmentVariable("CHARTFORGEX_REAL_IMAGE_SOURCES");
+        if (!string.IsNullOrWhiteSpace(configured)) {
+            foreach (var source in configured.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(item => item.Trim())) {
+                if (source.Length > 0) yield return source;
+            }
+        }
+
+        var systemCandidates = new[] {
+            @"C:\Windows\Web\touchkeyboard\TouchKeyboardThemeDark000.jpg",
+            @"C:\Windows\Web\touchkeyboard\TouchKeyboardThemeLight000.jpg",
+            @"C:\Windows\Web\4K\Wallpaper\Windows\img0_1920x1200.jpg",
+            @"C:\Windows\Web\Wallpaper\Spotlight\img14.jpg"
+        };
+
+        foreach (var source in systemCandidates) {
+            if (File.Exists(source)) yield return source;
+        }
+    }
+
+    private static byte[] ReadRealImageBytes(string source) {
+        if (Uri.TryCreate(source, UriKind.Absolute, out var uri) && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)) {
+            using var client = new HttpClient();
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("ChartForgeX smoke tests");
+            return client.GetByteArrayAsync(uri).GetAwaiter().GetResult();
+        }
+
+        return File.ReadAllBytes(source);
+    }
+}

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -160,6 +160,7 @@ internal static partial class SmokeTests {
         ("Visual block review regressions stay covered", VisualBlockReviewRegressionsStayCovered),
         ("Visual grid composes charts and visual blocks", VisualGridComposesChartsAndVisualBlocks),
         ("Visual canvas composes wallpaper style artboards", VisualCanvasComposesWallpaperStyleArtboards),
+        ("Real image inputs compose as visual canvas backgrounds", RealImageInputsComposeAsVisualCanvasBackgrounds),
         ("Visual blocks reject invalid inputs close to caller", VisualBlocksRejectInvalidInputsCloseToCaller),
         ("Explicit axis bounds affect SVG ticks", ExplicitAxisBoundsAffectSvgTicks),
         ("Example gallery is static and links generated artifacts", ExampleGalleryIsStaticAndLinksGeneratedArtifacts),

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -111,6 +111,10 @@ internal static partial class SmokeTests {
         Assert(decodedIndexedBmp.Width == 2 && decodedIndexedBmp.Height == 1 && decodedIndexedBmp.Pixels[0] == 255 && decodedIndexedBmp.Pixels[4 + 2] == 255, "RasterImageDecoder should decode indexed BMP palettes.");
         Assert(RasterImageDecoder.Decode(sourceImage.ToPpm()).Height == 12, "RasterImageDecoder should decode dependency-free PPM images.");
         Assert(RasterImageDecoder.Decode(sourceImage.ToTiff()).Width == 18, "RasterImageDecoder should decode dependency-free uncompressed TIFF images.");
+        var whiteIsZeroTiff = RasterImageDecoder.Decode(GrayscaleTiff(0, new byte[] { 0, 255 }));
+        Assert(whiteIsZeroTiff.Pixels[0] == 255 && whiteIsZeroTiff.Pixels[4] == 0, "RasterImageDecoder should decode WhiteIsZero grayscale TIFF images.");
+        Assert(!RasterImageDecoder.TryDecode(PlanarRgbTiff(), out _), "RasterImageDecoder should reject unsupported planar TIFF images without misreading channel planes.");
+        Assert(!RasterImageDecoder.TryDecode(OversizedTiff(), out _), "RasterImageDecoder TryDecode should return false for malformed raster dimensions that overflow.");
         var imageFilePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "chartforgex-raster-input-" + Guid.NewGuid().ToString("N") + ".png");
         try {
             System.IO.File.WriteAllBytes(imageFilePath, sourcePng);
@@ -315,10 +319,55 @@ internal static partial class SmokeTests {
         return bytes;
     }
 
+    private static byte[] GrayscaleTiff(ushort photometric, byte[] pixels) => SimpleTiff(2, 1, photometric, 1, 1, pixels);
+
+    private static byte[] PlanarRgbTiff() => SimpleTiff(1, 1, 2, 3, 2, new byte[] { 255, 0, 0 });
+
+    private static byte[] OversizedTiff() => SimpleTiff(0x80000000, 1, 1, 1, 1, Array.Empty<byte>());
+
+    private static byte[] SimpleTiff(uint width, uint height, ushort photometric, ushort samplesPerPixel, ushort planarConfiguration, byte[] pixels) {
+        const int entryCount = 10;
+        const int ifdOffset = 8;
+        const int ifdBytes = 2 + entryCount * 12 + 4;
+        const int pixelOffset = ifdOffset + ifdBytes;
+        var bytes = new byte[pixelOffset + pixels.Length];
+        bytes[0] = (byte)'I';
+        bytes[1] = (byte)'I';
+        WriteLittleEndianShort(bytes, 2, 42);
+        WriteLittleEndian(bytes, 4, ifdOffset);
+        WriteLittleEndianShort(bytes, ifdOffset, entryCount);
+        var entry = ifdOffset + 2;
+        WriteTiffEntry(bytes, ref entry, 256, 4, 1, width);
+        WriteTiffEntry(bytes, ref entry, 257, 4, 1, height);
+        WriteTiffEntry(bytes, ref entry, 258, 3, 1, 8);
+        WriteTiffEntry(bytes, ref entry, 259, 3, 1, 1);
+        WriteTiffEntry(bytes, ref entry, 262, 3, 1, photometric);
+        WriteTiffEntry(bytes, ref entry, 273, 4, 1, pixelOffset);
+        WriteTiffEntry(bytes, ref entry, 277, 3, 1, samplesPerPixel);
+        WriteTiffEntry(bytes, ref entry, 278, 4, 1, height);
+        WriteTiffEntry(bytes, ref entry, 279, 4, 1, (uint)pixels.Length);
+        WriteTiffEntry(bytes, ref entry, 284, 3, 1, planarConfiguration);
+        Buffer.BlockCopy(pixels, 0, bytes, pixelOffset, pixels.Length);
+        return bytes;
+    }
+
+    private static void WriteTiffEntry(byte[] data, ref int offset, ushort tag, ushort type, uint count, uint value) {
+        WriteLittleEndianShort(data, offset, tag);
+        WriteLittleEndianShort(data, offset + 2, type);
+        WriteLittleEndian(data, offset + 4, unchecked((int)count));
+        WriteLittleEndian(data, offset + 8, unchecked((int)value));
+        offset += 12;
+    }
+
     private static void WriteLittleEndian(byte[] data, int offset, int value) {
         data[offset] = (byte)(value & 255);
         data[offset + 1] = (byte)((value >> 8) & 255);
         data[offset + 2] = (byte)((value >> 16) & 255);
         data[offset + 3] = (byte)((value >> 24) & 255);
+    }
+
+    private static void WriteLittleEndianShort(byte[] data, int offset, int value) {
+        data[offset] = (byte)(value & 255);
+        data[offset + 1] = (byte)((value >> 8) & 255);
     }
 }

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -2,6 +2,7 @@ using System;
 using ChartForgeX.Composition;
 using ChartForgeX.Core;
 using ChartForgeX.Primitives;
+using ChartForgeX.Raster;
 using ChartForgeX.Topology;
 using ChartForgeX.VisualBlocks;
 
@@ -80,6 +81,55 @@ internal static partial class SmokeTests {
         Assert(nativeCanvas.ToPng().Length > 64, "VisualCanvas should render embedded ChartForgeX renderables to PNG output.");
         Assert(nativeCanvas.ToBmp().Length > 64, "VisualCanvas should render embedded ChartForgeX renderables to BMP output.");
 
+        var sourceImage = VisualCanvas.Create(18, 12)
+            .WithBackground(ChartColor.FromHex("#123456"), ChartColor.FromHex("#ABCDEF"))
+            .AddText(2, 2, 14, "PX", 8, ChartColor.White, emphasized: true);
+        var sourcePng = sourceImage.ToPng();
+        var decodedPng = RasterImageDecoder.Decode(sourcePng);
+        Assert(decodedPng.Width == 18 && decodedPng.Height == 12 && decodedPng.Pixels.Length == 18 * 12 * 4, "RasterImageDecoder should decode dependency-free PNG images to RGBA pixels.");
+        var decodedTransparentPng = RasterImageDecoder.Decode(PngWithTransparentColor());
+        Assert(decodedTransparentPng.Pixels[3] == 0, "RasterImageDecoder should apply PNG truecolor transparency metadata.");
+        var corruptPng = PngWithTransparentColor();
+        corruptPng[corruptPng.Length - 5] ^= 0x7F;
+        Assert(!RasterImageDecoder.TryDecode(corruptPng, out _), "RasterImageDecoder should reject PNG inputs with invalid chunk CRC data.");
+        using (var sourceStream = new System.IO.MemoryStream(sourcePng)) {
+            Assert(RasterImageDecoder.Read(sourceStream).Width == 18, "RasterImageDecoder should decode image streams.");
+        }
+
+        var sampleJpeg = Convert.FromBase64String("/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAAIAAgDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDlPgv+yH/qP9C9P4aKKKrCYmr7JanVwHxrnX9i0/3v9fef/9k=");
+        Assert(RasterImageDecoder.TryDecode(sampleJpeg, out var tryDecodedJpeg) && tryDecodedJpeg.Width == 8, "RasterImageDecoder should expose a non-throwing byte decode helper.");
+        Assert(!RasterImageDecoder.TryDecode(new byte[] { 1, 2, 3, 4 }, out _), "RasterImageDecoder TryDecode should return false for unsupported data.");
+        var decodedJpeg = RasterImageDecoder.Decode(sampleJpeg);
+        Assert(decodedJpeg.Width == 8 && decodedJpeg.Height == 8 && decodedJpeg.Pixels.Length == 8 * 8 * 4, "RasterImageDecoder should decode baseline JPEG images to RGBA pixels.");
+        var nonSquareJpeg = Convert.FromBase64String("/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAAGAAoDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDlfhX+yTon7nmHt/Cf8K+hIP2SdE8mPmH7o/hPp9KKK+nyLEVfq/xHPwDxJm/9nL/aJdD/2Q==");
+        var decodedNonSquareJpeg = RasterImageDecoder.Decode(nonSquareJpeg);
+        Assert(decodedNonSquareJpeg.Width == 10 && decodedNonSquareJpeg.Height == 6, "RasterImageDecoder should preserve JPEG dimensions before orientation metadata is applied.");
+        var orientedJpeg = RasterImageDecoder.Decode(WithExifOrientation(nonSquareJpeg, 6));
+        Assert(orientedJpeg.Width == 6 && orientedJpeg.Height == 10, "RasterImageDecoder should apply EXIF orientation for JPEG input.");
+        Assert(RasterImageDecoder.Decode(sourceImage.ToBmp()).Width == 18, "RasterImageDecoder should decode dependency-free BMP images.");
+        var decodedIndexedBmp = RasterImageDecoder.Decode(IndexedBmp());
+        Assert(decodedIndexedBmp.Width == 2 && decodedIndexedBmp.Height == 1 && decodedIndexedBmp.Pixels[0] == 255 && decodedIndexedBmp.Pixels[4 + 2] == 255, "RasterImageDecoder should decode indexed BMP palettes.");
+        Assert(RasterImageDecoder.Decode(sourceImage.ToPpm()).Height == 12, "RasterImageDecoder should decode dependency-free PPM images.");
+        Assert(RasterImageDecoder.Decode(sourceImage.ToTiff()).Width == 18, "RasterImageDecoder should decode dependency-free uncompressed TIFF images.");
+        var imageFilePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "chartforgex-raster-input-" + Guid.NewGuid().ToString("N") + ".png");
+        try {
+            System.IO.File.WriteAllBytes(imageFilePath, sourcePng);
+            Assert(RasterImageDecoder.TryRead(imageFilePath, out var tryReadPng) && tryReadPng.Height == 12, "RasterImageDecoder should expose a non-throwing file read helper.");
+            var imageLayerCanvas = VisualCanvas.Create(48, 32)
+                .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+                .AddImageFile(0, 0, 48, 32, imageFilePath, VisualCanvasImageFit.Cover)
+                .AddImageBytes(VisualCanvasPlacement.At(VisualCanvasAnchor.BottomRight, 4, 4), 12, 8, sourcePng, VisualCanvasImageFit.Contain)
+                .AddImageBytes(VisualCanvasPlacement.At(VisualCanvasAnchor.TopRight, 4, 4), 12, 8, sampleJpeg, VisualCanvasImageFit.Contain)
+                .AddText(4, 4, 40, "overlay", 9, ChartColor.White);
+            var imageLayerSvg = imageLayerCanvas.ToSvg("visual-canvas-raster-input");
+            Assert(imageLayerSvg.Contains("data:image/png;base64", StringComparison.Ordinal), "VisualCanvas image file layers should embed decoded source bytes for SVG output.");
+            Assert(imageLayerSvg.Contains("data:image/jpeg;base64", StringComparison.Ordinal), "VisualCanvas image byte layers should preserve JPEG source bytes for SVG output.");
+            Assert(imageLayerCanvas.ToPng().Length > 64, "VisualCanvas image file layers should render to PNG output.");
+            Assert(decodedPng.ToVisualCanvas().ToPng().Length > 64, "Decoded RGBA images should be reusable as visual canvases.");
+        } finally {
+            if (System.IO.File.Exists(imageFilePath)) System.IO.File.Delete(imageFilePath);
+        }
+
         var anchoredCanvas = VisualCanvas.Create(400, 300)
             .AddInfoTile(VisualCanvasPlacement.At(VisualCanvasAnchor.TopLeft, 20, 20), 120, 60, "PC", "HOST", "WK01")
             .AddInfoTile(VisualCanvasPlacement.At(VisualCanvasAnchor.BottomRight, 20, 20), 120, 60, "IP", "IP", "10.0.0.42")
@@ -97,6 +147,33 @@ internal static partial class SmokeTests {
         Assert(IsClose(relativeBounds.X, 80) && IsClose(relativeBounds.Y, 37), "VisualCanvas placements should resolve relative to another layer's bounds.");
         AssertThrows<ArgumentOutOfRangeException>(() => VisualCanvasPlacement.At((VisualCanvasAnchor)999, 0, 0), "VisualCanvas placement should reject unknown anchors.");
 
+        var keyValueCanvas = VisualCanvas.Create(420, 260)
+            .WithTitle("Key/value block")
+            .WithBackground(ChartColor.FromHex("#07111F"), ChartColor.FromHex("#102A43"))
+            .AddKeyValueBlock(
+                VisualCanvasPlacement.At(VisualCanvasAnchor.BottomRight, 24, 24),
+                300,
+                new[] {
+                    VisualCanvasKeyValueItem.LabelRow("System"),
+                    VisualCanvasKeyValueItem.Pair("Host", "DEV-WKS-01"),
+                    VisualCanvasKeyValueItem.Pair("IPv4", "10.0.0.42 192.168.1.42"),
+                    VisualCanvasKeyValueItem.Pair("Notes", "This value should wrap into multiple deterministic lines for cross-platform BGInfo-style text.")
+                },
+                labelFontSize: 15,
+                valueFontSize: 14,
+                columnGap: 18,
+                rowGap: 5,
+                valueWrapWidth: 160,
+                labelColor: ChartColor.FromHex("#FDE68A"),
+                valueColor: ChartColor.FromHex("#E0F2FE"));
+        var keyValue = (VisualCanvasKeyValueBlockLayer)keyValueCanvas.Layers[0];
+        Assert(keyValue.Height > 70, "VisualCanvas key/value blocks should measure wrapped row height.");
+        Assert(IsClose(keyValue.X, 96) && keyValue.Y > 24, "VisualCanvas key/value blocks should support bottom-right anchor placement.");
+        var keyValueSvg = keyValueCanvas.ToSvg("visual-canvas-key-value");
+        Assert(keyValueSvg.Contains("data-cfx-role=\"visual-canvas-key-value-block\"", StringComparison.Ordinal), "VisualCanvas should render key/value block layers in SVG.");
+        Assert(keyValueSvg.Contains("DEV-WKS-01", StringComparison.Ordinal) && keyValueSvg.Contains("cross-platform", StringComparison.Ordinal), "VisualCanvas key/value blocks should preserve wrapped value text.");
+        Assert(keyValueCanvas.ToPng().Length > 64, "VisualCanvas key/value blocks should render PNG output.");
+
         var overlay = VisualCanvas.CreateDesktopWallpaper()
             .WithTitle("Transparent overlay")
             .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
@@ -109,6 +186,8 @@ internal static partial class SmokeTests {
         AssertThrows<ArgumentOutOfRangeException>(() => canvas.PngOutputScale = 5, "VisualCanvas should reject unsupported PNG output scales.");
         AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").Progress = 1.2, "VisualCanvas info tile progress should stay normalized.");
         AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").WithMiniChart(VisualCanvasInfoTileMiniChartKind.Sparkline, new[] { double.NaN }), "VisualCanvas info tile mini charts should reject invalid values.");
+        AssertThrows<ArgumentException>(() => new VisualCanvasKeyValueBlockLayer(0, 0, 100, 1, Array.Empty<VisualCanvasKeyValueItem>()), "VisualCanvas key/value blocks should require rows.");
+        AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasKeyValueBlockLayer(0, 0, 100, 1, new[] { VisualCanvasKeyValueItem.Pair("A", "B") }) { LabelFontSize = 0 }, "VisualCanvas key/value blocks should reject invalid font sizes.");
         AssertThrows<ArgumentOutOfRangeException>(() => VisualCanvas.Create(24, 24).AddImage(0, 0, 12, 12, rgba: new byte[] { 0, 0, 0, 255 }, sourceWidth: 1, sourceHeight: 1, fit: (VisualCanvasImageFit)999), "VisualCanvas image fit should reject unknown values.");
         var htmlPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "chartforgex-visual-canvas-" + Guid.NewGuid().ToString("N") + ".html");
         var ppmPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "chartforgex-visual-canvas-" + Guid.NewGuid().ToString("N") + ".ppm");
@@ -126,4 +205,120 @@ internal static partial class SmokeTests {
     }
 
     private static bool IsClose(double actual, double expected) => Math.Abs(actual - expected) < 0.001;
+
+    private static byte[] WithExifOrientation(byte[] jpeg, ushort orientation) {
+        var segment = new byte[] {
+            0xFF, 0xE1, 0x00, 0x22,
+            (byte)'E', (byte)'x', (byte)'i', (byte)'f', 0x00, 0x00,
+            (byte)'M', (byte)'M', 0x00, 0x2A, 0x00, 0x00, 0x00, 0x08,
+            0x00, 0x01,
+            0x01, 0x12, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00
+        };
+        segment[28] = (byte)(orientation >> 8);
+        segment[29] = (byte)(orientation & 255);
+        var output = new byte[jpeg.Length + segment.Length];
+        Buffer.BlockCopy(jpeg, 0, output, 0, 2);
+        Buffer.BlockCopy(segment, 0, output, 2, segment.Length);
+        Buffer.BlockCopy(jpeg, 2, output, 2 + segment.Length, jpeg.Length - 2);
+        return output;
+    }
+
+    private static byte[] PngWithTransparentColor() {
+        using var stream = new System.IO.MemoryStream();
+        stream.Write(new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 }, 0, 8);
+        WritePngChunk(stream, "IHDR", new byte[] { 0, 0, 0, 1, 0, 0, 0, 1, 8, 2, 0, 0, 0 });
+        WritePngChunk(stream, "tRNS", new byte[] { 0, 0x12, 0, 0x34, 0, 0x56 });
+        WritePngChunk(stream, "IDAT", ZlibDeflate(new byte[] { 0, 0x12, 0x34, 0x56 }));
+        WritePngChunk(stream, "IEND", Array.Empty<byte>());
+        return stream.ToArray();
+    }
+
+    private static void WritePngChunk(System.IO.Stream stream, string type, byte[] data) {
+        WriteBigEndian(stream, data.Length);
+        var typeBytes = System.Text.Encoding.ASCII.GetBytes(type);
+        using var crcInput = new System.IO.MemoryStream();
+        crcInput.Write(typeBytes, 0, typeBytes.Length);
+        crcInput.Write(data, 0, data.Length);
+        stream.Write(typeBytes, 0, typeBytes.Length);
+        stream.Write(data, 0, data.Length);
+        WriteBigEndian(stream, unchecked((int)Crc32(crcInput.ToArray())));
+    }
+
+    private static byte[] ZlibDeflate(byte[] data) {
+        using var stream = new System.IO.MemoryStream();
+        stream.WriteByte(0x78);
+        stream.WriteByte(0x9C);
+        using (var deflate = new System.IO.Compression.DeflateStream(stream, System.IO.Compression.CompressionLevel.Optimal, true)) {
+            deflate.Write(data, 0, data.Length);
+        }
+
+        WriteBigEndian(stream, unchecked((int)Adler32(data)));
+        return stream.ToArray();
+    }
+
+    private static uint Adler32(byte[] data) {
+        const uint mod = 65521;
+        uint a = 1;
+        uint b = 0;
+        foreach (var value in data) {
+            a = (a + value) % mod;
+            b = (b + a) % mod;
+        }
+
+        return (b << 16) | a;
+    }
+
+    private static uint Crc32(byte[] data) {
+        uint crc = 0xffffffff;
+        foreach (var value in data) {
+            crc ^= value;
+            for (var i = 0; i < 8; i++) crc = (crc & 1) == 1 ? 0xedb88320 ^ (crc >> 1) : crc >> 1;
+        }
+
+        return ~crc;
+    }
+
+    private static void WriteBigEndian(System.IO.Stream stream, int value) {
+        stream.WriteByte((byte)((value >> 24) & 255));
+        stream.WriteByte((byte)((value >> 16) & 255));
+        stream.WriteByte((byte)((value >> 8) & 255));
+        stream.WriteByte((byte)(value & 255));
+    }
+
+    private static byte[] IndexedBmp() {
+        const int width = 2;
+        const int height = 1;
+        const int fileHeader = 14;
+        const int dibHeader = 40;
+        const int paletteBytes = 8;
+        const int stride = 4;
+        var bytes = new byte[fileHeader + dibHeader + paletteBytes + stride];
+        bytes[0] = (byte)'B';
+        bytes[1] = (byte)'M';
+        WriteLittleEndian(bytes, 2, bytes.Length);
+        WriteLittleEndian(bytes, 10, fileHeader + dibHeader + paletteBytes);
+        WriteLittleEndian(bytes, 14, dibHeader);
+        WriteLittleEndian(bytes, 18, width);
+        WriteLittleEndian(bytes, 22, height);
+        bytes[26] = 1;
+        bytes[28] = 8;
+        WriteLittleEndian(bytes, 34, stride);
+        WriteLittleEndian(bytes, 46, 2);
+        var palette = fileHeader + dibHeader;
+        bytes[palette + 2] = 255;
+        bytes[palette + 4] = 255;
+        var pixels = fileHeader + dibHeader + paletteBytes;
+        bytes[pixels] = 0;
+        bytes[pixels + 1] = 1;
+        return bytes;
+    }
+
+    private static void WriteLittleEndian(byte[] data, int offset, int value) {
+        data[offset] = (byte)(value & 255);
+        data[offset + 1] = (byte)((value >> 8) & 255);
+        data[offset + 2] = (byte)((value >> 16) & 255);
+        data[offset + 3] = (byte)((value >> 24) & 255);
+    }
 }

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -109,7 +109,11 @@ internal static partial class SmokeTests {
         Assert(RasterImageDecoder.Decode(sourceImage.ToBmp()).Width == 18, "RasterImageDecoder should decode dependency-free BMP images.");
         var decodedIndexedBmp = RasterImageDecoder.Decode(IndexedBmp());
         Assert(decodedIndexedBmp.Width == 2 && decodedIndexedBmp.Height == 1 && decodedIndexedBmp.Pixels[0] == 255 && decodedIndexedBmp.Pixels[4 + 2] == 255, "RasterImageDecoder should decode indexed BMP palettes.");
+        var decodedTransparentBmp = RasterImageDecoder.Decode(Transparent32BitBmp());
+        Assert(decodedTransparentBmp.Pixels[3] == 0, "RasterImageDecoder should preserve explicit BMP alpha channels even when all pixels are transparent.");
         Assert(RasterImageDecoder.Decode(sourceImage.ToPpm()).Height == 12, "RasterImageDecoder should decode dependency-free PPM images.");
+        var decodedCrLfPpm = RasterImageDecoder.Decode(BinaryPpmWithCrLfHeader());
+        Assert(decodedCrLfPpm.Pixels[0] == 255 && decodedCrLfPpm.Pixels[1] == 0 && decodedCrLfPpm.Pixels[2] == 0, "RasterImageDecoder should consume CRLF PPM header separators before binary pixels.");
         Assert(RasterImageDecoder.Decode(sourceImage.ToTiff()).Width == 18, "RasterImageDecoder should decode dependency-free uncompressed TIFF images.");
         var whiteIsZeroTiff = RasterImageDecoder.Decode(GrayscaleTiff(0, new byte[] { 0, 255 }));
         Assert(whiteIsZeroTiff.Pixels[0] == 255 && whiteIsZeroTiff.Pixels[4] == 0, "RasterImageDecoder should decode WhiteIsZero grayscale TIFF images.");
@@ -130,6 +134,14 @@ internal static partial class SmokeTests {
             Assert(imageLayerSvg.Contains("data:image/jpeg;base64", StringComparison.Ordinal), "VisualCanvas image byte layers should preserve JPEG source bytes for SVG output.");
             Assert(imageLayerCanvas.ToPng().Length > 64, "VisualCanvas image file layers should render to PNG output.");
             Assert(decodedPng.ToVisualCanvas().ToPng().Length > 64, "Decoded RGBA images should be reusable as visual canvases.");
+            var nonWebRasterSvg = VisualCanvas.Create(60, 20)
+                .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+                .AddImageBytes(0, 0, 20, 20, sourceImage.ToBmp())
+                .AddImageBytes(20, 0, 20, 20, sourceImage.ToPpm())
+                .AddImageBytes(40, 0, 20, 20, sourceImage.ToTiff())
+                .ToSvg("visual-canvas-non-web-raster-input");
+            Assert(nonWebRasterSvg.Contains("data:image/png;base64", StringComparison.Ordinal), "VisualCanvas should re-encode non-web raster image inputs as PNG for SVG output.");
+            Assert(!nonWebRasterSvg.Contains("data:image/bmp", StringComparison.Ordinal) && !nonWebRasterSvg.Contains("image/tiff", StringComparison.Ordinal) && !nonWebRasterSvg.Contains("image/x-portable-pixmap", StringComparison.Ordinal), "VisualCanvas SVG output should not embed non-web raster MIME types.");
         } finally {
             if (System.IO.File.Exists(imageFilePath)) System.IO.File.Delete(imageFilePath);
         }
@@ -316,6 +328,38 @@ internal static partial class SmokeTests {
         var pixels = fileHeader + dibHeader + paletteBytes;
         bytes[pixels] = 0;
         bytes[pixels + 1] = 1;
+        return bytes;
+    }
+
+    private static byte[] Transparent32BitBmp() {
+        const int width = 1;
+        const int height = 1;
+        const int fileHeader = 14;
+        const int dibHeader = 40;
+        const int pixelOffset = fileHeader + dibHeader;
+        var bytes = new byte[pixelOffset + 4];
+        bytes[0] = (byte)'B';
+        bytes[1] = (byte)'M';
+        WriteLittleEndian(bytes, 2, bytes.Length);
+        WriteLittleEndian(bytes, 10, pixelOffset);
+        WriteLittleEndian(bytes, 14, dibHeader);
+        WriteLittleEndian(bytes, 18, width);
+        WriteLittleEndian(bytes, 22, height);
+        bytes[26] = 1;
+        bytes[28] = 32;
+        WriteLittleEndian(bytes, 34, 4);
+        bytes[pixelOffset] = 0x30;
+        bytes[pixelOffset + 1] = 0x20;
+        bytes[pixelOffset + 2] = 0x10;
+        bytes[pixelOffset + 3] = 0x00;
+        return bytes;
+    }
+
+    private static byte[] BinaryPpmWithCrLfHeader() {
+        var header = System.Text.Encoding.ASCII.GetBytes("P6\n1 1\n255\r\n");
+        var bytes = new byte[header.Length + 3];
+        Buffer.BlockCopy(header, 0, bytes, 0, header.Length);
+        bytes[header.Length] = 255;
         return bytes;
     }
 

--- a/ChartForgeX/ChartExtensions.cs
+++ b/ChartForgeX/ChartExtensions.cs
@@ -467,6 +467,69 @@ public static partial class ChartExtensions {
     public static void SavePng(this VisualCanvas canvas, string path) => File.WriteAllBytes(path, canvas.ToPng());
 
     /// <summary>
+    /// Creates a visual canvas from decoded RGBA pixels with the image as the first layer.
+    /// </summary>
+    public static VisualCanvas ToVisualCanvas(this RgbaImage image, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch) {
+        VisualCanvas.ValidateEnum(fit, nameof(fit));
+        return VisualCanvas.Create(image.Width, image.Height)
+            .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+            .AddRasterImage(0, 0, image.Width, image.Height, image, fit);
+    }
+
+    /// <summary>
+    /// Adds decoded RGBA pixels as an image layer to a visual canvas.
+    /// </summary>
+    public static VisualCanvas AddRasterImage(this VisualCanvas canvas, double x, double y, double width, double height, RgbaImage image, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        return AddRenderedImage(canvas, x, y, width, height, image, RasterDataUri(image), fit, opacity);
+    }
+
+    /// <summary>
+    /// Adds decoded RGBA pixels as an image layer using anchor-based placement.
+    /// </summary>
+    public static VisualCanvas AddRasterImage(this VisualCanvas canvas, VisualCanvasPlacement placement, double width, double height, RgbaImage image, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var bounds = canvas.ResolvePlacement(placement, width, height);
+        return canvas.AddRasterImage(bounds.X, bounds.Y, bounds.Width, bounds.Height, image, fit, opacity);
+    }
+
+    /// <summary>
+    /// Decodes image bytes and adds them as an image layer to a visual canvas.
+    /// </summary>
+    public static VisualCanvas AddImageBytes(this VisualCanvas canvas, double x, double y, double width, double height, byte[] data, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        var image = RasterImageDecoder.Decode(data);
+        return AddRenderedImage(canvas, x, y, width, height, image, BinaryDataUri(data, RasterImageDecoder.MimeTypeFor(data)), fit, opacity);
+    }
+
+    /// <summary>
+    /// Decodes image bytes and adds them as an image layer using anchor-based placement.
+    /// </summary>
+    public static VisualCanvas AddImageBytes(this VisualCanvas canvas, VisualCanvasPlacement placement, double width, double height, byte[] data, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var bounds = canvas.ResolvePlacement(placement, width, height);
+        return canvas.AddImageBytes(bounds.X, bounds.Y, bounds.Width, bounds.Height, data, fit, opacity);
+    }
+
+    /// <summary>
+    /// Decodes an image file and adds it as an image layer to a visual canvas.
+    /// </summary>
+    public static VisualCanvas AddImageFile(this VisualCanvas canvas, double x, double y, double width, double height, string path, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (path == null) throw new ArgumentNullException(nameof(path));
+        var data = File.ReadAllBytes(path);
+        var image = RasterImageDecoder.Decode(data);
+        return AddRenderedImage(canvas, x, y, width, height, image, BinaryDataUri(data, RasterImageDecoder.MimeTypeFor(data, path)), fit, opacity);
+    }
+
+    /// <summary>
+    /// Decodes an image file and adds it as an image layer using anchor-based placement.
+    /// </summary>
+    public static VisualCanvas AddImageFile(this VisualCanvas canvas, VisualCanvasPlacement placement, double width, double height, string path, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var bounds = canvas.ResolvePlacement(placement, width, height);
+        return canvas.AddImageFile(bounds.X, bounds.Y, bounds.Width, bounds.Height, path, fit, opacity);
+    }
+
+    /// <summary>
     /// Adds a rendered chart layer to a visual canvas.
     /// </summary>
     public static VisualCanvas AddChart(this VisualCanvas canvas, double x, double y, double width, double height, Chart chart, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
@@ -561,4 +624,8 @@ public static partial class ChartExtensions {
         if (svg == null) throw new ArgumentNullException(nameof(svg));
         return "data:image/svg+xml;charset=utf-8," + Uri.EscapeDataString(svg);
     }
+
+    private static string RasterDataUri(RgbaImage image) => BinaryDataUri(PngWriter.WriteRgba(image), "image/png");
+
+    private static string BinaryDataUri(byte[] data, string mimeType) => "data:" + mimeType + ";base64," + Convert.ToBase64String(data);
 }

--- a/ChartForgeX/ChartExtensions.cs
+++ b/ChartForgeX/ChartExtensions.cs
@@ -498,7 +498,7 @@ public static partial class ChartExtensions {
     public static VisualCanvas AddImageBytes(this VisualCanvas canvas, double x, double y, double width, double height, byte[] data, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {
         if (data == null) throw new ArgumentNullException(nameof(data));
         var image = RasterImageDecoder.Decode(data);
-        return AddRenderedImage(canvas, x, y, width, height, image, BinaryDataUri(data, RasterImageDecoder.MimeTypeFor(data)), fit, opacity);
+        return AddRenderedImage(canvas, x, y, width, height, image, EmbeddedRasterDataUri(data, image, null), fit, opacity);
     }
 
     /// <summary>
@@ -517,7 +517,7 @@ public static partial class ChartExtensions {
         if (path == null) throw new ArgumentNullException(nameof(path));
         var data = File.ReadAllBytes(path);
         var image = RasterImageDecoder.Decode(data);
-        return AddRenderedImage(canvas, x, y, width, height, image, BinaryDataUri(data, RasterImageDecoder.MimeTypeFor(data, path)), fit, opacity);
+        return AddRenderedImage(canvas, x, y, width, height, image, EmbeddedRasterDataUri(data, image, path), fit, opacity);
     }
 
     /// <summary>
@@ -626,6 +626,12 @@ public static partial class ChartExtensions {
     }
 
     private static string RasterDataUri(RgbaImage image) => BinaryDataUri(PngWriter.WriteRgba(image), "image/png");
+
+    private static string EmbeddedRasterDataUri(byte[] data, RgbaImage image, string? path) {
+        var mimeType = RasterImageDecoder.MimeTypeFor(data, path);
+        if (mimeType == "image/png" || mimeType == "image/jpeg") return BinaryDataUri(data, mimeType);
+        return RasterDataUri(image);
+    }
 
     private static string BinaryDataUri(byte[] data, string mimeType) => "data:" + mimeType + ";base64," + Convert.ToBase64String(data);
 }

--- a/ChartForgeX/Raster/BmpReader.cs
+++ b/ChartForgeX/Raster/BmpReader.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+
+namespace ChartForgeX.Raster;
+
+internal static class BmpReader {
+    public static bool IsBmp(byte[] data) => data != null && data.Length >= 2 && data[0] == (byte)'B' && data[1] == (byte)'M';
+
+    public static RgbaImage Decode(byte[] data) {
+        if (!IsBmp(data)) throw new NotSupportedException("Input is not a BMP image.");
+        if (data.Length < 54) throw new InvalidDataException("BMP image is too short.");
+        var pixelOffset = ReadInt32(data, 10);
+        var dibSize = ReadInt32(data, 14);
+        if (dibSize < 40) throw new NotSupportedException("Only BITMAPINFOHEADER BMP images are supported.");
+        var width = ReadInt32(data, 18);
+        var rawHeight = ReadInt32(data, 22);
+        var planes = ReadUInt16(data, 26);
+        var bitsPerPixel = ReadUInt16(data, 28);
+        var compression = ReadInt32(data, 30);
+        var colorsUsed = ReadInt32(data, 46);
+        if (width <= 0 || rawHeight == 0) throw new InvalidDataException("BMP dimensions must be positive.");
+        if (planes != 1) throw new InvalidDataException("BMP image has an invalid plane count.");
+        if (compression != 0) throw new NotSupportedException("Compressed BMP images are not supported.");
+        if (bitsPerPixel != 8 && bitsPerPixel != 24 && bitsPerPixel != 32) throw new NotSupportedException("Only 8-bit indexed, 24-bit, and 32-bit BMP images are supported.");
+
+        var height = Math.Abs(rawHeight);
+        var topDown = rawHeight < 0;
+        var stride = checked(((width * bitsPerPixel) + 31) / 32 * 4);
+        if (pixelOffset < 0 || pixelOffset + stride * height > data.Length) throw new InvalidDataException("BMP pixel data exceeds the input size.");
+        var rgba = new byte[checked(width * height * 4)];
+        if (bitsPerPixel == 8) {
+            DecodeIndexed(data, pixelOffset, dibSize, colorsUsed, width, height, topDown, stride, rgba);
+            return new RgbaImage(width, height, rgba);
+        }
+
+        var bytesPerPixel = bitsPerPixel / 8;
+        var hasAlpha = bitsPerPixel == 32 && HasAnyAlpha(data, pixelOffset, width, height, topDown, stride);
+        for (var y = 0; y < height; y++) {
+            var sourceY = topDown ? y : height - 1 - y;
+            var source = pixelOffset + sourceY * stride;
+            var target = y * width * 4;
+            for (var x = 0; x < width; x++) {
+                rgba[target++] = data[source + 2];
+                rgba[target++] = data[source + 1];
+                rgba[target++] = data[source];
+                rgba[target++] = bytesPerPixel == 4 && hasAlpha ? data[source + 3] : (byte)255;
+                source += bytesPerPixel;
+            }
+        }
+
+        return new RgbaImage(width, height, rgba);
+    }
+
+    private static void DecodeIndexed(byte[] data, int pixelOffset, int dibSize, int colorsUsed, int width, int height, bool topDown, int stride, byte[] rgba) {
+        var paletteOffset = 14 + dibSize;
+        var paletteEntries = colorsUsed > 0 ? colorsUsed : 256;
+        if (paletteOffset < 0 || paletteOffset + paletteEntries * 4 > data.Length || paletteOffset + paletteEntries * 4 > pixelOffset) throw new InvalidDataException("BMP palette exceeds the input size.");
+        for (var y = 0; y < height; y++) {
+            var sourceY = topDown ? y : height - 1 - y;
+            var source = pixelOffset + sourceY * stride;
+            var target = y * width * 4;
+            for (var x = 0; x < width; x++) {
+                var index = data[source++];
+                if (index >= paletteEntries) throw new InvalidDataException("BMP palette index is out of range.");
+                var entry = paletteOffset + index * 4;
+                rgba[target++] = data[entry + 2];
+                rgba[target++] = data[entry + 1];
+                rgba[target++] = data[entry];
+                rgba[target++] = 255;
+            }
+        }
+    }
+
+    private static bool HasAnyAlpha(byte[] data, int pixelOffset, int width, int height, bool topDown, int stride) {
+        for (var y = 0; y < height; y++) {
+            var sourceY = topDown ? y : height - 1 - y;
+            var source = pixelOffset + sourceY * stride + 3;
+            for (var x = 0; x < width; x++) {
+                if (data[source] != 0) return true;
+                source += 4;
+            }
+        }
+
+        return false;
+    }
+
+    private static ushort ReadUInt16(byte[] data, int offset) => (ushort)(data[offset] | (data[offset + 1] << 8));
+
+    private static int ReadInt32(byte[] data, int offset) =>
+        data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24);
+}

--- a/ChartForgeX/Raster/BmpReader.cs
+++ b/ChartForgeX/Raster/BmpReader.cs
@@ -34,7 +34,6 @@ internal static class BmpReader {
         }
 
         var bytesPerPixel = bitsPerPixel / 8;
-        var hasAlpha = bitsPerPixel == 32 && HasAnyAlpha(data, pixelOffset, width, height, topDown, stride);
         for (var y = 0; y < height; y++) {
             var sourceY = topDown ? y : height - 1 - y;
             var source = pixelOffset + sourceY * stride;
@@ -43,7 +42,7 @@ internal static class BmpReader {
                 rgba[target++] = data[source + 2];
                 rgba[target++] = data[source + 1];
                 rgba[target++] = data[source];
-                rgba[target++] = bytesPerPixel == 4 && hasAlpha ? data[source + 3] : (byte)255;
+                rgba[target++] = bytesPerPixel == 4 ? data[source + 3] : (byte)255;
                 source += bytesPerPixel;
             }
         }
@@ -69,19 +68,6 @@ internal static class BmpReader {
                 rgba[target++] = 255;
             }
         }
-    }
-
-    private static bool HasAnyAlpha(byte[] data, int pixelOffset, int width, int height, bool topDown, int stride) {
-        for (var y = 0; y < height; y++) {
-            var sourceY = topDown ? y : height - 1 - y;
-            var source = pixelOffset + sourceY * stride + 3;
-            for (var x = 0; x < width; x++) {
-                if (data[source] != 0) return true;
-                source += 4;
-            }
-        }
-
-        return false;
     }
 
     private static ushort ReadUInt16(byte[] data, int offset) => (ushort)(data[offset] | (data[offset + 1] << 8));

--- a/ChartForgeX/Raster/JpegBitReader.cs
+++ b/ChartForgeX/Raster/JpegBitReader.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+
+namespace ChartForgeX.Raster;
+
+internal static partial class JpegReader {
+    private sealed class JpegBitReader {
+        private readonly byte[] _data;
+        private readonly int _end;
+        private int _offset;
+        private int _bits;
+        private int _bitCount;
+
+        public JpegBitReader(byte[] data, int offset, int end) {
+            _data = data;
+            _offset = offset;
+            _end = Math.Min(end <= 0 ? data.Length : end, data.Length);
+        }
+
+        public int ReadBit() {
+            if (_bitCount == 0) Fill();
+            _bitCount--;
+            return (_bits >> _bitCount) & 1;
+        }
+
+        public int ReadBits(int count) {
+            var value = 0;
+            for (var i = 0; i < count; i++) value = (value << 1) | ReadBit();
+            return value;
+        }
+
+        public void AlignToByte() {
+            _bitCount = 0;
+        }
+
+        private void Fill() {
+            while (_offset < _end && _data[_offset] == 0xFF) {
+                _offset++;
+                while (_offset < _end && _data[_offset] == 0xFF) _offset++;
+                if (_offset >= _end) throw new InvalidDataException("JPEG entropy data is truncated.");
+                var marker = _data[_offset++];
+                if (marker == 0x00) {
+                    _bits = 0xFF;
+                    _bitCount = 8;
+                    return;
+                }
+
+                if (marker >= 0xD0 && marker <= 0xD7) {
+                    _bitCount = 0;
+                    continue;
+                }
+
+                throw new InvalidDataException("Unexpected JPEG marker inside entropy data.");
+            }
+
+            if (_offset >= _end) throw new InvalidDataException("JPEG entropy data is truncated.");
+            _bits = _data[_offset++];
+            _bitCount = 8;
+        }
+    }
+}

--- a/ChartForgeX/Raster/JpegModels.cs
+++ b/ChartForgeX/Raster/JpegModels.cs
@@ -13,6 +13,7 @@ internal static partial class JpegReader {
         public JpegFrame? Frame;
         public int RestartInterval;
         public int AdobeTransform = -1;
+        public bool HasJfif;
         public bool Progressive;
         public int Orientation = 1;
     }

--- a/ChartForgeX/Raster/JpegModels.cs
+++ b/ChartForgeX/Raster/JpegModels.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ChartForgeX.Raster;
+
+internal static partial class JpegReader {
+    private sealed class JpegState {
+        public readonly int[][] QuantizationTables = new int[4][];
+        public readonly JpegHuffmanTable?[] DcTables = new JpegHuffmanTable?[4];
+        public readonly JpegHuffmanTable?[] AcTables = new JpegHuffmanTable?[4];
+        public readonly List<JpegScan> Scans = new();
+        public JpegFrame? Frame;
+        public int RestartInterval;
+        public int AdobeTransform = -1;
+        public bool Progressive;
+        public int Orientation = 1;
+    }
+
+    private sealed class JpegScan {
+        public readonly List<JpegScanComponent> Components = new();
+        public int SpectralStart;
+        public int SpectralEnd;
+        public int SuccessiveHigh;
+        public int SuccessiveLow;
+        public int DataOffset;
+        public int DataEnd;
+
+        public JpegScanComponent Find(JpegComponent component) {
+            foreach (var scanComponent in Components) {
+                if (ReferenceEquals(scanComponent.Component, component)) return scanComponent;
+            }
+
+            throw new InvalidDataException("JPEG scan is missing a component table mapping.");
+        }
+    }
+
+    private sealed class JpegScanComponent {
+        public readonly JpegComponent Component;
+        public readonly int DcTable;
+        public readonly int AcTable;
+
+        public JpegScanComponent(JpegComponent component, int dcTable, int acTable) {
+            Component = component;
+            DcTable = dcTable;
+            AcTable = acTable;
+        }
+    }
+
+    private sealed class JpegFrame {
+        public readonly int Width;
+        public readonly int Height;
+        public readonly JpegComponent[] Components;
+        public int MaxH;
+        public int MaxV;
+
+        public JpegFrame(int width, int height, int componentCount) {
+            Width = width;
+            Height = height;
+            Components = new JpegComponent[componentCount];
+        }
+
+        public JpegComponent Find(int id) {
+            foreach (var component in Components) {
+                if (component.Id == id) return component;
+            }
+
+            throw new InvalidDataException("JPEG scan references an unknown component.");
+        }
+    }
+
+    private sealed class JpegComponent {
+        public readonly int Id;
+        public readonly int H;
+        public readonly int V;
+        public readonly int QuantizationTable;
+        public int DcTable;
+        public int AcTable;
+        public int PreviousDc;
+        public int WidthInBlocks;
+        public int HeightInBlocks;
+        public int CurrentBlockOffset;
+        public int[] Coefficients = Array.Empty<int>();
+        public byte[] Samples = Array.Empty<byte>();
+
+        public JpegComponent(int id, int h, int v, int quantizationTable) {
+            Id = id;
+            H = h;
+            V = v;
+            QuantizationTable = quantizationTable;
+        }
+    }
+}

--- a/ChartForgeX/Raster/JpegReader.cs
+++ b/ChartForgeX/Raster/JpegReader.cs
@@ -314,8 +314,8 @@ internal static partial class JpegReader {
     private static void DecodeProgressiveDcFirst(byte[] data, JpegState state, JpegScan scan) {
         var reader = new JpegBitReader(data, scan.DataOffset, scan.DataEnd);
         var restartCounter = state.RestartInterval;
-        ForEachScanBlock(state.Frame!, scan, component => {
-            if (state.RestartInterval > 0 && restartCounter == 0) {
+        ForEachScanBlock(state.Frame!, scan, (component, beginsRestartUnit, endsRestartUnit) => {
+            if (beginsRestartUnit && state.RestartInterval > 0 && restartCounter == 0) {
                 reader.AlignToByte();
                 foreach (var item in scan.Components) item.Component.PreviousDc = 0;
                 restartCounter = state.RestartInterval;
@@ -325,7 +325,7 @@ internal static partial class JpegReader {
             var size = table.Decode(reader);
             component.PreviousDc += ReceiveExtended(reader, size);
             component.Coefficients[CurrentBlockOffset(component)] = component.PreviousDc << scan.SuccessiveLow;
-            if (state.RestartInterval > 0) restartCounter--;
+            if (endsRestartUnit && state.RestartInterval > 0) restartCounter--;
         });
     }
 
@@ -333,14 +333,14 @@ internal static partial class JpegReader {
         var reader = new JpegBitReader(data, scan.DataOffset, scan.DataEnd);
         var bit = 1 << scan.SuccessiveLow;
         var restartCounter = state.RestartInterval;
-        ForEachScanBlock(state.Frame!, scan, component => {
-            if (state.RestartInterval > 0 && restartCounter == 0) {
+        ForEachScanBlock(state.Frame!, scan, (component, beginsRestartUnit, endsRestartUnit) => {
+            if (beginsRestartUnit && state.RestartInterval > 0 && restartCounter == 0) {
                 reader.AlignToByte();
                 restartCounter = state.RestartInterval;
             }
 
             if (reader.ReadBit() != 0) component.Coefficients[CurrentBlockOffset(component)] |= bit;
-            if (state.RestartInterval > 0) restartCounter--;
+            if (endsRestartUnit && state.RestartInterval > 0) restartCounter--;
         });
     }
 
@@ -466,12 +466,12 @@ internal static partial class JpegReader {
         if ((Math.Abs(coefficient) & bit) == 0 && reader.ReadBit() != 0) coefficients[index] += coefficient > 0 ? bit : -bit;
     }
 
-    private static void ForEachScanBlock(JpegFrame frame, JpegScan scan, Action<JpegComponent> visit) {
+    private static void ForEachScanBlock(JpegFrame frame, JpegScan scan, Action<JpegComponent, bool, bool> visit) {
         if (scan.Components.Count == 1) {
             var component = scan.Components[0].Component;
             ForEachComponentBlock(component, (blockX, blockY) => {
                 component.CurrentBlockOffset = CoefficientOffset(component, blockX, blockY);
-                visit(component);
+                visit(component, true, true);
             });
             return;
         }
@@ -482,6 +482,8 @@ internal static partial class JpegReader {
         var mcuRows = DivideRoundUp(frame.Height, mcuHeight);
         for (var my = 0; my < mcuRows; my++) {
             for (var mx = 0; mx < mcuColumns; mx++) {
+                var blockCount = CountScanBlocksInMcu(scan, mx, my);
+                var blockIndex = 0;
                 foreach (var scanComponent in scan.Components) {
                     var component = scanComponent.Component;
                     for (var vy = 0; vy < component.V; vy++) {
@@ -490,12 +492,29 @@ internal static partial class JpegReader {
                             var blockY = my * component.V + vy;
                             if (blockX >= component.WidthInBlocks || blockY >= component.HeightInBlocks) continue;
                             component.CurrentBlockOffset = CoefficientOffset(component, blockX, blockY);
-                            visit(component);
+                            visit(component, blockIndex == 0, blockIndex == blockCount - 1);
+                            blockIndex++;
                         }
                     }
                 }
             }
         }
+    }
+
+    private static int CountScanBlocksInMcu(JpegScan scan, int mx, int my) {
+        var count = 0;
+        foreach (var scanComponent in scan.Components) {
+            var component = scanComponent.Component;
+            for (var vy = 0; vy < component.V; vy++) {
+                for (var hx = 0; hx < component.H; hx++) {
+                    var blockX = mx * component.H + hx;
+                    var blockY = my * component.V + vy;
+                    if (blockX < component.WidthInBlocks && blockY < component.HeightInBlocks) count++;
+                }
+            }
+        }
+
+        return count;
     }
 
     private static void ForEachComponentBlock(JpegComponent component, Action<int, int> visit) {

--- a/ChartForgeX/Raster/JpegReader.cs
+++ b/ChartForgeX/Raster/JpegReader.cs
@@ -1,0 +1,769 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ChartForgeX.Raster;
+
+internal static partial class JpegReader {
+    private static readonly int[] ZigZag = {
+        0, 1, 8, 16, 9, 2, 3, 10,
+        17, 24, 32, 25, 18, 11, 4, 5,
+        12, 19, 26, 33, 40, 48, 41, 34,
+        27, 20, 13, 6, 7, 14, 21, 28,
+        35, 42, 49, 56, 57, 50, 43, 36,
+        29, 22, 15, 23, 30, 37, 44, 51,
+        58, 59, 52, 45, 38, 31, 39, 46,
+        53, 60, 61, 54, 47, 55, 62, 63
+    };
+
+    private static readonly double[] Cosine = BuildCosineTable();
+
+    public static bool IsJpeg(byte[] data) => data != null && data.Length >= 3 && data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF;
+
+    public static RgbaImage Decode(byte[] data) {
+        if (!IsJpeg(data)) throw new NotSupportedException("Input is not a JPEG image.");
+        var state = Parse(data);
+        if (state.Frame == null) throw new InvalidDataException("JPEG image is missing a frame header.");
+        if (state.Scans.Count == 0) throw new InvalidDataException("JPEG image is missing scan data.");
+        if (state.Progressive) DecodeProgressiveScans(data, state);
+        else DecodeScan(data, state, state.Scans[0]);
+        return BuildImage(state);
+    }
+
+    private static JpegState Parse(byte[] data) {
+        var state = new JpegState();
+        var offset = 2;
+        while (offset < data.Length) {
+            var marker = NextMarker(data, ref offset);
+            if (marker == 0xD9) break;
+            if (marker == 0xDA) {
+                var scan = ParseScanHeader(data, ref offset, state);
+                scan.DataOffset = offset;
+                scan.DataEnd = FindEntropyEnd(data, offset);
+                state.Scans.Add(scan);
+                offset = scan.DataEnd;
+                continue;
+            }
+
+            if (marker >= 0xD0 && marker <= 0xD7) continue;
+            if (marker == 0x01) continue;
+            if (offset + 2 > data.Length) throw new InvalidDataException("JPEG segment exceeds input size.");
+            var length = ReadUInt16(data, offset);
+            if (length < 2 || offset + length > data.Length) throw new InvalidDataException("Invalid JPEG segment length.");
+            var segment = offset + 2;
+            var segmentLength = length - 2;
+            switch (marker) {
+                case 0xC0:
+                    state.Progressive = false;
+                    ParseFrame(data, segment, segmentLength, state);
+                    break;
+                case 0xC2:
+                    state.Progressive = true;
+                    ParseFrame(data, segment, segmentLength, state);
+                    break;
+                case 0xC4:
+                    ParseHuffmanTables(data, segment, segmentLength, state);
+                    break;
+                case 0xDB:
+                    ParseQuantizationTables(data, segment, segmentLength, state);
+                    break;
+                case 0xDD:
+                    state.RestartInterval = ReadUInt16(data, segment);
+                    break;
+                case 0xE1:
+                    ParseExif(data, segment, segmentLength, state);
+                    break;
+            }
+
+            offset += length;
+        }
+
+        return state;
+    }
+
+    private static void ParseFrame(byte[] data, int offset, int length, JpegState state) {
+        if (length < 6) throw new InvalidDataException("Invalid JPEG frame header.");
+        var precision = data[offset];
+        if (precision != 8) throw new NotSupportedException("Only 8-bit JPEG images are supported.");
+        var height = ReadUInt16(data, offset + 1);
+        var width = ReadUInt16(data, offset + 3);
+        var componentCount = data[offset + 5];
+        if (componentCount != 1 && componentCount != 3) throw new NotSupportedException("Only grayscale and three-component JPEG images are supported.");
+        if (length < 6 + componentCount * 3) throw new InvalidDataException("JPEG frame component data is truncated.");
+        if (width <= 0 || height <= 0) throw new InvalidDataException("JPEG dimensions must be positive.");
+        var frame = new JpegFrame(width, height, componentCount);
+        offset += 6;
+        for (var i = 0; i < componentCount; i++) {
+            var id = data[offset++];
+            var sampling = data[offset++];
+            var quant = data[offset++];
+            frame.Components[i] = new JpegComponent(id, sampling >> 4, sampling & 15, quant);
+            if (frame.Components[i].H <= 0 || frame.Components[i].H > 4 || frame.Components[i].V <= 0 || frame.Components[i].V > 4) throw new NotSupportedException("JPEG sampling factors must be between one and four.");
+            if (quant >= state.QuantizationTables.Length) throw new InvalidDataException("JPEG component references an invalid quantization table.");
+            frame.MaxH = Math.Max(frame.MaxH, frame.Components[i].H);
+            frame.MaxV = Math.Max(frame.MaxV, frame.Components[i].V);
+        }
+
+        if (frame.MaxH <= 0 || frame.MaxV <= 0) throw new InvalidDataException("JPEG frame has invalid sampling factors.");
+        foreach (var component in frame.Components) {
+            component.WidthInBlocks = DivideRoundUp(DivideRoundUp(width * component.H, frame.MaxH), 8);
+            component.HeightInBlocks = DivideRoundUp(DivideRoundUp(height * component.V, frame.MaxV), 8);
+            component.Coefficients = new int[component.WidthInBlocks * component.HeightInBlocks * 64];
+            component.Samples = new byte[component.WidthInBlocks * component.HeightInBlocks * 64];
+        }
+
+        state.Frame = frame;
+    }
+
+    private static JpegScan ParseScanHeader(byte[] data, ref int offset, JpegState state) {
+        if (offset + 2 > data.Length) throw new InvalidDataException("JPEG scan header is truncated.");
+        var length = ReadUInt16(data, offset);
+        if (length < 2 || offset + length > data.Length) throw new InvalidDataException("Invalid JPEG scan length.");
+        if (length < 6) throw new InvalidDataException("JPEG scan header is too short.");
+        var p = offset + 2;
+        var count = data[p++];
+        if (state.Frame == null) throw new InvalidDataException("JPEG scan appears before a frame header.");
+        if (!state.Progressive && count != state.Frame.Components.Length) throw new NotSupportedException("Baseline JPEG scans must include all frame components.");
+        if (length < 6 + count * 2) throw new InvalidDataException("JPEG scan component data is truncated.");
+        var scan = new JpegScan();
+        for (var i = 0; i < count; i++) {
+            var id = data[p++];
+            var table = data[p++];
+            if ((table >> 4) >= 4 || (table & 15) >= 4) throw new InvalidDataException("JPEG scan references an invalid Huffman table.");
+            var component = state.Frame.Find(id);
+            component.DcTable = table >> 4;
+            component.AcTable = table & 15;
+            scan.Components.Add(new JpegScanComponent(component, table >> 4, table & 15));
+        }
+
+        scan.SpectralStart = data[p++];
+        scan.SpectralEnd = data[p++];
+        var approximation = data[p++];
+        scan.SuccessiveHigh = approximation >> 4;
+        scan.SuccessiveLow = approximation & 15;
+        if (!state.Progressive && (scan.SpectralStart != 0 || scan.SpectralEnd != 63 || scan.SuccessiveHigh != 0 || scan.SuccessiveLow != 0)) throw new NotSupportedException("Only baseline sequential JPEG scans are supported for SOF0 images.");
+        if (state.Progressive) {
+            if (scan.SpectralStart > scan.SpectralEnd || scan.SpectralEnd > 63) throw new InvalidDataException("Invalid progressive JPEG spectral selection.");
+            if (scan.SpectralStart > 0 && count != 1) throw new NotSupportedException("Progressive JPEG AC scans must contain a single component.");
+            if (scan.SuccessiveHigh > 13 || scan.SuccessiveLow > 13) throw new InvalidDataException("Invalid progressive JPEG successive approximation.");
+        }
+
+        offset += length;
+        return scan;
+    }
+
+    private static void ParseQuantizationTables(byte[] data, int offset, int length, JpegState state) {
+        var end = offset + length;
+        while (offset < end) {
+            var info = data[offset++];
+            var precision = info >> 4;
+            var id = info & 15;
+            if (precision != 0) throw new NotSupportedException("Only 8-bit JPEG quantization tables are supported.");
+            if (id >= state.QuantizationTables.Length || offset + 64 > end) throw new InvalidDataException("Invalid JPEG quantization table.");
+            var table = new int[64];
+            for (var i = 0; i < 64; i++) table[ZigZag[i]] = data[offset++];
+            state.QuantizationTables[id] = table;
+        }
+    }
+
+    private static void ParseExif(byte[] data, int offset, int length, JpegState state) {
+        if (length < 14) return;
+        if (data[offset] != (byte)'E' || data[offset + 1] != (byte)'x' || data[offset + 2] != (byte)'i' || data[offset + 3] != (byte)'f' || data[offset + 4] != 0 || data[offset + 5] != 0) return;
+        var tiff = offset + 6;
+        var end = offset + length;
+        var little = data[tiff] == (byte)'I' && data[tiff + 1] == (byte)'I';
+        var big = data[tiff] == (byte)'M' && data[tiff + 1] == (byte)'M';
+        if (!little && !big) return;
+        if (ReadUInt16(data, tiff + 2, little) != 42) return;
+        var ifd = tiff + checked((int)ReadUInt32(data, tiff + 4, little));
+        if (ifd < tiff || ifd + 2 > end) return;
+        var count = ReadUInt16(data, ifd, little);
+        var entry = ifd + 2;
+        for (var i = 0; i < count && entry + 12 <= end; i++, entry += 12) {
+            var tag = ReadUInt16(data, entry, little);
+            if (tag != 0x0112) continue;
+            var type = ReadUInt16(data, entry + 2, little);
+            var valueCount = ReadUInt32(data, entry + 4, little);
+            if (type == 3 && valueCount >= 1) {
+                var orientation = ReadUInt16(data, entry + 8, little);
+                if (orientation >= 1 && orientation <= 8) state.Orientation = orientation;
+            }
+
+            return;
+        }
+    }
+
+    private static void ParseHuffmanTables(byte[] data, int offset, int length, JpegState state) {
+        var end = offset + length;
+        while (offset < end) {
+            var info = data[offset++];
+            var tableClass = info >> 4;
+            var id = info & 15;
+            if (id >= 4 || offset + 16 > end) throw new InvalidDataException("Invalid JPEG Huffman table.");
+            var counts = new byte[16];
+            var symbols = 0;
+            for (var i = 0; i < 16; i++) {
+                counts[i] = data[offset++];
+                symbols += counts[i];
+            }
+
+            if (offset + symbols > end) throw new InvalidDataException("JPEG Huffman symbols are truncated.");
+            var values = new byte[symbols];
+            Buffer.BlockCopy(data, offset, values, 0, symbols);
+            offset += symbols;
+            var table = new JpegHuffmanTable(counts, values);
+            if (tableClass == 0) state.DcTables[id] = table;
+            else if (tableClass == 1) state.AcTables[id] = table;
+            else throw new InvalidDataException("Invalid JPEG Huffman table class.");
+        }
+    }
+
+    private static void DecodeScan(byte[] data, JpegState state, JpegScan scan) {
+        var frame = state.Frame!;
+        var reader = new JpegBitReader(data, scan.DataOffset, scan.DataEnd);
+        var mcuWidth = frame.MaxH * 8;
+        var mcuHeight = frame.MaxV * 8;
+        var mcuColumns = DivideRoundUp(frame.Width, mcuWidth);
+        var mcuRows = DivideRoundUp(frame.Height, mcuHeight);
+        var block = new int[64];
+        var samples = new byte[64];
+        var restartCounter = state.RestartInterval;
+        for (var my = 0; my < mcuRows; my++) {
+            for (var mx = 0; mx < mcuColumns; mx++) {
+                if (state.RestartInterval > 0 && restartCounter == 0) {
+                    reader.AlignToByte();
+                    foreach (var component in frame.Components) component.PreviousDc = 0;
+                    restartCounter = state.RestartInterval;
+                }
+
+                foreach (var component in frame.Components) {
+                    for (var vy = 0; vy < component.V; vy++) {
+                        for (var hx = 0; hx < component.H; hx++) {
+                            Array.Clear(block, 0, block.Length);
+                            DecodeBlock(reader, state, component, block);
+                            InverseDct(block, state.QuantizationTables[component.QuantizationTable]!, samples);
+                            var blockX = mx * component.H + hx;
+                            var blockY = my * component.V + vy;
+                            StoreBlock(component, blockX, blockY, samples);
+                        }
+                    }
+                }
+
+                if (state.RestartInterval > 0) restartCounter--;
+            }
+        }
+    }
+
+    private static void DecodeBlock(JpegBitReader reader, JpegState state, JpegComponent component, int[] block) {
+        var dcTable = state.DcTables[component.DcTable] ?? throw new InvalidDataException("JPEG DC Huffman table is missing.");
+        var acTable = state.AcTables[component.AcTable] ?? throw new InvalidDataException("JPEG AC Huffman table is missing.");
+        if (state.QuantizationTables[component.QuantizationTable] == null) throw new InvalidDataException("JPEG quantization table is missing.");
+        var dcSize = dcTable.Decode(reader);
+        var dcDelta = ReceiveExtended(reader, dcSize);
+        component.PreviousDc += dcDelta;
+        block[0] = component.PreviousDc;
+        var index = 1;
+        while (index < 64) {
+            var symbol = acTable.Decode(reader);
+            if (symbol == 0) break;
+            var run = symbol >> 4;
+            var size = symbol & 15;
+            if (size == 0) {
+                if (run == 15) {
+                    index += 16;
+                    continue;
+                }
+
+                throw new InvalidDataException("Invalid JPEG AC coefficient run.");
+            }
+
+            index += run;
+            if (index >= 64) throw new InvalidDataException("JPEG AC coefficient run exceeds block size.");
+            block[ZigZag[index]] = ReceiveExtended(reader, size);
+            index++;
+        }
+    }
+
+    private static void DecodeProgressiveScans(byte[] data, JpegState state) {
+        var frame = state.Frame!;
+        foreach (var scan in state.Scans) {
+            if (scan.SpectralStart == 0 && scan.SpectralEnd == 0) {
+                if (scan.SuccessiveHigh == 0) DecodeProgressiveDcFirst(data, state, scan);
+                else DecodeProgressiveDcRefine(data, state, scan);
+            } else {
+                if (scan.SuccessiveHigh == 0) DecodeProgressiveAcFirst(data, state, scan);
+                else DecodeProgressiveAcRefine(data, state, scan);
+            }
+        }
+
+        var samples = new byte[64];
+        foreach (var component in frame.Components) {
+            var quantization = state.QuantizationTables[component.QuantizationTable] ?? throw new InvalidDataException("JPEG quantization table is missing.");
+            for (var blockY = 0; blockY < component.HeightInBlocks; blockY++) {
+                for (var blockX = 0; blockX < component.WidthInBlocks; blockX++) {
+                    var offset = CoefficientOffset(component, blockX, blockY);
+                    var coefficients = new int[64];
+                    Array.Copy(component.Coefficients, offset, coefficients, 0, 64);
+                    InverseDct(coefficients, quantization, samples);
+                    StoreBlock(component, blockX, blockY, samples);
+                }
+            }
+        }
+    }
+
+    private static void DecodeProgressiveDcFirst(byte[] data, JpegState state, JpegScan scan) {
+        var reader = new JpegBitReader(data, scan.DataOffset, scan.DataEnd);
+        var restartCounter = state.RestartInterval;
+        ForEachScanBlock(state.Frame!, scan, component => {
+            if (state.RestartInterval > 0 && restartCounter == 0) {
+                reader.AlignToByte();
+                foreach (var item in scan.Components) item.Component.PreviousDc = 0;
+                restartCounter = state.RestartInterval;
+            }
+
+            var table = state.DcTables[scan.Find(component).DcTable] ?? throw new InvalidDataException("JPEG DC Huffman table is missing.");
+            var size = table.Decode(reader);
+            component.PreviousDc += ReceiveExtended(reader, size);
+            component.Coefficients[CurrentBlockOffset(component)] = component.PreviousDc << scan.SuccessiveLow;
+            if (state.RestartInterval > 0) restartCounter--;
+        });
+    }
+
+    private static void DecodeProgressiveDcRefine(byte[] data, JpegState state, JpegScan scan) {
+        var reader = new JpegBitReader(data, scan.DataOffset, scan.DataEnd);
+        var bit = 1 << scan.SuccessiveLow;
+        var restartCounter = state.RestartInterval;
+        ForEachScanBlock(state.Frame!, scan, component => {
+            if (state.RestartInterval > 0 && restartCounter == 0) {
+                reader.AlignToByte();
+                restartCounter = state.RestartInterval;
+            }
+
+            if (reader.ReadBit() != 0) component.Coefficients[CurrentBlockOffset(component)] |= bit;
+            if (state.RestartInterval > 0) restartCounter--;
+        });
+    }
+
+    private static void DecodeProgressiveAcFirst(byte[] data, JpegState state, JpegScan scan) {
+        var scanComponent = scan.Components[0];
+        var component = scanComponent.Component;
+        var table = state.AcTables[scanComponent.AcTable] ?? throw new InvalidDataException("JPEG AC Huffman table is missing.");
+        var reader = new JpegBitReader(data, scan.DataOffset, scan.DataEnd);
+        var eobRun = 0;
+        var restartCounter = state.RestartInterval;
+        ForEachComponentBlock(component, (blockX, blockY) => {
+            if (state.RestartInterval > 0 && restartCounter == 0) {
+                reader.AlignToByte();
+                eobRun = 0;
+                restartCounter = state.RestartInterval;
+            }
+
+            var offset = CoefficientOffset(component, blockX, blockY);
+            if (eobRun > 0) {
+                eobRun--;
+            } else {
+                var k = scan.SpectralStart;
+                while (k <= scan.SpectralEnd) {
+                    var symbol = table.Decode(reader);
+                    var run = symbol >> 4;
+                    var size = symbol & 15;
+                    if (size == 0) {
+                        if (run == 15) {
+                            k += 16;
+                            continue;
+                        }
+
+                        eobRun = (1 << run) + (run == 0 ? 0 : reader.ReadBits(run)) - 1;
+                        break;
+                    }
+
+                    k += run;
+                    if (k > scan.SpectralEnd) throw new InvalidDataException("Progressive JPEG AC coefficient run exceeds spectral band.");
+                    component.Coefficients[offset + ZigZag[k]] = ReceiveExtended(reader, size) << scan.SuccessiveLow;
+                    k++;
+                }
+            }
+
+            if (state.RestartInterval > 0) restartCounter--;
+        });
+    }
+
+    private static void DecodeProgressiveAcRefine(byte[] data, JpegState state, JpegScan scan) {
+        var scanComponent = scan.Components[0];
+        var component = scanComponent.Component;
+        var table = state.AcTables[scanComponent.AcTable] ?? throw new InvalidDataException("JPEG AC Huffman table is missing.");
+        var reader = new JpegBitReader(data, scan.DataOffset, scan.DataEnd);
+        var bit = 1 << scan.SuccessiveLow;
+        var eobRun = 0;
+        var restartCounter = state.RestartInterval;
+        ForEachComponentBlock(component, (blockX, blockY) => {
+            if (state.RestartInterval > 0 && restartCounter == 0) {
+                reader.AlignToByte();
+                eobRun = 0;
+                restartCounter = state.RestartInterval;
+            }
+
+            var offset = CoefficientOffset(component, blockX, blockY);
+            if (eobRun > 0) {
+                RefineBand(reader, component.Coefficients, offset, scan.SpectralStart, scan.SpectralEnd, bit);
+                eobRun--;
+            } else {
+                var k = scan.SpectralStart;
+                while (k <= scan.SpectralEnd) {
+                    var symbol = table.Decode(reader);
+                    var run = symbol >> 4;
+                    var size = symbol & 15;
+                    if (size == 0) {
+                        if (run < 15) {
+                            eobRun = (1 << run) + (run == 0 ? 0 : reader.ReadBits(run));
+                            RefineBandFrom(reader, component.Coefficients, offset, k, scan.SpectralEnd, bit);
+                            eobRun--;
+                            break;
+                        }
+
+                        run = 16;
+                    } else if (size == 1) {
+                        var newCoefficient = reader.ReadBit() == 1 ? bit : -bit;
+                        while (k <= scan.SpectralEnd) {
+                            var index = offset + ZigZag[k];
+                            var coefficient = component.Coefficients[index];
+                            if (coefficient != 0) {
+                                RefineCoefficient(reader, component.Coefficients, index, bit);
+                            } else {
+                                if (run == 0) {
+                                    component.Coefficients[index] = newCoefficient;
+                                    k++;
+                                    break;
+                                }
+
+                                run--;
+                            }
+
+                            k++;
+                        }
+                    } else {
+                        throw new InvalidDataException("Invalid progressive JPEG AC refinement symbol.");
+                    }
+                }
+            }
+
+            if (state.RestartInterval > 0) restartCounter--;
+        });
+    }
+
+    private static void RefineBand(JpegBitReader reader, int[] coefficients, int offset, int spectralStart, int spectralEnd, int bit) =>
+        RefineBandFrom(reader, coefficients, offset, spectralStart, spectralEnd, bit);
+
+    private static void RefineBandFrom(JpegBitReader reader, int[] coefficients, int offset, int spectralStart, int spectralEnd, int bit) {
+        for (var k = spectralStart; k <= spectralEnd; k++) {
+            var index = offset + ZigZag[k];
+            if (coefficients[index] != 0) RefineCoefficient(reader, coefficients, index, bit);
+        }
+    }
+
+    private static void RefineCoefficient(JpegBitReader reader, int[] coefficients, int index, int bit) {
+        var coefficient = coefficients[index];
+        if ((Math.Abs(coefficient) & bit) == 0 && reader.ReadBit() != 0) coefficients[index] += coefficient > 0 ? bit : -bit;
+    }
+
+    private static void ForEachScanBlock(JpegFrame frame, JpegScan scan, Action<JpegComponent> visit) {
+        if (scan.Components.Count == 1) {
+            var component = scan.Components[0].Component;
+            ForEachComponentBlock(component, (blockX, blockY) => {
+                component.CurrentBlockOffset = CoefficientOffset(component, blockX, blockY);
+                visit(component);
+            });
+            return;
+        }
+
+        var mcuWidth = frame.MaxH * 8;
+        var mcuHeight = frame.MaxV * 8;
+        var mcuColumns = DivideRoundUp(frame.Width, mcuWidth);
+        var mcuRows = DivideRoundUp(frame.Height, mcuHeight);
+        for (var my = 0; my < mcuRows; my++) {
+            for (var mx = 0; mx < mcuColumns; mx++) {
+                foreach (var scanComponent in scan.Components) {
+                    var component = scanComponent.Component;
+                    for (var vy = 0; vy < component.V; vy++) {
+                        for (var hx = 0; hx < component.H; hx++) {
+                            var blockX = mx * component.H + hx;
+                            var blockY = my * component.V + vy;
+                            if (blockX >= component.WidthInBlocks || blockY >= component.HeightInBlocks) continue;
+                            component.CurrentBlockOffset = CoefficientOffset(component, blockX, blockY);
+                            visit(component);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ForEachComponentBlock(JpegComponent component, Action<int, int> visit) {
+        for (var blockY = 0; blockY < component.HeightInBlocks; blockY++) {
+            for (var blockX = 0; blockX < component.WidthInBlocks; blockX++) visit(blockX, blockY);
+        }
+    }
+
+    private static int CurrentBlockOffset(JpegComponent component) => component.CurrentBlockOffset;
+    private static int CoefficientOffset(JpegComponent component, int blockX, int blockY) => (blockY * component.WidthInBlocks + blockX) * 64;
+
+    private static void InverseDct(int[] coefficients, int[] quantization, byte[] output) {
+        for (var y = 0; y < 8; y++) {
+            for (var x = 0; x < 8; x++) {
+                var sum = 0.0;
+                for (var v = 0; v < 8; v++) {
+                    for (var u = 0; u < 8; u++) {
+                        var cu = u == 0 ? 1.0 / Math.Sqrt(2) : 1.0;
+                        var cv = v == 0 ? 1.0 / Math.Sqrt(2) : 1.0;
+                        sum += cu * cv * coefficients[v * 8 + u] * quantization[v * 8 + u] * Cosine[x * 8 + u] * Cosine[y * 8 + v];
+                    }
+                }
+
+                output[y * 8 + x] = ClampToByte(Math.Round(sum / 4.0 + 128.0));
+            }
+        }
+    }
+
+    private static RgbaImage BuildImage(JpegState state) {
+        var frame = state.Frame!;
+        var rgba = new byte[frame.Width * frame.Height * 4];
+        var target = 0;
+        for (var y = 0; y < frame.Height; y++) {
+            for (var x = 0; x < frame.Width; x++) {
+                if (frame.Components.Length == 1) {
+                    var gray = Sample(frame.Components[0], x, y, frame);
+                    rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = 255;
+                } else {
+                    var yy = Sample(frame.Components[0], x, y, frame);
+                    var cb = Sample(frame.Components[1], x, y, frame) - 128;
+                    var cr = Sample(frame.Components[2], x, y, frame) - 128;
+                    rgba[target++] = ClampToByte(yy + 1.402 * cr);
+                    rgba[target++] = ClampToByte(yy - 0.344136 * cb - 0.714136 * cr);
+                    rgba[target++] = ClampToByte(yy + 1.772 * cb);
+                    rgba[target++] = 255;
+                }
+            }
+        }
+
+        return ApplyOrientation(new RgbaImage(frame.Width, frame.Height, rgba), state.Orientation);
+    }
+
+    private static RgbaImage ApplyOrientation(RgbaImage image, int orientation) {
+        if (orientation <= 1 || orientation > 8) return image;
+        var swap = orientation >= 5 && orientation <= 8;
+        var width = swap ? image.Height : image.Width;
+        var height = swap ? image.Width : image.Height;
+        var pixels = new byte[width * height * 4];
+        for (var y = 0; y < image.Height; y++) {
+            for (var x = 0; x < image.Width; x++) {
+                MapOrientation(x, y, image.Width, image.Height, orientation, out var dx, out var dy);
+                Buffer.BlockCopy(image.Pixels, (y * image.Width + x) * 4, pixels, (dy * width + dx) * 4, 4);
+            }
+        }
+
+        return new RgbaImage(width, height, pixels);
+    }
+
+    private static void MapOrientation(int x, int y, int width, int height, int orientation, out int dx, out int dy) {
+        switch (orientation) {
+            case 2:
+                dx = width - 1 - x; dy = y; break;
+            case 3:
+                dx = width - 1 - x; dy = height - 1 - y; break;
+            case 4:
+                dx = x; dy = height - 1 - y; break;
+            case 5:
+                dx = y; dy = x; break;
+            case 6:
+                dx = height - 1 - y; dy = x; break;
+            case 7:
+                dx = height - 1 - y; dy = width - 1 - x; break;
+            case 8:
+                dx = y; dy = width - 1 - x; break;
+            default:
+                dx = x; dy = y; break;
+        }
+    }
+
+    private static byte Sample(JpegComponent component, int x, int y, JpegFrame frame) {
+        var sx = x * component.H / frame.MaxH;
+        var sy = y * component.V / frame.MaxV;
+        sx = Math.Min(sx, component.WidthInBlocks * 8 - 1);
+        sy = Math.Min(sy, component.HeightInBlocks * 8 - 1);
+        var blockX = sx / 8;
+        var blockY = sy / 8;
+        var offset = (blockY * component.WidthInBlocks + blockX) * 64 + (sy % 8) * 8 + (sx % 8);
+        return component.Samples[offset];
+    }
+
+    private static void StoreBlock(JpegComponent component, int blockX, int blockY, byte[] samples) {
+        if (blockX >= component.WidthInBlocks || blockY >= component.HeightInBlocks) return;
+        var offset = (blockY * component.WidthInBlocks + blockX) * 64;
+        Buffer.BlockCopy(samples, 0, component.Samples, offset, 64);
+    }
+
+    private static int ReceiveExtended(JpegBitReader reader, int length) {
+        if (length == 0) return 0;
+        var value = reader.ReadBits(length);
+        var threshold = 1 << (length - 1);
+        return value < threshold ? value + ((-1) << length) + 1 : value;
+    }
+
+    private static int NextMarker(byte[] data, ref int offset) {
+        while (offset < data.Length && data[offset] != 0xFF) offset++;
+        while (offset < data.Length && data[offset] == 0xFF) offset++;
+        if (offset >= data.Length) throw new InvalidDataException("JPEG marker is truncated.");
+        return data[offset++];
+    }
+
+    private static int FindEntropyEnd(byte[] data, int offset) {
+        while (offset < data.Length) {
+            if (data[offset] != 0xFF) {
+                offset++;
+                continue;
+            }
+
+            var markerOffset = offset;
+            offset++;
+            while (offset < data.Length && data[offset] == 0xFF) offset++;
+            if (offset >= data.Length) return markerOffset;
+            var marker = data[offset];
+            if (marker == 0x00 || marker >= 0xD0 && marker <= 0xD7) {
+                offset++;
+                continue;
+            }
+
+            return markerOffset;
+        }
+
+        return data.Length;
+    }
+
+    private static int ReadUInt16(byte[] data, int offset) => (data[offset] << 8) | data[offset + 1];
+    private static int ReadUInt16(byte[] data, int offset, bool little) => little ? data[offset] | (data[offset + 1] << 8) : ReadUInt16(data, offset);
+    private static uint ReadUInt32(byte[] data, int offset, bool little) =>
+        little
+            ? (uint)(data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24))
+            : ((uint)data[offset] << 24) | ((uint)data[offset + 1] << 16) | ((uint)data[offset + 2] << 8) | data[offset + 3];
+    private static int DivideRoundUp(int value, int divisor) => (value + divisor - 1) / divisor;
+    private static byte ClampToByte(double value) => (byte)Math.Max(0, Math.Min(255, (int)Math.Round(value)));
+
+    private static double[] BuildCosineTable() {
+        var table = new double[64];
+        for (var x = 0; x < 8; x++) {
+            for (var u = 0; u < 8; u++) table[x * 8 + u] = Math.Cos((2 * x + 1) * u * Math.PI / 16.0);
+        }
+
+        return table;
+    }
+
+    private sealed class JpegState {
+        public readonly int[][] QuantizationTables = new int[4][];
+        public readonly JpegHuffmanTable?[] DcTables = new JpegHuffmanTable?[4];
+        public readonly JpegHuffmanTable?[] AcTables = new JpegHuffmanTable?[4];
+        public readonly List<JpegScan> Scans = new();
+        public JpegFrame? Frame;
+        public int RestartInterval;
+        public bool Progressive;
+        public int Orientation = 1;
+    }
+
+    private sealed class JpegScan {
+        public readonly List<JpegScanComponent> Components = new();
+        public int SpectralStart;
+        public int SpectralEnd;
+        public int SuccessiveHigh;
+        public int SuccessiveLow;
+        public int DataOffset;
+        public int DataEnd;
+
+        public JpegScanComponent Find(JpegComponent component) {
+            foreach (var scanComponent in Components) {
+                if (ReferenceEquals(scanComponent.Component, component)) return scanComponent;
+            }
+
+            throw new InvalidDataException("JPEG scan is missing a component table mapping.");
+        }
+    }
+
+    private sealed class JpegScanComponent {
+        public readonly JpegComponent Component;
+        public readonly int DcTable;
+        public readonly int AcTable;
+
+        public JpegScanComponent(JpegComponent component, int dcTable, int acTable) {
+            Component = component;
+            DcTable = dcTable;
+            AcTable = acTable;
+        }
+    }
+
+    private sealed class JpegFrame {
+        public readonly int Width;
+        public readonly int Height;
+        public readonly JpegComponent[] Components;
+        public int MaxH;
+        public int MaxV;
+
+        public JpegFrame(int width, int height, int componentCount) {
+            Width = width;
+            Height = height;
+            Components = new JpegComponent[componentCount];
+        }
+
+        public JpegComponent Find(int id) {
+            foreach (var component in Components) {
+                if (component.Id == id) return component;
+            }
+
+            throw new InvalidDataException("JPEG scan references an unknown component.");
+        }
+    }
+
+    private sealed class JpegComponent {
+        public readonly int Id;
+        public readonly int H;
+        public readonly int V;
+        public readonly int QuantizationTable;
+        public int DcTable;
+        public int AcTable;
+        public int PreviousDc;
+        public int WidthInBlocks;
+        public int HeightInBlocks;
+        public int CurrentBlockOffset;
+        public int[] Coefficients = Array.Empty<int>();
+        public byte[] Samples = Array.Empty<byte>();
+
+        public JpegComponent(int id, int h, int v, int quantizationTable) {
+            Id = id;
+            H = h;
+            V = v;
+            QuantizationTable = quantizationTable;
+        }
+    }
+
+    private sealed class JpegHuffmanTable {
+        private readonly Dictionary<int, byte> _symbols = new();
+
+        public JpegHuffmanTable(byte[] counts, byte[] values) {
+            var code = 0;
+            var valueIndex = 0;
+            for (var length = 1; length <= 16; length++) {
+                var count = counts[length - 1];
+                for (var i = 0; i < count; i++) _symbols[(length << 16) | code++] = values[valueIndex++];
+                code <<= 1;
+            }
+        }
+
+        public int Decode(JpegBitReader reader) {
+            var code = 0;
+            for (var length = 1; length <= 16; length++) {
+                code = (code << 1) | reader.ReadBit();
+                if (_symbols.TryGetValue((length << 16) | code, out var symbol)) return symbol;
+            }
+
+            throw new InvalidDataException("Invalid JPEG Huffman code.");
+        }
+    }
+
+}

--- a/ChartForgeX/Raster/JpegReader.cs
+++ b/ChartForgeX/Raster/JpegReader.cs
@@ -70,6 +70,9 @@ internal static partial class JpegReader {
                 case 0xDD:
                     state.RestartInterval = ReadUInt16(data, segment);
                     break;
+                case 0xE0:
+                    ParseJfif(data, segment, segmentLength, state);
+                    break;
                 case 0xE1:
                     ParseExif(data, segment, segmentLength, state);
                     break;
@@ -194,6 +197,11 @@ internal static partial class JpegReader {
 
             return;
         }
+    }
+
+    private static void ParseJfif(byte[] data, int offset, int length, JpegState state) {
+        if (length < 5) return;
+        state.HasJfif = data[offset] == (byte)'J' && data[offset + 1] == (byte)'F' && data[offset + 2] == (byte)'I' && data[offset + 3] == (byte)'F' && data[offset + 4] == 0;
     }
 
     private static void ParseAdobe(byte[] data, int offset, int length, JpegState state) {
@@ -619,7 +627,11 @@ internal static partial class JpegReader {
     private static bool UsesDirectRgb(JpegFrame frame, JpegState state) =>
         frame.Components.Length == 3 &&
         (state.AdobeTransform == 0 ||
-         frame.Components[0].Id == (byte)'R' && frame.Components[1].Id == (byte)'G' && frame.Components[2].Id == (byte)'B');
+         frame.Components[0].Id == (byte)'R' && frame.Components[1].Id == (byte)'G' && frame.Components[2].Id == (byte)'B' ||
+         !state.HasJfif && state.AdobeTransform < 0 && !UsesDefaultYcbcrComponentIds(frame));
+
+    private static bool UsesDefaultYcbcrComponentIds(JpegFrame frame) =>
+        frame.Components[0].Id == 1 && frame.Components[1].Id == 2 && frame.Components[2].Id == 3;
 
     private static RgbaImage ApplyOrientation(RgbaImage image, int orientation) {
         if (orientation <= 1 || orientation > 8) return image;

--- a/ChartForgeX/Raster/JpegReader.cs
+++ b/ChartForgeX/Raster/JpegReader.cs
@@ -26,7 +26,7 @@ internal static partial class JpegReader {
         if (state.Frame == null) throw new InvalidDataException("JPEG image is missing a frame header.");
         if (state.Scans.Count == 0) throw new InvalidDataException("JPEG image is missing scan data.");
         if (state.Progressive) DecodeProgressiveScans(data, state);
-        else DecodeScan(data, state, state.Scans[0]);
+        else DecodeSequentialScans(data, state);
         return BuildImage(state);
     }
 
@@ -72,6 +72,9 @@ internal static partial class JpegReader {
                     break;
                 case 0xE1:
                     ParseExif(data, segment, segmentLength, state);
+                    break;
+                case 0xEE:
+                    ParseAdobe(data, segment, segmentLength, state);
                     break;
             }
 
@@ -123,7 +126,7 @@ internal static partial class JpegReader {
         var p = offset + 2;
         var count = data[p++];
         if (state.Frame == null) throw new InvalidDataException("JPEG scan appears before a frame header.");
-        if (!state.Progressive && count != state.Frame.Components.Length) throw new NotSupportedException("Baseline JPEG scans must include all frame components.");
+        if (count <= 0 || count > state.Frame.Components.Length) throw new InvalidDataException("JPEG scan component count is invalid.");
         if (length < 6 + count * 2) throw new InvalidDataException("JPEG scan component data is truncated.");
         var scan = new JpegScan();
         for (var i = 0; i < count; i++) {
@@ -193,6 +196,12 @@ internal static partial class JpegReader {
         }
     }
 
+    private static void ParseAdobe(byte[] data, int offset, int length, JpegState state) {
+        if (length < 12) return;
+        if (data[offset] != (byte)'A' || data[offset + 1] != (byte)'d' || data[offset + 2] != (byte)'o' || data[offset + 3] != (byte)'b' || data[offset + 4] != (byte)'e') return;
+        state.AdobeTransform = data[offset + 11];
+    }
+
     private static void ParseHuffmanTables(byte[] data, int offset, int length, JpegState state) {
         var end = offset + length;
         while (offset < end) {
@@ -218,32 +227,59 @@ internal static partial class JpegReader {
         }
     }
 
-    private static void DecodeScan(byte[] data, JpegState state, JpegScan scan) {
+    private static void DecodeSequentialScans(byte[] data, JpegState state) {
+        foreach (var scan in state.Scans) DecodeSequentialScan(data, state, scan);
+    }
+
+    private static void DecodeSequentialScan(byte[] data, JpegState state, JpegScan scan) {
         var frame = state.Frame!;
         var reader = new JpegBitReader(data, scan.DataOffset, scan.DataEnd);
+        var block = new int[64];
+        var samples = new byte[64];
+        var restartCounter = state.RestartInterval;
+        if (scan.Components.Count == 1) {
+            var component = scan.Components[0].Component;
+            ApplyScanTables(scan);
+            ForEachComponentBlock(component, (blockX, blockY) => {
+                if (state.RestartInterval > 0 && restartCounter == 0) {
+                    reader.AlignToByte();
+                    component.PreviousDc = 0;
+                    restartCounter = state.RestartInterval;
+                }
+
+                Array.Clear(block, 0, block.Length);
+                DecodeBlock(reader, state, component, block);
+                InverseDct(block, state.QuantizationTables[component.QuantizationTable]!, samples);
+                StoreBlock(component, blockX, blockY, samples);
+                if (state.RestartInterval > 0) restartCounter--;
+            });
+            return;
+        }
+
         var mcuWidth = frame.MaxH * 8;
         var mcuHeight = frame.MaxV * 8;
         var mcuColumns = DivideRoundUp(frame.Width, mcuWidth);
         var mcuRows = DivideRoundUp(frame.Height, mcuHeight);
-        var block = new int[64];
-        var samples = new byte[64];
-        var restartCounter = state.RestartInterval;
         for (var my = 0; my < mcuRows; my++) {
             for (var mx = 0; mx < mcuColumns; mx++) {
                 if (state.RestartInterval > 0 && restartCounter == 0) {
                     reader.AlignToByte();
-                    foreach (var component in frame.Components) component.PreviousDc = 0;
+                    foreach (var scanComponent in scan.Components) scanComponent.Component.PreviousDc = 0;
                     restartCounter = state.RestartInterval;
                 }
 
-                foreach (var component in frame.Components) {
+                foreach (var scanComponent in scan.Components) {
+                    var component = scanComponent.Component;
+                    component.DcTable = scanComponent.DcTable;
+                    component.AcTable = scanComponent.AcTable;
                     for (var vy = 0; vy < component.V; vy++) {
                         for (var hx = 0; hx < component.H; hx++) {
+                            var blockX = mx * component.H + hx;
+                            var blockY = my * component.V + vy;
+                            if (blockX >= component.WidthInBlocks || blockY >= component.HeightInBlocks) continue;
                             Array.Clear(block, 0, block.Length);
                             DecodeBlock(reader, state, component, block);
                             InverseDct(block, state.QuantizationTables[component.QuantizationTable]!, samples);
-                            var blockX = mx * component.H + hx;
-                            var blockY = my * component.V + vy;
                             StoreBlock(component, blockX, blockY, samples);
                         }
                     }
@@ -251,6 +287,13 @@ internal static partial class JpegReader {
 
                 if (state.RestartInterval > 0) restartCounter--;
             }
+        }
+    }
+
+    private static void ApplyScanTables(JpegScan scan) {
+        foreach (var scanComponent in scan.Components) {
+            scanComponent.Component.DcTable = scanComponent.DcTable;
+            scanComponent.Component.AcTable = scanComponent.AcTable;
         }
     }
 
@@ -547,11 +590,17 @@ internal static partial class JpegReader {
         var frame = state.Frame!;
         var rgba = new byte[frame.Width * frame.Height * 4];
         var target = 0;
+        var directRgb = UsesDirectRgb(frame, state);
         for (var y = 0; y < frame.Height; y++) {
             for (var x = 0; x < frame.Width; x++) {
                 if (frame.Components.Length == 1) {
                     var gray = Sample(frame.Components[0], x, y, frame);
                     rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = 255;
+                } else if (directRgb) {
+                    rgba[target++] = Sample(frame.Components[0], x, y, frame);
+                    rgba[target++] = Sample(frame.Components[1], x, y, frame);
+                    rgba[target++] = Sample(frame.Components[2], x, y, frame);
+                    rgba[target++] = 255;
                 } else {
                     var yy = Sample(frame.Components[0], x, y, frame);
                     var cb = Sample(frame.Components[1], x, y, frame) - 128;
@@ -566,6 +615,11 @@ internal static partial class JpegReader {
 
         return ApplyOrientation(new RgbaImage(frame.Width, frame.Height, rgba), state.Orientation);
     }
+
+    private static bool UsesDirectRgb(JpegFrame frame, JpegState state) =>
+        frame.Components.Length == 3 &&
+        (state.AdobeTransform == 0 ||
+         frame.Components[0].Id == (byte)'R' && frame.Components[1].Id == (byte)'G' && frame.Components[2].Id == (byte)'B');
 
     private static RgbaImage ApplyOrientation(RgbaImage image, int orientation) {
         if (orientation <= 1 || orientation > 8) return image;
@@ -674,91 +728,6 @@ internal static partial class JpegReader {
         }
 
         return table;
-    }
-
-    private sealed class JpegState {
-        public readonly int[][] QuantizationTables = new int[4][];
-        public readonly JpegHuffmanTable?[] DcTables = new JpegHuffmanTable?[4];
-        public readonly JpegHuffmanTable?[] AcTables = new JpegHuffmanTable?[4];
-        public readonly List<JpegScan> Scans = new();
-        public JpegFrame? Frame;
-        public int RestartInterval;
-        public bool Progressive;
-        public int Orientation = 1;
-    }
-
-    private sealed class JpegScan {
-        public readonly List<JpegScanComponent> Components = new();
-        public int SpectralStart;
-        public int SpectralEnd;
-        public int SuccessiveHigh;
-        public int SuccessiveLow;
-        public int DataOffset;
-        public int DataEnd;
-
-        public JpegScanComponent Find(JpegComponent component) {
-            foreach (var scanComponent in Components) {
-                if (ReferenceEquals(scanComponent.Component, component)) return scanComponent;
-            }
-
-            throw new InvalidDataException("JPEG scan is missing a component table mapping.");
-        }
-    }
-
-    private sealed class JpegScanComponent {
-        public readonly JpegComponent Component;
-        public readonly int DcTable;
-        public readonly int AcTable;
-
-        public JpegScanComponent(JpegComponent component, int dcTable, int acTable) {
-            Component = component;
-            DcTable = dcTable;
-            AcTable = acTable;
-        }
-    }
-
-    private sealed class JpegFrame {
-        public readonly int Width;
-        public readonly int Height;
-        public readonly JpegComponent[] Components;
-        public int MaxH;
-        public int MaxV;
-
-        public JpegFrame(int width, int height, int componentCount) {
-            Width = width;
-            Height = height;
-            Components = new JpegComponent[componentCount];
-        }
-
-        public JpegComponent Find(int id) {
-            foreach (var component in Components) {
-                if (component.Id == id) return component;
-            }
-
-            throw new InvalidDataException("JPEG scan references an unknown component.");
-        }
-    }
-
-    private sealed class JpegComponent {
-        public readonly int Id;
-        public readonly int H;
-        public readonly int V;
-        public readonly int QuantizationTable;
-        public int DcTable;
-        public int AcTable;
-        public int PreviousDc;
-        public int WidthInBlocks;
-        public int HeightInBlocks;
-        public int CurrentBlockOffset;
-        public int[] Coefficients = Array.Empty<int>();
-        public byte[] Samples = Array.Empty<byte>();
-
-        public JpegComponent(int id, int h, int v, int quantizationTable) {
-            Id = id;
-            H = h;
-            V = v;
-            QuantizationTable = quantizationTable;
-        }
     }
 
     private sealed class JpegHuffmanTable {

--- a/ChartForgeX/Raster/PngReader.cs
+++ b/ChartForgeX/Raster/PngReader.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace ChartForgeX.Raster;
+
+internal static class PngReader {
+    private static readonly byte[] Signature = { 137, 80, 78, 71, 13, 10, 26, 10 };
+
+    public static bool IsPng(byte[] data) {
+        if (data == null || data.Length < Signature.Length) return false;
+        for (var i = 0; i < Signature.Length; i++) {
+            if (data[i] != Signature[i]) return false;
+        }
+
+        return true;
+    }
+
+    public static RgbaImage Decode(byte[] data) {
+        if (!IsPng(data)) throw new NotSupportedException("Input is not a PNG image.");
+        var offset = Signature.Length;
+        var width = 0;
+        var height = 0;
+        var bitDepth = 0;
+        var colorType = 0;
+        byte[]? palette = null;
+        byte[]? transparency = null;
+        using var idat = new MemoryStream();
+
+        while (offset + 12 <= data.Length) {
+            var length = checked((int)ReadUInt32(data, offset));
+            offset += 4;
+            var type = Encoding.ASCII.GetString(data, offset, 4);
+            var typeOffset = offset;
+            offset += 4;
+            if (length < 0 || offset + length + 4 > data.Length) throw new InvalidDataException("PNG chunk length exceeds the input size.");
+            var expectedCrc = ReadUInt32(data, offset + length);
+            var actualCrc = Crc32(data, typeOffset, checked(4 + length));
+            if (expectedCrc != actualCrc) throw new InvalidDataException("PNG chunk CRC does not match.");
+            if (type == "IHDR") {
+                width = checked((int)ReadUInt32(data, offset));
+                height = checked((int)ReadUInt32(data, offset + 4));
+                bitDepth = data[offset + 8];
+                colorType = data[offset + 9];
+                if (data[offset + 12] != 0) throw new NotSupportedException("Interlaced PNG images are not supported.");
+            } else if (type == "PLTE") {
+                palette = Slice(data, offset, length);
+            } else if (type == "tRNS") {
+                transparency = Slice(data, offset, length);
+            } else if (type == "IDAT") {
+                idat.Write(data, offset, length);
+            } else if (type == "IEND") {
+                break;
+            }
+
+            offset += length + 4;
+        }
+
+        if (width <= 0 || height <= 0) throw new InvalidDataException("PNG image is missing a valid IHDR chunk.");
+        if (bitDepth != 8) throw new NotSupportedException("Only 8-bit PNG images are supported.");
+        var components = ComponentsFor(colorType);
+        if (colorType == 3 && palette == null) throw new InvalidDataException("Indexed PNG image is missing a palette.");
+        var raw = InflateZlib(idat.ToArray());
+        var stride = checked(width * components);
+        var expected = checked(height * (stride + 1));
+        if (raw.Length < expected) throw new InvalidDataException("PNG image data is shorter than expected.");
+        var unfiltered = Unfilter(raw, width, height, components, stride);
+        return ToRgba(unfiltered, width, height, colorType, palette, transparency);
+    }
+
+    private static int ComponentsFor(int colorType) {
+        switch (colorType) {
+            case 0: return 1;
+            case 2: return 3;
+            case 3: return 1;
+            case 4: return 2;
+            case 6: return 4;
+            default: throw new NotSupportedException("Unsupported PNG color type: " + colorType + ".");
+        }
+    }
+
+    private static byte[] InflateZlib(byte[] data) {
+        if (data.Length < 6) throw new InvalidDataException("PNG zlib stream is too short.");
+        if ((data[0] & 0x0F) != 8) throw new NotSupportedException("Only deflate-compressed PNG zlib streams are supported.");
+        if (((data[0] << 8) + data[1]) % 31 != 0) throw new InvalidDataException("PNG zlib header checksum is invalid.");
+        if ((data[1] & 0x20) != 0) throw new NotSupportedException("PNG zlib streams with preset dictionaries are not supported.");
+        using var input = new MemoryStream(data, 2, data.Length - 6);
+        using var deflate = new DeflateStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        deflate.CopyTo(output);
+        var inflated = output.ToArray();
+        if (ReadUInt32(data, data.Length - 4) != Adler32(inflated)) throw new InvalidDataException("PNG zlib Adler-32 checksum does not match.");
+        return inflated;
+    }
+
+    private static byte[] Unfilter(byte[] raw, int width, int height, int bpp, int stride) {
+        var output = new byte[checked(height * stride)];
+        var source = 0;
+        for (var y = 0; y < height; y++) {
+            var filter = raw[source++];
+            var row = y * stride;
+            for (var x = 0; x < stride; x++) {
+                var value = raw[source++];
+                var left = x >= bpp ? output[row + x - bpp] : 0;
+                var up = y > 0 ? output[row - stride + x] : 0;
+                var upLeft = y > 0 && x >= bpp ? output[row - stride + x - bpp] : 0;
+                output[row + x] = (byte)(value + Predictor(filter, left, up, upLeft));
+            }
+        }
+
+        return output;
+    }
+
+    private static int Predictor(int filter, int left, int up, int upLeft) {
+        switch (filter) {
+            case 0: return 0;
+            case 1: return left;
+            case 2: return up;
+            case 3: return (left + up) / 2;
+            case 4: return Paeth(left, up, upLeft);
+            default: throw new InvalidDataException("Unknown PNG scanline filter: " + filter + ".");
+        }
+    }
+
+    private static int Paeth(int left, int up, int upLeft) {
+        var p = left + up - upLeft;
+        var pa = Math.Abs(p - left);
+        var pb = Math.Abs(p - up);
+        var pc = Math.Abs(p - upLeft);
+        if (pa <= pb && pa <= pc) return left;
+        return pb <= pc ? up : upLeft;
+    }
+
+    private static RgbaImage ToRgba(byte[] pixels, int width, int height, int colorType, byte[]? palette, byte[]? transparency) {
+        var rgba = new byte[checked(width * height * 4)];
+        var source = 0;
+        var target = 0;
+        for (var i = 0; i < width * height; i++) {
+            switch (colorType) {
+                case 0:
+                    var gray = pixels[source++];
+                    rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = 255;
+                    if (transparency != null && transparency.Length >= 2 && gray == ReadUInt16LowByte(transparency, 0)) rgba[target - 1] = 0;
+                    break;
+                case 2:
+                    var r = pixels[source++];
+                    var green = pixels[source++];
+                    var b = pixels[source++];
+                    rgba[target++] = r; rgba[target++] = green; rgba[target++] = b; rgba[target++] = 255;
+                    if (transparency != null && transparency.Length >= 6 && r == ReadUInt16LowByte(transparency, 0) && green == ReadUInt16LowByte(transparency, 2) && b == ReadUInt16LowByte(transparency, 4)) rgba[target - 1] = 0;
+                    break;
+                case 3:
+                    var index = pixels[source++];
+                    var paletteOffset = index * 3;
+                    if (palette == null || paletteOffset + 2 >= palette.Length) throw new InvalidDataException("PNG palette index is out of range.");
+                    rgba[target++] = palette[paletteOffset]; rgba[target++] = palette[paletteOffset + 1]; rgba[target++] = palette[paletteOffset + 2];
+                    rgba[target++] = transparency != null && index < transparency.Length ? transparency[index] : (byte)255;
+                    break;
+                case 4:
+                    var g = pixels[source++];
+                    rgba[target++] = g; rgba[target++] = g; rgba[target++] = g; rgba[target++] = pixels[source++];
+                    break;
+                case 6:
+                    rgba[target++] = pixels[source++]; rgba[target++] = pixels[source++]; rgba[target++] = pixels[source++]; rgba[target++] = pixels[source++];
+                    break;
+            }
+        }
+
+        return new RgbaImage(width, height, rgba);
+    }
+
+    private static uint ReadUInt32(byte[] data, int offset) =>
+        ((uint)data[offset] << 24) | ((uint)data[offset + 1] << 16) | ((uint)data[offset + 2] << 8) | data[offset + 3];
+
+    private static byte ReadUInt16LowByte(byte[] data, int offset) => data[offset + 1];
+
+    private static uint Adler32(byte[] data) {
+        const uint mod = 65521;
+        uint a = 1;
+        uint b = 0;
+        foreach (var value in data) {
+            a = (a + value) % mod;
+            b = (b + a) % mod;
+        }
+
+        return (b << 16) | a;
+    }
+
+    private static uint Crc32(byte[] data, int offset, int length) {
+        uint crc = 0xffffffff;
+        for (var i = 0; i < length; i++) {
+            crc ^= data[offset + i];
+            for (var bit = 0; bit < 8; bit++) crc = (crc & 1) == 1 ? 0xedb88320 ^ (crc >> 1) : crc >> 1;
+        }
+
+        return ~crc;
+    }
+
+    private static byte[] Slice(byte[] data, int offset, int length) {
+        var copy = new byte[length];
+        Buffer.BlockCopy(data, offset, copy, 0, length);
+        return copy;
+    }
+}

--- a/ChartForgeX/Raster/PpmReader.cs
+++ b/ChartForgeX/Raster/PpmReader.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace ChartForgeX.Raster;
+
+internal static class PpmReader {
+    public static bool IsPpm(byte[] data) => data != null && data.Length >= 2 && data[0] == (byte)'P' && (data[1] == (byte)'3' || data[1] == (byte)'6');
+
+    public static RgbaImage Decode(byte[] data) {
+        if (!IsPpm(data)) throw new NotSupportedException("Input is not a PPM image.");
+        var reader = new PpmTokenReader(data);
+        var magic = reader.NextToken();
+        var width = ParsePositive(reader.NextToken(), "width");
+        var height = ParsePositive(reader.NextToken(), "height");
+        var maxValue = ParsePositive(reader.NextToken(), "max value");
+        if (maxValue > 255) throw new NotSupportedException("Only PPM images with max value up to 255 are supported.");
+        return magic == "P6" ? DecodeBinary(data, reader.Position, width, height, maxValue) : DecodeAscii(reader, width, height, maxValue);
+    }
+
+    private static RgbaImage DecodeBinary(byte[] data, int offset, int width, int height, int maxValue) {
+        SkipSingleWhitespace(data, ref offset);
+        var expected = checked(width * height * 3);
+        if (offset + expected > data.Length) throw new InvalidDataException("PPM pixel data is shorter than expected.");
+        var rgba = new byte[checked(width * height * 4)];
+        var source = offset;
+        var target = 0;
+        for (var i = 0; i < width * height; i++) {
+            rgba[target++] = Scale(data[source++], maxValue);
+            rgba[target++] = Scale(data[source++], maxValue);
+            rgba[target++] = Scale(data[source++], maxValue);
+            rgba[target++] = 255;
+        }
+
+        return new RgbaImage(width, height, rgba);
+    }
+
+    private static RgbaImage DecodeAscii(PpmTokenReader reader, int width, int height, int maxValue) {
+        var rgba = new byte[checked(width * height * 4)];
+        var target = 0;
+        for (var i = 0; i < width * height; i++) {
+            rgba[target++] = Scale(ParseNonNegative(reader.NextToken()), maxValue);
+            rgba[target++] = Scale(ParseNonNegative(reader.NextToken()), maxValue);
+            rgba[target++] = Scale(ParseNonNegative(reader.NextToken()), maxValue);
+            rgba[target++] = 255;
+        }
+
+        return new RgbaImage(width, height, rgba);
+    }
+
+    private static byte Scale(int value, int maxValue) {
+        if (value > maxValue) throw new InvalidDataException("PPM sample value exceeds the max value.");
+        return maxValue == 255 ? (byte)value : (byte)Math.Round(value * 255.0 / maxValue);
+    }
+
+    private static int ParsePositive(string token, string name) {
+        var value = ParseNonNegative(token);
+        if (value <= 0) throw new InvalidDataException("PPM " + name + " must be positive.");
+        return value;
+    }
+
+    private static int ParseNonNegative(string token) {
+        if (!int.TryParse(token, NumberStyles.None, CultureInfo.InvariantCulture, out var value) || value < 0) throw new InvalidDataException("Invalid PPM numeric token.");
+        return value;
+    }
+
+    private static void SkipSingleWhitespace(byte[] data, ref int offset) {
+        if (offset < data.Length && IsWhitespace(data[offset])) offset++;
+    }
+
+    private static bool IsWhitespace(byte value) => value == 9 || value == 10 || value == 12 || value == 13 || value == 32;
+
+    private sealed class PpmTokenReader {
+        private readonly byte[] _data;
+
+        public PpmTokenReader(byte[] data) {
+            _data = data;
+        }
+
+        public int Position { get; private set; }
+
+        public string NextToken() {
+            SkipWhitespaceAndComments();
+            if (Position >= _data.Length) throw new InvalidDataException("Unexpected end of PPM image.");
+            var start = Position;
+            while (Position < _data.Length && !IsWhitespace(_data[Position]) && _data[Position] != (byte)'#') Position++;
+            return Encoding.ASCII.GetString(_data, start, Position - start);
+        }
+
+        private void SkipWhitespaceAndComments() {
+            while (Position < _data.Length) {
+                if (IsWhitespace(_data[Position])) {
+                    Position++;
+                    continue;
+                }
+
+                if (_data[Position] == (byte)'#') {
+                    while (Position < _data.Length && _data[Position] != 10 && _data[Position] != 13) Position++;
+                    continue;
+                }
+
+                break;
+            }
+        }
+    }
+}

--- a/ChartForgeX/Raster/PpmReader.cs
+++ b/ChartForgeX/Raster/PpmReader.cs
@@ -20,7 +20,7 @@ internal static class PpmReader {
     }
 
     private static RgbaImage DecodeBinary(byte[] data, int offset, int width, int height, int maxValue) {
-        SkipSingleWhitespace(data, ref offset);
+        SkipBinaryHeaderSeparator(data, ref offset);
         var expected = checked(width * height * 3);
         if (offset + expected > data.Length) throw new InvalidDataException("PPM pixel data is shorter than expected.");
         var rgba = new byte[checked(width * height * 4)];
@@ -65,8 +65,14 @@ internal static class PpmReader {
         return value;
     }
 
-    private static void SkipSingleWhitespace(byte[] data, ref int offset) {
-        if (offset < data.Length && IsWhitespace(data[offset])) offset++;
+    private static void SkipBinaryHeaderSeparator(byte[] data, ref int offset) {
+        if (offset >= data.Length || !IsWhitespace(data[offset])) return;
+        if (data[offset] == 13 && offset + 1 < data.Length && data[offset + 1] == 10) {
+            offset += 2;
+            return;
+        }
+
+        offset++;
     }
 
     private static bool IsWhitespace(byte value) => value == 9 || value == 10 || value == 12 || value == 13 || value == 32;

--- a/ChartForgeX/Raster/RasterImageDecoder.cs
+++ b/ChartForgeX/Raster/RasterImageDecoder.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+
+namespace ChartForgeX.Raster;
+
+/// <summary>Decodes dependency-free raster image formats into RGBA pixels.</summary>
+public static class RasterImageDecoder {
+    /// <summary>Reads and decodes a raster image file.</summary>
+    /// <param name="path">The source image path.</param>
+    /// <returns>The decoded RGBA image.</returns>
+    public static RgbaImage Read(string path) {
+        if (path == null) throw new ArgumentNullException(nameof(path));
+        return Decode(File.ReadAllBytes(path));
+    }
+
+    /// <summary>Reads and decodes a raster image stream.</summary>
+    /// <param name="stream">The source image stream.</param>
+    /// <returns>The decoded RGBA image.</returns>
+    public static RgbaImage Read(Stream stream) {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return Decode(buffer.ToArray());
+    }
+
+    /// <summary>Decodes raster image bytes into RGBA pixels.</summary>
+    /// <param name="data">The encoded image bytes.</param>
+    /// <returns>The decoded RGBA image.</returns>
+    public static RgbaImage Decode(byte[] data) {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        if (PngReader.IsPng(data)) return PngReader.Decode(data);
+        if (JpegReader.IsJpeg(data)) return JpegReader.Decode(data);
+        if (BmpReader.IsBmp(data)) return BmpReader.Decode(data);
+        if (PpmReader.IsPpm(data)) return PpmReader.Decode(data);
+        if (TiffReader.IsTiff(data)) return TiffReader.Decode(data);
+
+        throw new NotSupportedException("Unsupported raster image format. Supported dependency-free input formats are baseline JPEG, PNG, BMP, PPM, and uncompressed RGB TIFF.");
+    }
+
+    /// <summary>Attempts to read and decode a raster image file.</summary>
+    /// <param name="path">The source image path.</param>
+    /// <param name="image">The decoded RGBA image when successful.</param>
+    /// <returns><c>true</c> when the image could be decoded.</returns>
+    public static bool TryRead(string? path, out RgbaImage image) {
+        image = default;
+        if (path == null || path.Trim().Length == 0) return false;
+        try {
+            image = Read(path);
+            return true;
+        } catch (IOException) {
+            return false;
+        } catch (UnauthorizedAccessException) {
+            return false;
+        } catch (InvalidDataException) {
+            return false;
+        } catch (NotSupportedException) {
+            return false;
+        }
+    }
+
+    /// <summary>Attempts to read and decode a raster image stream.</summary>
+    /// <param name="stream">The source image stream.</param>
+    /// <param name="image">The decoded RGBA image when successful.</param>
+    /// <returns><c>true</c> when the image could be decoded.</returns>
+    public static bool TryRead(Stream? stream, out RgbaImage image) {
+        image = default;
+        if (stream == null) return false;
+        try {
+            image = Read(stream);
+            return true;
+        } catch (IOException) {
+            return false;
+        } catch (InvalidDataException) {
+            return false;
+        } catch (NotSupportedException) {
+            return false;
+        }
+    }
+
+    /// <summary>Attempts to decode raster image bytes.</summary>
+    /// <param name="data">The encoded image bytes.</param>
+    /// <param name="image">The decoded RGBA image when successful.</param>
+    /// <returns><c>true</c> when the image could be decoded.</returns>
+    public static bool TryDecode(byte[]? data, out RgbaImage image) {
+        image = default;
+        if (data == null) return false;
+        try {
+            image = Decode(data);
+            return true;
+        } catch (InvalidDataException) {
+            return false;
+        } catch (NotSupportedException) {
+            return false;
+        }
+    }
+
+    internal static string MimeTypeFor(byte[] data, string? path = null) {
+        if (data != null) {
+            if (PngReader.IsPng(data)) return "image/png";
+            if (JpegReader.IsJpeg(data)) return "image/jpeg";
+            if (BmpReader.IsBmp(data)) return "image/bmp";
+            if (PpmReader.IsPpm(data)) return "image/x-portable-pixmap";
+            if (TiffReader.IsTiff(data)) return "image/tiff";
+        }
+
+        var extension = path == null ? string.Empty : Path.GetExtension(path).ToLowerInvariant();
+        switch (extension) {
+            case ".png": return "image/png";
+            case ".jpg":
+            case ".jpeg": return "image/jpeg";
+            case ".bmp": return "image/bmp";
+            case ".ppm":
+            case ".pnm": return "image/x-portable-pixmap";
+            case ".tif":
+            case ".tiff": return "image/tiff";
+            default: return "application/octet-stream";
+        }
+    }
+}

--- a/ChartForgeX/Raster/RasterImageDecoder.cs
+++ b/ChartForgeX/Raster/RasterImageDecoder.cs
@@ -51,9 +51,7 @@ public static class RasterImageDecoder {
             return false;
         } catch (UnauthorizedAccessException) {
             return false;
-        } catch (InvalidDataException) {
-            return false;
-        } catch (NotSupportedException) {
+        } catch (Exception ex) when (IsDecodeFailure(ex)) {
             return false;
         }
     }
@@ -68,11 +66,7 @@ public static class RasterImageDecoder {
         try {
             image = Read(stream);
             return true;
-        } catch (IOException) {
-            return false;
-        } catch (InvalidDataException) {
-            return false;
-        } catch (NotSupportedException) {
+        } catch (Exception ex) when (IsDecodeFailure(ex)) {
             return false;
         }
     }
@@ -87,12 +81,19 @@ public static class RasterImageDecoder {
         try {
             image = Decode(data);
             return true;
-        } catch (InvalidDataException) {
-            return false;
-        } catch (NotSupportedException) {
+        } catch (Exception ex) when (IsDecodeFailure(ex)) {
             return false;
         }
     }
+
+    private static bool IsDecodeFailure(Exception ex) =>
+        ex is IOException ||
+        ex is UnauthorizedAccessException ||
+        ex is InvalidDataException ||
+        ex is NotSupportedException ||
+        ex is ArgumentException ||
+        ex is ArithmeticException ||
+        ex is IndexOutOfRangeException;
 
     internal static string MimeTypeFor(byte[] data, string? path = null) {
         if (data != null) {

--- a/ChartForgeX/Raster/RgbaImage.cs
+++ b/ChartForgeX/Raster/RgbaImage.cs
@@ -2,11 +2,19 @@ using System;
 
 namespace ChartForgeX.Raster;
 
-internal readonly struct RgbaImage {
+/// <summary>Represents a dependency-free 32-bit RGBA raster image.</summary>
+public readonly struct RgbaImage {
+    /// <summary>Gets the image width in pixels.</summary>
     public readonly int Width;
+    /// <summary>Gets the image height in pixels.</summary>
     public readonly int Height;
+    /// <summary>Gets the image pixels as RGBA bytes, row-major from top-left.</summary>
     public readonly byte[] Pixels;
 
+    /// <summary>Initializes an RGBA raster image.</summary>
+    /// <param name="width">The image width in pixels.</param>
+    /// <param name="height">The image height in pixels.</param>
+    /// <param name="pixels">RGBA pixels, row-major from top-left.</param>
     public RgbaImage(int width, int height, byte[] pixels) {
         if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width), width, "Image width must be positive.");
         if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height), height, "Image height must be positive.");

--- a/ChartForgeX/Raster/TiffReader.cs
+++ b/ChartForgeX/Raster/TiffReader.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ChartForgeX.Raster;
+
+internal static class TiffReader {
+    public static bool IsTiff(byte[] data) =>
+        data != null && data.Length >= 4 &&
+        ((data[0] == (byte)'I' && data[1] == (byte)'I' && data[2] == 42 && data[3] == 0) ||
+         (data[0] == (byte)'M' && data[1] == (byte)'M' && data[2] == 0 && data[3] == 42));
+
+    public static RgbaImage Decode(byte[] data) {
+        if (!IsTiff(data)) throw new NotSupportedException("Input is not a TIFF image.");
+        var little = data[0] == (byte)'I';
+        var ifdOffset = checked((int)ReadUInt32(data, 4, little));
+        var entries = ReadEntries(data, ifdOffset, little);
+        var width = checked((int)GetRequiredValue(data, entries, 256, little));
+        var height = checked((int)GetRequiredValue(data, entries, 257, little));
+        var compression = GetValue(data, entries, 259, little, 1);
+        var photometric = GetValue(data, entries, 262, little, 2);
+        var samplesPerPixel = checked((int)GetValue(data, entries, 277, little, photometric == 1 ? 1u : 3u));
+        if (width <= 0 || height <= 0) throw new InvalidDataException("TIFF dimensions must be positive.");
+        if (compression != 1) throw new NotSupportedException("Only uncompressed TIFF images are supported.");
+        if (photometric != 1 && photometric != 2) throw new NotSupportedException("Only grayscale and RGB TIFF images are supported.");
+        if (samplesPerPixel != 1 && samplesPerPixel != 3 && samplesPerPixel != 4) throw new NotSupportedException("Only 1, 3, or 4 sample TIFF images are supported.");
+        var bits = GetValues(data, entries, 258, little);
+        if (bits.Count == 0) bits.Add(8);
+        foreach (var bit in bits) {
+            if (bit != 8) throw new NotSupportedException("Only 8-bit TIFF samples are supported.");
+        }
+
+        var offsets = GetValues(data, entries, 273, little);
+        var byteCounts = GetValues(data, entries, 279, little);
+        if (offsets.Count == 0 || byteCounts.Count == 0) throw new InvalidDataException("TIFF image is missing strip data.");
+        var rgba = new byte[checked(width * height * 4)];
+        var rowBytes = checked(width * samplesPerPixel);
+        var target = 0;
+        for (var strip = 0; strip < offsets.Count && target < rgba.Length; strip++) {
+            var source = checked((int)offsets[strip]);
+            var end = source + checked((int)byteCounts[Math.Min(strip, byteCounts.Count - 1)]);
+            if (source < 0 || end > data.Length) throw new InvalidDataException("TIFF strip exceeds the input size.");
+            while (source + rowBytes <= end && target < rgba.Length) {
+                for (var x = 0; x < width && target < rgba.Length; x++) {
+                    if (samplesPerPixel == 1) {
+                        var gray = data[source++];
+                        rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = 255;
+                    } else {
+                        rgba[target++] = data[source++];
+                        rgba[target++] = data[source++];
+                        rgba[target++] = data[source++];
+                        rgba[target++] = samplesPerPixel == 4 ? data[source++] : (byte)255;
+                    }
+                }
+            }
+        }
+
+        if (target != rgba.Length) throw new InvalidDataException("TIFF strip data is shorter than expected.");
+        return new RgbaImage(width, height, rgba);
+    }
+
+    private static List<TiffEntry> ReadEntries(byte[] data, int offset, bool little) {
+        if (offset < 0 || offset + 2 > data.Length) throw new InvalidDataException("Invalid TIFF IFD offset.");
+        var count = ReadUInt16(data, offset, little);
+        offset += 2;
+        if (offset + count * 12 > data.Length) throw new InvalidDataException("TIFF IFD exceeds the input size.");
+        var entries = new List<TiffEntry>(count);
+        for (var i = 0; i < count; i++) {
+            entries.Add(new TiffEntry(
+                ReadUInt16(data, offset, little),
+                ReadUInt16(data, offset + 2, little),
+                ReadUInt32(data, offset + 4, little),
+                ReadUInt32(data, offset + 8, little),
+                offset + 8));
+            offset += 12;
+        }
+
+        return entries;
+    }
+
+    private static uint GetRequiredValue(byte[] data, List<TiffEntry> entries, ushort tag, bool little) {
+        var values = GetValues(data, entries, tag, little);
+        if (values.Count == 0) throw new InvalidDataException("TIFF image is missing required tag " + tag + ".");
+        return values[0];
+    }
+
+    private static uint GetValue(byte[] data, List<TiffEntry> entries, ushort tag, bool little, uint fallback) {
+        var values = GetValues(data, entries, tag, little);
+        return values.Count == 0 ? fallback : values[0];
+    }
+
+    private static List<uint> GetValues(byte[] data, List<TiffEntry> entries, ushort tag, bool little) {
+        foreach (var entry in entries) {
+            if (entry.Tag != tag) continue;
+            var size = TypeSize(entry.Type);
+            var totalBytes = checked((int)(entry.Count * size));
+            var offset = totalBytes <= 4 ? entry.ValueOffsetPosition : checked((int)entry.ValueOrOffset);
+            if (offset < 0 || offset + totalBytes > data.Length) throw new InvalidDataException("TIFF tag data exceeds the input size.");
+            var values = new List<uint>(checked((int)entry.Count));
+            for (var i = 0; i < entry.Count; i++) {
+                values.Add(ReadTypedValue(data, offset + i * size, entry.Type, little));
+            }
+
+            return values;
+        }
+
+        return new List<uint>();
+    }
+
+    private static int TypeSize(ushort type) {
+        switch (type) {
+            case 1:
+            case 2: return 1;
+            case 3: return 2;
+            case 4: return 4;
+            default: throw new NotSupportedException("Unsupported TIFF field type: " + type + ".");
+        }
+    }
+
+    private static uint ReadTypedValue(byte[] data, int offset, ushort type, bool little) {
+        switch (type) {
+            case 1:
+            case 2: return data[offset];
+            case 3: return ReadUInt16(data, offset, little);
+            case 4: return ReadUInt32(data, offset, little);
+            default: throw new NotSupportedException("Unsupported TIFF field type: " + type + ".");
+        }
+    }
+
+    private static ushort ReadUInt16(byte[] data, int offset, bool little) =>
+        little ? (ushort)(data[offset] | (data[offset + 1] << 8)) : (ushort)((data[offset] << 8) | data[offset + 1]);
+
+    private static uint ReadUInt32(byte[] data, int offset, bool little) =>
+        little
+            ? (uint)(data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24))
+            : ((uint)data[offset] << 24) | ((uint)data[offset + 1] << 16) | ((uint)data[offset + 2] << 8) | data[offset + 3];
+
+    private readonly struct TiffEntry {
+        public readonly ushort Tag;
+        public readonly ushort Type;
+        public readonly uint Count;
+        public readonly uint ValueOrOffset;
+        public readonly int ValueOffsetPosition;
+
+        public TiffEntry(ushort tag, ushort type, uint count, uint valueOrOffset, int valueOffsetPosition) {
+            Tag = tag;
+            Type = type;
+            Count = count;
+            ValueOrOffset = valueOrOffset;
+            ValueOffsetPosition = valueOffsetPosition;
+        }
+    }
+}

--- a/ChartForgeX/Raster/TiffReader.cs
+++ b/ChartForgeX/Raster/TiffReader.cs
@@ -19,10 +19,10 @@ internal static class TiffReader {
         var height = checked((int)GetRequiredValue(data, entries, 257, little));
         var compression = GetValue(data, entries, 259, little, 1);
         var photometric = GetValue(data, entries, 262, little, 2);
-        var samplesPerPixel = checked((int)GetValue(data, entries, 277, little, photometric == 1 ? 1u : 3u));
+        var samplesPerPixel = checked((int)GetValue(data, entries, 277, little, photometric == 0 || photometric == 1 ? 1u : 3u));
         if (width <= 0 || height <= 0) throw new InvalidDataException("TIFF dimensions must be positive.");
         if (compression != 1) throw new NotSupportedException("Only uncompressed TIFF images are supported.");
-        if (photometric != 1 && photometric != 2) throw new NotSupportedException("Only grayscale and RGB TIFF images are supported.");
+        if (photometric != 0 && photometric != 1 && photometric != 2) throw new NotSupportedException("Only grayscale and RGB TIFF images are supported.");
         if (samplesPerPixel != 1 && samplesPerPixel != 3 && samplesPerPixel != 4) throw new NotSupportedException("Only 1, 3, or 4 sample TIFF images are supported.");
         var bits = GetValues(data, entries, 258, little);
         if (bits.Count == 0) bits.Add(8);
@@ -30,6 +30,8 @@ internal static class TiffReader {
             if (bit != 8) throw new NotSupportedException("Only 8-bit TIFF samples are supported.");
         }
 
+        var planarConfiguration = GetValue(data, entries, 284, little, 1);
+        if (planarConfiguration != 1) throw new NotSupportedException("Planar TIFF images with separate sample planes are not supported.");
         var offsets = GetValues(data, entries, 273, little);
         var byteCounts = GetValues(data, entries, 279, little);
         if (offsets.Count == 0 || byteCounts.Count == 0) throw new InvalidDataException("TIFF image is missing strip data.");
@@ -44,6 +46,7 @@ internal static class TiffReader {
                 for (var x = 0; x < width && target < rgba.Length; x++) {
                     if (samplesPerPixel == 1) {
                         var gray = data[source++];
+                        if (photometric == 0) gray = (byte)(255 - gray);
                         rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = gray; rgba[target++] = 255;
                     } else {
                         rgba[target++] = data[source++];

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -32,6 +32,8 @@ public sealed class PngVisualCanvasRenderer {
             DrawText(canvas, text.X, text.Y, text.Width, text.Text, text.FontSize, text.Color, text.Alignment, text.Emphasized);
         } else if (layer is VisualCanvasHeroTitleLayer hero) {
             DrawHeroTitle(canvas, hero);
+        } else if (layer is VisualCanvasKeyValueBlockLayer keyValue) {
+            DrawKeyValueBlock(canvas, keyValue, theme);
         } else if (layer is VisualCanvasInfoTileLayer tile) {
             DrawInfoTile(canvas, tile, theme);
         } else if (layer is VisualCanvasHeroBadgeLayer badge) {
@@ -90,6 +92,25 @@ public sealed class PngVisualCanvasRenderer {
         foreach (var run in hero.Runs) {
             canvas.DrawTextEmphasized(x, hero.Y, run.Text, run.Color, hero.FontSize);
             x += RgbaCanvas.MeasureTextEmphasizedWidth(run.Text, hero.FontSize, null);
+        }
+    }
+
+    private static void DrawKeyValueBlock(RgbaCanvas canvas, VisualCanvasKeyValueBlockLayer block, VisualCanvasTheme theme) {
+        var layout = VisualCanvasKeyValueBlockLayout.Build(block);
+        var defaultLabel = block.LabelColorOverride ?? theme.TileLabelColor;
+        var defaultValue = block.ValueColorOverride ?? theme.TileValueColor;
+        foreach (var row in layout.Rows) {
+            var labelColor = row.Item.LabelColor ?? defaultLabel;
+            if (block.LabelEmphasized) canvas.DrawTextEmphasized(row.LabelX, row.Y, row.LabelText, labelColor, block.LabelFontSize);
+            else canvas.DrawText(row.LabelX, row.Y, row.LabelText, labelColor, block.LabelFontSize);
+            if (row.LabelOnly) continue;
+
+            var valueColor = row.Item.ValueColor ?? defaultValue;
+            for (var i = 0; i < row.ValueLines.Count; i++) {
+                var lineY = row.Y + row.ValueLineHeight * i;
+                if (block.ValueEmphasized) canvas.DrawTextEmphasized(row.ValueX, lineY, row.ValueLines[i], valueColor, block.ValueFontSize);
+                else canvas.DrawText(row.ValueX, lineY, row.ValueLines[i], valueColor, block.ValueFontSize);
+            }
         }
     }
 

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -81,6 +81,8 @@ public sealed class SvgVisualCanvasRenderer {
             RenderText(writer, text);
         } else if (layer is VisualCanvasHeroTitleLayer hero) {
             RenderHeroTitle(writer, hero);
+        } else if (layer is VisualCanvasKeyValueBlockLayer keyValue) {
+            RenderKeyValueBlock(writer, keyValue, theme);
         } else if (layer is VisualCanvasInfoTileLayer tile) {
             RenderInfoTile(writer, tile, id, theme);
         } else if (layer is VisualCanvasHeroBadgeLayer badge) {
@@ -163,6 +165,45 @@ public sealed class SvgVisualCanvasRenderer {
             .Attribute("letter-spacing", "0")
             .EndStartElement();
         foreach (var run in hero.Runs) writer.StartElement("tspan").Attribute("fill", run.Color.ToCss()).Text(run.Text).EndElement();
+        writer.EndElement().Line();
+    }
+
+    private static void RenderKeyValueBlock(SvgMarkupWriter writer, VisualCanvasKeyValueBlockLayer block, VisualCanvasTheme theme) {
+        var layout = VisualCanvasKeyValueBlockLayout.Build(block);
+        var labelColor = block.LabelColorOverride ?? theme.TileLabelColor;
+        var valueColor = block.ValueColorOverride ?? theme.TileValueColor;
+        var fontFamily = string.IsNullOrWhiteSpace(block.FontFamilyName) ? "Segoe UI, Arial, sans-serif" : block.FontFamilyName;
+        writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-key-value-block").EndStartElement().Line();
+        foreach (var row in layout.Rows) {
+            writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-key-value-row").EndStartElement().Line();
+            writer.StartElement("text")
+                .Attribute("x", row.LabelX)
+                .Attribute("y", row.Y + block.LabelFontSize)
+                .Attribute("fill", (row.Item.LabelColor ?? labelColor).ToCss())
+                .Attribute("font-family", fontFamily)
+                .Attribute("font-size", block.LabelFontSize)
+                .Attribute("font-weight", block.LabelEmphasized ? "800" : "500")
+                .Text(row.LabelText)
+                .EndElement()
+                .Line();
+            if (!row.LabelOnly) {
+                for (var i = 0; i < row.ValueLines.Count; i++) {
+                    writer.StartElement("text")
+                        .Attribute("x", row.ValueX)
+                        .Attribute("y", row.Y + block.ValueFontSize + row.ValueLineHeight * i)
+                        .Attribute("fill", (row.Item.ValueColor ?? valueColor).ToCss())
+                        .Attribute("font-family", fontFamily)
+                        .Attribute("font-size", block.ValueFontSize)
+                        .Attribute("font-weight", block.ValueEmphasized ? "700" : "500")
+                        .Text(row.ValueLines[i])
+                        .EndElement()
+                        .Line();
+                }
+            }
+
+            writer.EndElement().Line();
+        }
+
         writer.EndElement().Line();
     }
 

--- a/ChartForgeX/VisualCanvas/VisualCanvasKeyValueBlock.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasKeyValueBlock.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+using ChartForgeX.Raster;
+
+namespace ChartForgeX.Composition;
+
+/// <summary>A row rendered inside a key/value visual canvas block.</summary>
+public sealed class VisualCanvasKeyValueItem {
+    private string _label;
+    private string _value;
+
+    /// <summary>Initializes a label-only key/value block row.</summary>
+    public VisualCanvasKeyValueItem(string label) : this(label, string.Empty, true) { }
+
+    /// <summary>Initializes a key/value block row.</summary>
+    public VisualCanvasKeyValueItem(string label, string? value) : this(label, value, false) { }
+
+    private VisualCanvasKeyValueItem(string label, string? value, bool labelOnly) {
+        _label = label ?? throw new ArgumentNullException(nameof(label));
+        _value = value ?? string.Empty;
+        LabelOnly = labelOnly;
+    }
+
+    /// <summary>Gets or sets the row label.</summary>
+    public string Label { get => _label; set => _label = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets the row value.</summary>
+    public string Value { get => _value; set => _value = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets whether this row should render as a label-only heading.</summary>
+    public bool LabelOnly { get; set; }
+    /// <summary>Gets or sets an optional row-specific label color.</summary>
+    public ChartColor? LabelColor { get; set; }
+    /// <summary>Gets or sets an optional row-specific value color.</summary>
+    public ChartColor? ValueColor { get; set; }
+
+    /// <summary>Creates a label-only key/value block row.</summary>
+    public static VisualCanvasKeyValueItem LabelRow(string label) => new(label);
+    /// <summary>Creates a key/value block row.</summary>
+    public static VisualCanvasKeyValueItem Pair(string label, string? value) => new(label, value);
+}
+
+/// <summary>Reusable key/value text block with measured label columns and wrapped value text.</summary>
+public sealed class VisualCanvasKeyValueBlockLayer : VisualCanvasLayer {
+    private readonly List<VisualCanvasKeyValueItem> _items = new();
+    private double _labelFontSize = 16;
+    private double _valueFontSize = 16;
+    private double _columnGap = 24;
+    private double _rowGap = 4;
+    private double? _labelWidth;
+    private double? _valueWrapWidth;
+    private string _fontFamilyName = string.Empty;
+
+    /// <summary>Initializes a key/value text block layer.</summary>
+    /// <param name="x">The block X coordinate.</param>
+    /// <param name="y">The block Y coordinate.</param>
+    /// <param name="width">The block width.</param>
+    /// <param name="height">The initial block height.</param>
+    /// <param name="items">The key/value rows.</param>
+    public VisualCanvasKeyValueBlockLayer(double x, double y, double width, double height, IEnumerable<VisualCanvasKeyValueItem> items) : base(x, y, width, height) {
+        if (items == null) throw new ArgumentNullException(nameof(items));
+        foreach (var item in items) _items.Add(item ?? throw new ArgumentException("Key/value blocks cannot contain null items.", nameof(items)));
+        if (_items.Count == 0) throw new ArgumentException("Key/value blocks require at least one item.", nameof(items));
+    }
+
+    /// <summary>Gets the key/value rows.</summary>
+    public IReadOnlyList<VisualCanvasKeyValueItem> Items => _items;
+    /// <summary>Gets or sets the label font size.</summary>
+    public double LabelFontSize { get => _labelFontSize; set { ValidatePositive(value, nameof(value)); _labelFontSize = value; } }
+    /// <summary>Gets or sets the value font size.</summary>
+    public double ValueFontSize { get => _valueFontSize; set { ValidatePositive(value, nameof(value)); _valueFontSize = value; } }
+    /// <summary>Gets or sets the gap between label and value columns.</summary>
+    public double ColumnGap { get => _columnGap; set { ValidateNonNegative(value, nameof(value)); _columnGap = value; } }
+    /// <summary>Gets or sets the gap between rows.</summary>
+    public double RowGap { get => _rowGap; set { ValidateNonNegative(value, nameof(value)); _rowGap = value; } }
+    /// <summary>Gets or sets an explicit label column width. When empty, the widest label is measured.</summary>
+    public double? LabelWidth {
+        get => _labelWidth;
+        set {
+            if (value.HasValue) ValidatePositive(value.Value, nameof(value));
+            _labelWidth = value;
+        }
+    }
+    /// <summary>Gets or sets an explicit value wrap width. When empty, the remaining block width is used.</summary>
+    public double? ValueWrapWidth {
+        get => _valueWrapWidth;
+        set {
+            if (value.HasValue) ValidatePositive(value.Value, nameof(value));
+            _valueWrapWidth = value;
+        }
+    }
+    /// <summary>Gets or sets an optional default label color override.</summary>
+    public ChartColor? LabelColorOverride { get; set; }
+    /// <summary>Gets or sets an optional default value color override.</summary>
+    public ChartColor? ValueColorOverride { get; set; }
+    /// <summary>Gets or sets the SVG font family name. PNG output uses the dependency-free built-in font path.</summary>
+    public string FontFamilyName { get => _fontFamilyName; set => _fontFamilyName = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets whether labels use the emphasized text treatment.</summary>
+    public bool LabelEmphasized { get; set; } = true;
+    /// <summary>Gets or sets whether values use the emphasized text treatment.</summary>
+    public bool ValueEmphasized { get; set; }
+
+    /// <summary>Measures the block height using the current text and wrapping settings.</summary>
+    public double MeasureHeight() => VisualCanvasKeyValueBlockLayout.Build(this).Height;
+}
+
+internal sealed class VisualCanvasKeyValueBlockLayout {
+    private VisualCanvasKeyValueBlockLayout(IReadOnlyList<VisualCanvasKeyValueRowLayout> rows, double labelWidth, double valueWidth, double height) {
+        Rows = rows;
+        LabelWidth = labelWidth;
+        ValueWidth = valueWidth;
+        Height = height;
+    }
+
+    public IReadOnlyList<VisualCanvasKeyValueRowLayout> Rows { get; }
+    public double LabelWidth { get; }
+    public double ValueWidth { get; }
+    public double Height { get; }
+
+    public static VisualCanvasKeyValueBlockLayout Build(VisualCanvasKeyValueBlockLayer block) {
+        if (block == null) throw new ArgumentNullException(nameof(block));
+        var hasPairs = false;
+        var labelWidth = block.LabelWidth ?? 0;
+        if (!block.LabelWidth.HasValue) {
+            foreach (var item in block.Items) {
+                if (item.LabelOnly) continue;
+                hasPairs = true;
+                labelWidth = Math.Max(labelWidth, Measure(item.Label, block.LabelFontSize, block.LabelEmphasized));
+            }
+        } else {
+            foreach (var item in block.Items) {
+                if (!item.LabelOnly) {
+                    hasPairs = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasPairs) labelWidth = 0;
+        var labelLimit = hasPairs ? Math.Max(1, block.Width - Math.Min(block.ColumnGap, Math.Max(0, block.Width - 1)) - 1) : Math.Max(0, block.Width);
+        labelWidth = Math.Min(labelWidth, labelLimit);
+        var columnGap = hasPairs ? Math.Min(block.ColumnGap, Math.Max(0, block.Width - labelWidth - 1)) : 0;
+        var remainingWidth = Math.Max(1, block.Width - labelWidth - columnGap);
+        var valueWidth = Math.Min(block.ValueWrapWidth ?? remainingWidth, remainingWidth);
+        var labelLineHeight = Math.Max(1, RgbaCanvas.MeasureTextHeight(block.LabelFontSize, null));
+        var valueLineHeight = Math.Max(1, RgbaCanvas.MeasureTextHeight(block.ValueFontSize, null));
+        var rows = new List<VisualCanvasKeyValueRowLayout>(block.Items.Count);
+        var y = block.Y;
+
+        foreach (var item in block.Items) {
+            var labelOnly = item.LabelOnly || !hasPairs;
+            var rowLabelWidth = labelOnly ? block.Width : labelWidth;
+            var rowValueWidth = labelOnly ? 0 : valueWidth;
+            var labelText = FitText(item.Label, block.LabelFontSize, Math.Max(1, rowLabelWidth), block.LabelEmphasized);
+            IReadOnlyList<string> valueLines = Array.Empty<string>();
+            if (!labelOnly) valueLines = WrapText(item.Value, Math.Max(1, rowValueWidth), block.ValueFontSize, block.ValueEmphasized);
+            var lineCount = Math.Max(1, valueLines.Count);
+            var rowHeight = labelOnly ? labelLineHeight : Math.Max(labelLineHeight, lineCount * valueLineHeight);
+            rows.Add(new VisualCanvasKeyValueRowLayout(item, block.X, y, block.X, block.X + labelWidth + columnGap, rowLabelWidth, rowValueWidth, labelText, valueLines, rowHeight, labelLineHeight, valueLineHeight, labelOnly));
+            y += rowHeight + block.RowGap;
+        }
+
+        var height = rows.Count == 0 ? 1 : Math.Max(1, y - block.Y - block.RowGap);
+        return new VisualCanvasKeyValueBlockLayout(rows, labelWidth, valueWidth, height);
+    }
+
+    private static IReadOnlyList<string> WrapText(string value, double maxWidth, double fontSize, bool emphasized) {
+        var normalized = (value ?? string.Empty).Replace("\r\n", "\n").Replace('\r', '\n');
+        var lines = new List<string>();
+        var paragraphs = normalized.Split('\n');
+        foreach (var paragraph in paragraphs) {
+            if (paragraph.Length == 0) {
+                lines.Add(string.Empty);
+                continue;
+            }
+
+            var current = string.Empty;
+            foreach (var word in paragraph.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
+                var candidate = current.Length == 0 ? word : current + " " + word;
+                if (Measure(candidate, fontSize, emphasized) <= maxWidth) {
+                    current = candidate;
+                    continue;
+                }
+
+                if (current.Length > 0) lines.Add(current);
+                current = Measure(word, fontSize, emphasized) <= maxWidth ? word : FitText(word, fontSize, maxWidth, emphasized);
+            }
+
+            lines.Add(current);
+        }
+
+        if (lines.Count == 0) lines.Add(string.Empty);
+        return lines;
+    }
+
+    private static string FitText(string value, double fontSize, double maxWidth, bool emphasized) {
+        if (string.IsNullOrEmpty(value) || Measure(value, fontSize, emphasized) <= maxWidth) return value;
+        const string suffix = "...";
+        if (Measure(suffix, fontSize, emphasized) > maxWidth) return string.Empty;
+        var low = 0;
+        var high = value.Length;
+        while (low < high) {
+            var mid = (low + high + 1) / 2;
+            if (Measure(value.Substring(0, mid) + suffix, fontSize, emphasized) <= maxWidth) low = mid;
+            else high = mid - 1;
+        }
+
+        return value.Substring(0, low) + suffix;
+    }
+
+    private static double Measure(string value, double fontSize, bool emphasized) =>
+        emphasized ? RgbaCanvas.MeasureTextEmphasizedWidth(value, fontSize, null) : RgbaCanvas.MeasureTextWidth(value, fontSize, null);
+}
+
+internal sealed class VisualCanvasKeyValueRowLayout {
+    public VisualCanvasKeyValueRowLayout(VisualCanvasKeyValueItem item, double x, double y, double labelX, double valueX, double labelWidth, double valueWidth, string labelText, IReadOnlyList<string> valueLines, double rowHeight, double labelLineHeight, double valueLineHeight, bool labelOnly) {
+        Item = item;
+        X = x;
+        Y = y;
+        LabelX = labelX;
+        ValueX = valueX;
+        LabelWidth = labelWidth;
+        ValueWidth = valueWidth;
+        LabelText = labelText;
+        ValueLines = valueLines;
+        RowHeight = rowHeight;
+        LabelLineHeight = labelLineHeight;
+        ValueLineHeight = valueLineHeight;
+        LabelOnly = labelOnly;
+    }
+
+    public VisualCanvasKeyValueItem Item { get; }
+    public double X { get; }
+    public double Y { get; }
+    public double LabelX { get; }
+    public double ValueX { get; }
+    public double LabelWidth { get; }
+    public double ValueWidth { get; }
+    public string LabelText { get; }
+    public IReadOnlyList<string> ValueLines { get; }
+    public double RowHeight { get; }
+    public double LabelLineHeight { get; }
+    public double ValueLineHeight { get; }
+    public bool LabelOnly { get; }
+}

--- a/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
@@ -372,6 +372,43 @@ public sealed class VisualCanvas {
         return AddHeroTitle(bounds.X, bounds.Y, bounds.Width, fontSize, runs, alignment);
     }
 
+    /// <summary>Adds a key/value text block with measured columns and wrapped values.</summary>
+    public VisualCanvas AddKeyValueBlock(double x, double y, double width, IEnumerable<VisualCanvasKeyValueItem> items, double labelFontSize = 16, double valueFontSize = 16, double columnGap = 24, double rowGap = 4, double? labelWidth = null, double? valueWrapWidth = null, ChartColor? labelColor = null, ChartColor? valueColor = null, string? fontFamilyName = null) {
+        var layer = new VisualCanvasKeyValueBlockLayer(x, y, width, 1, items) {
+            LabelFontSize = labelFontSize,
+            ValueFontSize = valueFontSize,
+            ColumnGap = columnGap,
+            RowGap = rowGap,
+            LabelWidth = labelWidth,
+            ValueWrapWidth = valueWrapWidth,
+            LabelColorOverride = labelColor,
+            ValueColorOverride = valueColor,
+            FontFamilyName = fontFamilyName ?? string.Empty
+        };
+        layer.Height = layer.MeasureHeight();
+        return AddLayer(layer);
+    }
+
+    /// <summary>Adds a key/value text block with measured columns and wrapped values using anchor-based placement.</summary>
+    public VisualCanvas AddKeyValueBlock(VisualCanvasPlacement placement, double width, IEnumerable<VisualCanvasKeyValueItem> items, double labelFontSize = 16, double valueFontSize = 16, double columnGap = 24, double rowGap = 4, double? labelWidth = null, double? valueWrapWidth = null, ChartColor? labelColor = null, ChartColor? valueColor = null, string? fontFamilyName = null) {
+        var layer = new VisualCanvasKeyValueBlockLayer(0, 0, width, 1, items) {
+            LabelFontSize = labelFontSize,
+            ValueFontSize = valueFontSize,
+            ColumnGap = columnGap,
+            RowGap = rowGap,
+            LabelWidth = labelWidth,
+            ValueWrapWidth = valueWrapWidth,
+            LabelColorOverride = labelColor,
+            ValueColorOverride = valueColor,
+            FontFamilyName = fontFamilyName ?? string.Empty
+        };
+        var bounds = ResolvePlacement(placement, width, layer.MeasureHeight());
+        layer.X = bounds.X;
+        layer.Y = bounds.Y;
+        layer.Height = bounds.Height;
+        return AddLayer(layer);
+    }
+
     /// <summary>Adds a reusable information tile.</summary>
     public VisualCanvas AddInfoTile(double x, double y, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text, VisualCanvasInfoTileMiniChartKind miniChartKind = VisualCanvasInfoTileMiniChartKind.None, IEnumerable<double>? miniChartValues = null, double? miniChartMaximum = null) =>
         AddLayer(new VisualCanvasInfoTileLayer(x, y, width, height, icon, label, value) { Detail = detail ?? string.Empty, AccentOverride = accent, Progress = progress, SurfaceStyle = surfaceStyle, IconKind = iconKind }.WithMiniChart(miniChartKind, miniChartValues, miniChartMaximum));
@@ -474,6 +511,13 @@ public abstract class VisualCanvasLayer {
     /// <param name="parameterName">The parameter name used when throwing.</param>
     protected static void ValidatePositive(double value, string parameterName) {
         if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) throw new ArgumentOutOfRangeException(parameterName, value, "Value must be finite and greater than zero.");
+    }
+
+    /// <summary>Validates that a numeric value is finite and not negative.</summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="parameterName">The parameter name used when throwing.</param>
+    protected static void ValidateNonNegative(double value, string parameterName) {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value < 0) throw new ArgumentOutOfRangeException(parameterName, value, "Value must be finite and greater than or equal to zero.");
     }
 }
 

--- a/docs/visual-canvas.md
+++ b/docs/visual-canvas.md
@@ -11,9 +11,11 @@ The first canvas primitives are intentionally generic:
 - reusable `VisualCanvasTheme` colors for accents, tile text, glass fills, badge fills, feature strips, placeholders, and backdrop highlights
 - absolute text layers
 - multi-color hero title layers
+- key/value text blocks with measured label columns, wrapped value text, per-row color overrides, and anchor-based placement
 - information tiles for side rails, with glass, outline, or raised surfaces, text or built-in icons, progress rails, and compact right-side mini charts
 - hero badges for logos, terminal prompts, or product marks
 - image layers using SVG hrefs and host-provided RGBA pixels for raster output, with `Stretch`, `Contain`, `Cover`, and `Center` fit modes
+- dependency-free raster image input for baseline JPEG, PNG, BMP, PPM, and uncompressed RGB TIFF files or byte arrays
 - rendered ChartForgeX layers for charts, chart grids, visual blocks, visual grids, and topology diagrams
 - anchor-based placement for all built-in canvas layers and rendered ChartForgeX layers
 - feature strips for compact bottom rows
@@ -59,19 +61,57 @@ var canvas = VisualCanvas.CreateSocialPreview()
     .WithBackdrop(VisualCanvasBackdropStyle.TechHorizon)
     .AddInfoTile(58, 92, 250, 82, "PC", "HOSTNAME", "DEV-Workstation", accent: ChartColor.FromHex("#2F80FF"), iconKind: VisualCanvasInfoTileIconKind.Computer)
     .AddInfoTile(892, 70, 250, 96, "CPU", "CPU", "Intel Core i7-12700K", "23%", ChartColor.FromHex("#60A5FA"), 0.23, VisualCanvasInfoTileSurfaceStyle.Raised, VisualCanvasInfoTileIconKind.Cpu, VisualCanvasInfoTileMiniChartKind.Area, new[] { 18d, 26d, 22d, 37d, 48d, 43d }, 100)
+    .AddKeyValueBlock(
+        VisualCanvasPlacement.At(VisualCanvasAnchor.BottomLeft, 66, 50),
+        300,
+        new[] {
+            VisualCanvasKeyValueItem.LabelRow("System"),
+            VisualCanvasKeyValueItem.Pair("Host", "DEV-WKS-01"),
+            VisualCanvasKeyValueItem.Pair("IPv4", "10.0.0.42 192.168.1.42"),
+            VisualCanvasKeyValueItem.Pair("Domain", "corp.example.test")
+        },
+        valueWrapWidth: 170,
+        labelColor: ChartColor.FromHex("#C4D4EC"),
+        valueColor: ChartColor.FromHex("#F8FAFC"))
     .AddHeroBadge(538, 157, 124, 88, ">_", ChartColor.FromHex("#22A7FF"))
     .AddHeroTitle(312, 296, 576, 82, new[] {
         new VisualCanvasTextRun("Power", ChartColor.FromHex("#F8FAFC")),
         new VisualCanvasTextRun("BGInfo", ChartColor.FromHex("#2F80FF"))
     })
     .AddText(330, 402, 540, "Desktop background insights for Windows and PowerShell", 24, ChartColor.FromHex("#C6D3EA"), VisualCanvasTextAlignment.Center)
-    .AddChart(VisualCanvasPlacement.At(VisualCanvasAnchor.BottomLeft, 66, 50), 220, 120, cpuChart, VisualCanvasImageFit.Contain)
+    .AddChart(VisualCanvasPlacement.At(VisualCanvasAnchor.BottomCenter, -160, 50), 220, 120, cpuChart, VisualCanvasImageFit.Contain)
     .AddVisualBlock(VisualCanvasPlacement.At(VisualCanvasAnchor.BottomRight, 106, 74), 180, 104, ramCard, VisualCanvasImageFit.Center);
 
 canvas.SaveSvg("powerbginfo-social-preview.svg");
 canvas.SavePng("powerbginfo-social-preview.png");
 canvas.SaveBmp("powerbginfo-social-preview.bmp");
 ```
+
+To start from an existing background image without `System.Drawing` or platform-specific graphics APIs, decode it through the reusable raster input path and place it as the first canvas layer:
+
+```csharp
+using ChartForgeX;
+using ChartForgeX.Composition;
+using ChartForgeX.Raster;
+
+var background = RasterImageDecoder.Read("wallpaper.png");
+
+var canvas = background
+    .ToVisualCanvas()
+    .AddKeyValueBlock(
+        VisualCanvasPlacement.At(VisualCanvasAnchor.TopLeft, 20, 20),
+        360,
+        new[] {
+            VisualCanvasKeyValueItem.Pair("Host", "DEV-WKS-01"),
+            VisualCanvasKeyValueItem.Pair("IPv4", "10.0.0.42 192.168.1.42")
+        });
+
+canvas.SavePng("wallpaper-with-info.png");
+```
+
+`AddImageFile(...)` and `AddImageBytes(...)` are available when an image should be placed into an existing canvas region. The dependency-free decoder supports baseline JPEG, PNG, BMP, PPM, and uncompressed RGB TIFF. Progressive JPEG remains outside the built-in decoder for now; hosts that need unsupported image variants can decode them before handing RGBA pixels to `AddRasterImage(...)`.
+
+For user-supplied files, use `RasterImageDecoder.TryRead(...)` or `TryDecode(...)` when unsupported or corrupt images should be handled as a normal validation result instead of an exception.
 
 `VisualCanvasPlacement` resolves layer coordinates from a named anchor. For `TopLeft`, offsets move right and down from the top-left edge. For `BottomRight`, positive offsets are insets from the right and bottom edges, so `VisualCanvasPlacement.At(VisualCanvasAnchor.BottomRight, 20, 20)` places a layer 20 pixels from the bottom-right corner. Center anchors use offsets as signed nudges from the centered position.
 


### PR DESCRIPTION
## Summary
- add reusable VisualCanvas key/value blocks with anchor-based placement for wallpaper-style overlays
- add dependency-free raster input decoding for PNG, JPEG including progressive scans, BMP, PPM, and uncompressed TIFF
- add VisualCanvas helpers for decoded images, image files, image bytes, and rendered ChartForgeX content
- add real-image smoke coverage for local system backgrounds and opt-in configured paths or URLs

## Why
This moves ChartForgeX closer to being the reusable cross-platform image engine that can eventually replace PowerBGInfo's ImagePlayground.Gdi usage without adding runtime dependencies.

## Validation
- dotnet test .\ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Debug -f net8.0
- dotnet build .\ChartForgeX.sln -c Debug
- real-image validation harness with Windows Web backgrounds and Wikimedia JPEG/PNG samples: 11 passed, 0 failed
