### PR TITLE
Add ChartColor conversion helpers

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/ColorPrimitiveTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/ColorPrimitiveTests.cs
@@ -1,0 +1,33 @@
+using ChartForgeX.Primitives;
+using ChartForgeX.Themes;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void ChartColorConversionsAndKnownNamesStayDeterministic() {
+        Assert(ChartColors.Emerald400.WithAlpha(172).A == 172, "Named chart colors should support explicit alpha values.");
+        Assert(ChartColors.Emerald400.WithOpacity(0.5).A == 128, "Named chart colors should support opacity helpers.");
+        Assert(ChartColors.Emerald400.WithAlpha(172).ToHexRgba() == "#34D399AC", "Named chart colors should round-trip to RGBA hex.");
+        Assert(ChartColor.FromArgb(0x8034D399u).ToHexRgba() == "#34D39980", "Chart colors should support packed ARGB conversion.");
+        Assert(ChartColor.FromArgb(unchecked((int)0x8034D399u)).ToArgb() == 0x8034D399u, "Chart colors should round-trip signed packed ARGB conversion.");
+        Assert(ChartColor.FromRgba(0x34D39980u).ToArgb() == 0x8034D399u, "Chart colors should support packed RGBA conversion.");
+        Assert(ChartColor.FromArgb(128, 52, 211, 153).ToRgba() == 0x34D39980u, "Chart colors should expose packed RGBA output.");
+        Assert(ChartColor.TryFromHex("#34D39980", out var rgbaHex) && rgbaHex.ToArgb() == 0x8034D399u, "Chart colors should expose non-throwing hex parsing.");
+        Assert(!ChartColor.TryFromHex("#12", out _), "Chart colors should reject invalid hex without throwing when using TryFromHex.");
+
+        var (deR, deG, deB, deA) = ChartColors.Emerald400.WithAlpha(128);
+        Assert(deR == 52 && deG == 211 && deB == 153 && deA == 128, "Chart colors should deconstruct into RGBA channels.");
+        Assert(ChartColors.GetNamedColors().Count >= 142, "ChartForgeX should expose the stable System.Drawing/CSS named color set.");
+        Assert(ChartColors.TryGet("RebeccaPurple", out var rebecca) && rebecca.ToHex() == "#663399", "Named color lookup should include modern CSS colors.");
+        Assert(ChartColor.Parse("DarkSlateGrey").ToHex() == ChartColors.DarkSlateGray.ToHex(), "Named color parsing should support grey aliases.");
+        Assert(!ChartColors.TryGet("ActiveCaption", out _), "Dynamic Windows system colors should stay out of the deterministic ChartForgeX named color map.");
+        Assert(!ChartColors.TryGet("ButtonFace", out _), "Dynamic Windows system color aliases should be resolved by host adapters, not the core renderer.");
+        Assert(ChartColors.TryGet("Slate950", out var slate) && slate.ToHex() == ChartColors.Slate950.ToHex(), "Named color lookup should include ChartForgeX design tokens.");
+        Assert(ChartColor.Parse("emerald400").ToHex() == ChartColors.Emerald400.ToHex(), "Named color parsing should support ChartForgeX design tokens.");
+        Assert(ChartColors.GetTokenColors().Count >= 29, "ChartForgeX should expose its design token color set.");
+
+        var tokenPalette = ChartPalettes.FromHex("Slate950", "Blue400", "Emerald400");
+        Assert(tokenPalette[0].ToHex() == ChartColors.Slate950.ToHex() && tokenPalette[2].ToHex() == ChartColors.Emerald400.ToHex(), "Palette parsing should accept ChartForgeX design token names.");
+        Assert(ChartColor.Parse("#34D399").ToHex() == ChartColors.Emerald400.ToHex(), "Color parsing should keep hex support.");
+    }
+}

--- a/ChartForgeX.Tests/SmokeTests/CoreRenderingTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/CoreRenderingTests.cs
@@ -424,18 +424,6 @@ internal static partial class SmokeTests {
         theme.Palette = palette;
         palette[0] = ChartColor.White;
         Assert(theme.Palette[0].R == ChartColor.Black.R && theme.Palette[0].G == ChartColor.Black.G && theme.Palette[0].B == ChartColor.Black.B, "Themes should snapshot assigned palettes instead of retaining caller-owned arrays.");
-        Assert(ChartColors.Emerald400.WithAlpha(172).A == 172, "Named chart colors should support explicit alpha values.");
-        Assert(ChartColors.Emerald400.WithOpacity(0.5).A == 128, "Named chart colors should support opacity helpers.");
-        Assert(ChartColors.Emerald400.WithAlpha(172).ToHexRgba() == "#34D399AC", "Named chart colors should round-trip to RGBA hex.");
-        Assert(ChartColors.GetNamedColors().Count >= 142, "ChartForgeX should expose the stable System.Drawing/CSS named color set.");
-        Assert(ChartColors.TryGet("RebeccaPurple", out var rebecca) && rebecca.ToHex() == "#663399", "Named color lookup should include modern CSS colors.");
-        Assert(ChartColor.Parse("DarkSlateGrey").ToHex() == ChartColors.DarkSlateGray.ToHex(), "Named color parsing should support grey aliases.");
-        Assert(ChartColors.TryGet("Slate950", out var slate) && slate.ToHex() == ChartColors.Slate950.ToHex(), "Named color lookup should include ChartForgeX design tokens.");
-        Assert(ChartColor.Parse("emerald400").ToHex() == ChartColors.Emerald400.ToHex(), "Named color parsing should support ChartForgeX design tokens.");
-        Assert(ChartColors.GetTokenColors().Count >= 29, "ChartForgeX should expose its design token color set.");
-        var tokenPalette = ChartPalettes.FromHex("Slate950", "Blue400", "Emerald400");
-        Assert(tokenPalette[0].ToHex() == ChartColors.Slate950.ToHex() && tokenPalette[2].ToHex() == ChartColors.Emerald400.ToHex(), "Palette parsing should accept ChartForgeX design token names.");
-        Assert(ChartColor.Parse("#34D399").ToHex() == ChartColors.Emerald400.ToHex(), "Color parsing should keep hex support.");
         var pastel = ChartPalettes.Pastel;
         pastel[0] = ChartColor.Black;
         Assert(ChartPalettes.Pastel[0].R != ChartColor.Black.R || ChartPalettes.Pastel[0].G != ChartColor.Black.G || ChartPalettes.Pastel[0].B != ChartColor.Black.B, "Palette presets should return fresh arrays so callers can mutate local copies safely.");

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -13,6 +13,7 @@ internal static partial class SmokeTests {
         ("Mark surface polish stays shared across SVG and PNG", MarkSurfacePolishStaysSharedAcrossSvgAndPng),
         ("SVG fitted text polish stays shared across specialized charts", SvgFittedTextPolishStaysSharedAcrossSpecializedCharts),
         ("Color readability math stays shared across SVG and PNG", ColorReadabilityMathStaysSharedAcrossSvgAndPng),
+        ("Chart color conversions and known names stay deterministic", ChartColorConversionsAndKnownNamesStayDeterministic),
         ("Example app clears generated output before writing", ExampleAppClearsGeneratedOutputBeforeWriting),
         ("Generated examples stay assigned to catalog families", GeneratedExamplesStayAssignedToCatalogFamilies),
         ("SVG markup writer streams escaped elements", SvgMarkupWriterStreamsEscapedElements),

--- a/ChartForgeX/Primitives/ChartColor.cs
+++ b/ChartForgeX/Primitives/ChartColor.cs
@@ -46,6 +46,30 @@ public readonly struct ChartColor {
     public static ChartColor FromRgb(byte r, byte g, byte b) => new(r, g, b, 255);
 
     /// <summary>
+    /// Creates a color from explicit alpha, red, green, and blue channels.
+    /// </summary>
+    /// <param name="a">The alpha channel.</param>
+    /// <param name="r">The red channel.</param>
+    /// <param name="g">The green channel.</param>
+    /// <param name="b">The blue channel.</param>
+    /// <returns>A chart color.</returns>
+    public static ChartColor FromArgb(byte a, byte r, byte g, byte b) => new(r, g, b, a);
+
+    /// <summary>
+    /// Creates a color from a packed 0xAARRGGBB value.
+    /// </summary>
+    /// <param name="argb">The packed ARGB color.</param>
+    /// <returns>A chart color.</returns>
+    public static ChartColor FromArgb(uint argb) => new((byte)(argb >> 16), (byte)(argb >> 8), (byte)argb, (byte)(argb >> 24));
+
+    /// <summary>
+    /// Creates a color from a packed 0xAARRGGBB value.
+    /// </summary>
+    /// <param name="argb">The packed ARGB color.</param>
+    /// <returns>A chart color.</returns>
+    public static ChartColor FromArgb(int argb) => FromArgb(unchecked((uint)argb));
+
+    /// <summary>
     /// Creates a color with an explicit alpha channel.
     /// </summary>
     /// <param name="r">The red channel.</param>
@@ -54,6 +78,13 @@ public readonly struct ChartColor {
     /// <param name="a">The alpha channel.</param>
     /// <returns>A chart color.</returns>
     public static ChartColor FromRgba(byte r, byte g, byte b, byte a) => new(r, g, b, a);
+
+    /// <summary>
+    /// Creates a color from a packed 0xRRGGBBAA value.
+    /// </summary>
+    /// <param name="rgba">The packed RGBA color.</param>
+    /// <returns>A chart color.</returns>
+    public static ChartColor FromRgba(uint rgba) => new((byte)(rgba >> 24), (byte)(rgba >> 16), (byte)(rgba >> 8), (byte)rgba);
 
     /// <summary>
     /// Creates a copy of this color with a different alpha channel.
@@ -101,6 +132,23 @@ public readonly struct ChartColor {
     }
 
     /// <summary>
+    /// Attempts to create a color from #RGB, #RGBA, #RRGGBB, or #RRGGBBAA notation.
+    /// </summary>
+    /// <param name="hex">The hexadecimal color string.</param>
+    /// <param name="color">The parsed chart color.</param>
+    /// <returns>True when parsing succeeds.</returns>
+    public static bool TryFromHex(string? hex, out ChartColor color) {
+        color = default;
+        if (string.IsNullOrWhiteSpace(hex)) return false;
+        try {
+            color = FromHex(hex!);
+            return true;
+        } catch (ArgumentException) {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Parses a named color or a hexadecimal color string.
     /// </summary>
     /// <param name="value">The named color or hexadecimal color string.</param>
@@ -140,6 +188,38 @@ public readonly struct ChartColor {
     /// </summary>
     /// <returns>A CSS-compatible hexadecimal color string with alpha.</returns>
     public string ToHexRgba() => $"#{R:X2}{G:X2}{B:X2}{A:X2}";
+
+    /// <summary>
+    /// Converts the color to a packed 0xAARRGGBB value.
+    /// </summary>
+    /// <returns>The packed ARGB color.</returns>
+    public uint ToArgb() => ((uint)A << 24) | ((uint)R << 16) | ((uint)G << 8) | B;
+
+    /// <summary>
+    /// Converts the color to a packed 0xAARRGGBB signed integer.
+    /// </summary>
+    /// <returns>The packed ARGB color as a signed integer.</returns>
+    public int ToArgbInt32() => unchecked((int)ToArgb());
+
+    /// <summary>
+    /// Converts the color to a packed 0xRRGGBBAA value.
+    /// </summary>
+    /// <returns>The packed RGBA color.</returns>
+    public uint ToRgba() => ((uint)R << 24) | ((uint)G << 16) | ((uint)B << 8) | A;
+
+    /// <summary>
+    /// Deconstructs the color into red, green, blue, and alpha channels.
+    /// </summary>
+    /// <param name="r">The red channel.</param>
+    /// <param name="g">The green channel.</param>
+    /// <param name="b">The blue channel.</param>
+    /// <param name="a">The alpha channel.</param>
+    public void Deconstruct(out byte r, out byte g, out byte b, out byte a) {
+        r = R;
+        g = G;
+        b = B;
+        a = A;
+    }
 
     /// <summary>
     /// Converts the color to a CSS color string.


### PR DESCRIPTION
## Summary
- Add dependency-free `ChartColor` conversion helpers for packed ARGB/RGBA values.
- Add non-throwing hex parsing and channel deconstruction helpers.
- Move color primitive smoke coverage into a dedicated test file and keep dynamic Windows system colors out of the deterministic core color map.

## Why
PowerBGInfo and other consumers need reusable color conversion primitives without pulling `System.Drawing` into ChartForgeX. This keeps ChartForgeX as the shared engine while preserving deterministic color behavior.

## Validation
- `dotnet test .\ChartForgeX.Tests\ChartForgeX.Tests.csproj -c Debug -f net8.0 --no-restore` passed: 452/452.
