### PR TITLE
Move topology HTML assets out of renderers

### DIFF
--- a/ChartForgeX/ChartForgeX.csproj
+++ b/ChartForgeX/ChartForgeX.csproj
@@ -40,6 +40,9 @@
   <ItemGroup>
     <None Include="..\README.nuget.md" Pack="true" PackagePath="README.md" />
     <None Include="..\assets\ChartForgeX.png" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="Topology\Assets\topology.css" LogicalName="ChartForgeX.Topology.Assets.topology.css" />
     <EmbeddedResource Include="Topology\Assets\topology-interaction.js" LogicalName="ChartForgeX.Topology.Assets.topology-interaction.js" />
+    <EmbeddedResource Include="Topology\Assets\topology-icon-stencil-browser.css" LogicalName="ChartForgeX.Topology.Assets.topology-icon-stencil-browser.css" />
+    <EmbeddedResource Include="Topology\Assets\topology-icon-stencil-browser.js" LogicalName="ChartForgeX.Topology.Assets.topology-icon-stencil-browser.js" />
   </ItemGroup>
 </Project>

--- a/ChartForgeX/Topology/Assets/topology-icon-stencil-browser.css
+++ b/ChartForgeX/Topology/Assets/topology-icon-stencil-browser.css
@@ -1,0 +1,32 @@
+body{margin:0;background:#f6f8fb;color:#0f172a;font-family:Inter,Segoe UI,system-ui,sans-serif}
+.cfx-icon-browser{min-height:100vh;padding:24px;box-sizing:border-box}
+.cfx-icon-browser__header{display:flex;gap:24px;align-items:flex-start;justify-content:space-between;max-width:1500px;margin:0 auto 18px}
+.cfx-icon-browser__eyebrow{margin:0 0 6px;color:#2563eb;font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.04em}
+.cfx-icon-browser h1{margin:0;font-size:28px;letter-spacing:0}
+.cfx-icon-browser__subtitle{margin:6px 0 0;max-width:760px;color:#475569;font-size:14px}
+.cfx-icon-browser__search{display:grid;grid-template-columns:minmax(260px,360px) auto;gap:8px 12px;align-items:center}
+.cfx-icon-browser__search input{grid-column:1 / -1;height:40px;border:1px solid #cbd5e1;border-radius:8px;background:white;padding:0 12px;font:500 14px/1 Inter,Segoe UI,system-ui,sans-serif;color:#0f172a;box-shadow:0 8px 20px rgba(15,23,42,.05)}
+.cfx-icon-browser__search span{font-size:13px;font-weight:800;color:#0f172a}
+.cfx-icon-browser__search small{justify-self:end;color:#64748b}
+.cfx-icon-browser__shell{max-width:1500px;margin:0 auto;display:grid;grid-template-columns:240px minmax(0,1fr) 280px;gap:16px;align-items:start}
+.cfx-icon-browser__sidebar,.cfx-icon-browser__inspector{background:#fff;border:1px solid #dbe3ef;border-radius:10px;box-shadow:0 12px 28px rgba(15,23,42,.06);padding:14px;position:sticky;top:16px}
+.cfx-icon-browser__sidebar section+section{margin-top:18px}
+.cfx-icon-browser h2{margin:0 0 10px;font-size:13px}
+.cfx-icon-browser button{width:100%;height:34px;border:1px solid transparent;border-radius:7px;background:transparent;color:#334155;font:700 12px/1 Inter,Segoe UI,system-ui,sans-serif;display:flex;align-items:center;justify-content:space-between;gap:8px;padding:0 10px;cursor:pointer;text-align:left}
+.cfx-icon-browser button:hover,.cfx-icon-browser button[aria-pressed='true']{background:#eff6ff;border-color:#bfdbfe;color:#1d4ed8}
+.cfx-icon-browser button small{color:#64748b}
+.cfx-icon-browser__workspace{min-width:0}
+.cfx-icon-browser__filters{display:flex;gap:8px;align-items:center;overflow:auto;padding:0 0 10px}
+.cfx-icon-browser__filters button{width:auto;white-space:nowrap;background:#fff;border-color:#dbe3ef}
+.cfx-icon-browser__palette{background:#fff;border:1px solid #dbe3ef;border-radius:10px;padding:12px;box-shadow:0 12px 28px rgba(15,23,42,.06);overflow:auto}
+.cfx-icon-browser__palette svg{min-width:980px}
+.cfx-icon-browser__palette [data-cfx-role='topology-node']{cursor:pointer}
+.cfx-icon-browser__palette .cfx-icon-browser-hidden{display:none}
+.cfx-icon-browser__palette .cfx-icon-browser-selected{filter:drop-shadow(0 12px 18px rgba(37,99,235,.25))}
+.cfx-icon-browser__inspector h2{font-size:18px;margin:0 0 14px}
+.cfx-icon-browser__inspector dl{display:grid;grid-template-columns:82px minmax(0,1fr);gap:8px 10px;margin:0}
+.cfx-icon-browser__inspector dt{color:#64748b;font-size:12px}
+.cfx-icon-browser__inspector dd{margin:0;color:#0f172a;font-size:12px;font-weight:700;overflow-wrap:anywhere}
+.cfx-icon-browser__hint{margin:16px 0 0;color:#64748b;font-size:12px;line-height:1.45}
+@media(max-width:1100px){.cfx-icon-browser__header{display:block}.cfx-icon-browser__search{margin-top:14px}.cfx-icon-browser__shell{grid-template-columns:1fr}.cfx-icon-browser__sidebar,.cfx-icon-browser__inspector{position:static}.cfx-icon-browser__sidebar{display:grid;grid-template-columns:1fr 1fr;gap:14px}.cfx-icon-browser__sidebar section+section{margin-top:0}}
+@media(max-width:640px){.cfx-icon-browser{padding:16px}.cfx-icon-browser__sidebar{grid-template-columns:1fr}.cfx-icon-browser__search{grid-template-columns:1fr}.cfx-icon-browser h1{font-size:24px}}

--- a/ChartForgeX/Topology/Assets/topology-icon-stencil-browser.js
+++ b/ChartForgeX/Topology/Assets/topology-icon-stencil-browser.js
@@ -1,0 +1,118 @@
+(() => {
+  const root = document.querySelector('[data-cfx-icon-browser="true"]');
+  if (!root) return;
+  const search = root.querySelector('[data-cfx-icon-search]');
+  const count = root.querySelector('[data-cfx-icon-count]');
+  const nodes = Array.from(root.querySelectorAll('[data-cfx-role="topology-node"]'));
+  const badges = Array.from(root.querySelectorAll('[data-cfx-role="topology-node-status"]'));
+  const groups = Array.from(root.querySelectorAll('[data-cfx-role="topology-group"]'));
+  const state = { vendor: '', pack: '', category: '', search: search ? search.value.toLowerCase().trim() : '' };
+  const attr = (element, name) => element.getAttribute(name) || '';
+  const meta = (element, key) => attr(element, 'data-cfx-meta-' + key);
+  const detail = name => root.querySelector('[data-cfx-icon-detail="' + name + '"]');
+  const setText = (name, value) => { const target = detail(name); if (target) target.textContent = value || '-'; };
+  const textFor = element => [
+    attr(element, 'data-node-icon-id'),
+    attr(element, 'data-node-icon-label'),
+    attr(element, 'data-node-icon-pack'),
+    attr(element, 'data-node-icon-shape'),
+    attr(element, 'data-node-kind'),
+    meta(element, 'category'),
+    meta(element, 'vendor'),
+    meta(element, 'pack-label'),
+    meta(element, 'icon-tags'),
+    meta(element, 'icon-source-path'),
+    meta(element, 'pack-source-url'),
+    meta(element, 'pack-source-license')
+  ].join(' ').toLowerCase();
+  const nodeVisible = node => {
+    if (state.vendor && meta(node, 'vendor') !== state.vendor) return false;
+    if (state.pack && attr(node, 'data-node-icon-pack') !== state.pack) return false;
+    if (state.category && meta(node, 'category') !== state.category) return false;
+    return !state.search || textFor(node).includes(state.search);
+  };
+  const syncButtons = kind => {
+    root.querySelectorAll('[data-cfx-icon-filter="' + kind + '"]').forEach(button => {
+      button.setAttribute('aria-pressed', attr(button, 'data-cfx-icon-filter-value') === state[kind] ? 'true' : 'false');
+    });
+  };
+  const apply = () => {
+    let visible = 0;
+    let firstVisible = null;
+    const visibleNodeIds = new Set();
+    const visibleByPack = new Set();
+    for (const node of nodes) {
+      const show = nodeVisible(node);
+      node.classList.toggle('cfx-icon-browser-hidden', !show);
+      if (show) {
+        visible++;
+        if (!firstVisible) firstVisible = node;
+        visibleNodeIds.add(attr(node, 'data-node-id'));
+        visibleByPack.add(attr(node, 'data-node-icon-pack'));
+      }
+    }
+    for (const badge of badges) badge.classList.toggle('cfx-icon-browser-hidden', !visibleNodeIds.has(attr(badge, 'data-node-id')));
+    for (const group of groups) {
+      const pack = attr(group, 'data-group-icon-id').split(':')[0] || meta(group, 'packid');
+      group.classList.toggle('cfx-icon-browser-hidden', pack && !visibleByPack.has(pack));
+    }
+    if (count) count.textContent = visible + ' icons';
+    if (firstVisible && (state.search || state.vendor || state.pack || state.category)) {
+      window.requestAnimationFrame(() => firstVisible.scrollIntoView({ block: 'nearest', inline: 'center' }));
+    }
+  };
+  const select = node => {
+    nodes.forEach(item => item.classList.toggle('cfx-icon-browser-selected', item === node));
+    const payload = {
+      iconId: attr(node, 'data-node-icon-id'),
+      iconPack: attr(node, 'data-node-icon-pack'),
+      iconLabel: attr(node, 'data-node-icon-label'),
+      iconShape: attr(node, 'data-node-icon-shape'),
+      iconArtwork: attr(node, 'data-node-icon-artwork') || meta(node, 'icon-artwork'),
+      nodeKind: attr(node, 'data-node-kind'),
+      category: meta(node, 'category'),
+      vendor: meta(node, 'vendor'),
+      packLabel: meta(node, 'pack-label'),
+      tags: meta(node, 'icon-tags'),
+      sourcePath: meta(node, 'icon-source-path'),
+      sourceUrl: meta(node, 'pack-source-url'),
+      sourceRevision: meta(node, 'icon-source-revision') || meta(node, 'pack-source-revision'),
+      sourceLicense: meta(node, 'pack-source-license'),
+      sourceLicenseUrl: meta(node, 'pack-source-licenseurl')
+    };
+    setText('label', payload.iconLabel);
+    setText('id', payload.iconId);
+    setText('pack', payload.packLabel || payload.iconPack);
+    setText('vendor', payload.vendor);
+    setText('category', payload.category);
+    setText('shape', payload.iconShape);
+    setText('artwork', payload.iconArtwork || 'fallback shape');
+    setText('source', payload.sourcePath || payload.sourceUrl);
+    setText('revision', payload.sourceRevision);
+    setText('license', payload.sourceLicense);
+    root.dispatchEvent(new CustomEvent('cfx-icon-browser-select', { bubbles: true, detail: payload }));
+  };
+  root.querySelectorAll('[data-cfx-icon-filter]').forEach(button => {
+    button.addEventListener('click', () => {
+      const kind = attr(button, 'data-cfx-icon-filter');
+      state[kind] = attr(button, 'data-cfx-icon-filter-value');
+      syncButtons(kind);
+      apply();
+    });
+  });
+  if (search) search.addEventListener('input', () => {
+    state.search = search.value.toLowerCase().trim();
+    apply();
+  });
+  nodes.forEach(node => {
+    node.setAttribute('tabindex', '0');
+    node.addEventListener('click', () => select(node));
+    node.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        select(node);
+      }
+    });
+  });
+  apply();
+})();

--- a/ChartForgeX/Topology/Assets/topology.css
+++ b/ChartForgeX/Topology/Assets/topology.css
@@ -1,0 +1,97 @@
+.cfx-topology-wrapper{margin:0 auto;overflow:visible}
+.cfx-topology-wrapper{--cfx-topology-control-bg:rgba(255,255,255,.94);--cfx-topology-control-bg-hover:#eff6ff;--cfx-topology-control-text:#1e3a8a;--cfx-topology-control-muted:#475569;--cfx-topology-control-border:rgba(37,99,235,.28);--cfx-topology-control-border-hover:var(--cfx-topology-accent,#2563eb);--cfx-topology-control-shadow:0 10px 24px rgba(15,23,42,.12);--cfx-topology-control-panel-bg:rgba(255,255,255,.78);--cfx-topology-control-focus:0 0 0 3px rgba(37,99,235,.18);--cfx-topology-accent:#2563eb}
+@media (prefers-color-scheme:dark){.cfx-topology-wrapper{--cfx-topology-control-bg:rgba(15,23,42,.9);--cfx-topology-control-bg-hover:rgba(37,99,235,.24);--cfx-topology-control-text:#dbeafe;--cfx-topology-control-muted:#a8b8cc;--cfx-topology-control-border:rgba(148,163,184,.32);--cfx-topology-control-shadow:0 12px 28px rgba(0,0,0,.35);--cfx-topology-control-panel-bg:rgba(15,23,42,.74);--cfx-topology-control-focus:0 0 0 3px rgba(96,165,250,.26);--cfx-topology-accent:#60a5fa}}
+.cfx-topology-viewport{position:relative}
+.cfx-topology-wrapper svg{max-width:100%;height:auto;display:block;overflow:visible}
+.cfx-topology-wrapper[data-cfx-viewport-controls='true'] .cfx-topology-viewport{overflow:hidden;touch-action:none}
+.cfx-topology-wrapper[data-cfx-viewport-controls='true'] .cfx-topology-viewport>svg{transform:translate(var(--cfx-topology-pan-x,0),var(--cfx-topology-pan-y,0)) scale(var(--cfx-topology-zoom,1));transform-origin:center center;transition:transform .12s ease;will-change:transform}
+.cfx-topology-controls{position:absolute;z-index:5;top:12px;left:12px;display:grid;gap:6px}
+.cfx-topology-wrapper[data-cfx-controls-placement='top-right'] .cfx-topology-controls{left:auto;right:12px}
+.cfx-topology-wrapper[data-cfx-controls-placement='bottom-left'] .cfx-topology-controls{top:auto;bottom:12px}
+.cfx-topology-wrapper[data-cfx-controls-placement='bottom-right'] .cfx-topology-controls{top:auto;right:12px;bottom:12px;left:auto}
+.cfx-topology-wrapper[data-cfx-controls-placement='left-rail'] .cfx-topology-controls,.cfx-topology-wrapper[data-cfx-controls-placement='right-rail'] .cfx-topology-controls{top:12px;bottom:auto;display:flex;flex-direction:column}
+.cfx-topology-wrapper[data-cfx-controls-placement='right-rail'] .cfx-topology-controls{right:12px;left:auto}
+.cfx-topology-controls button,.cfx-topology-scenarios button{min-width:34px;height:34px;border:1px solid rgba(37,99,235,.28);border-radius:6px;background:rgba(255,255,255,.92);color:#1e3a8a;cursor:pointer;font:700 12px/1 __CFX_FONT_FAMILY__;box-shadow:0 8px 18px rgba(15,23,42,.1)}
+.cfx-topology-scenarios{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 10px;align-items:center}
+.cfx-topology-scenarios button{height:32px;padding:0 12px;border-color:color-mix(in srgb,var(--cfx-topology-scenario-color,#2563eb) 32%,transparent);color:#0f172a}
+.cfx-topology-scenarios button:before{content:'';display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:7px;background:var(--cfx-topology-scenario-color,#64748b)}
+.cfx-topology-scenarios label{display:inline-flex;align-items:center;gap:7px;min-height:30px;padding:0 10px;border:1px solid var(--cfx-topology-control-border);border-radius:6px;background:var(--cfx-topology-control-bg);color:var(--cfx-topology-control-text);cursor:pointer;font:700 12px/1 __CFX_FONT_FAMILY__}
+.cfx-topology-scenarios input[type='checkbox']{width:14px;height:14px;margin:0;accent-color:var(--cfx-topology-scenario-color,var(--cfx-topology-accent,#2563eb))}
+.cfx-topology-scenarios label:has(input:checked){border-color:var(--cfx-topology-scenario-color,var(--cfx-topology-accent,#2563eb));background:var(--cfx-topology-control-bg-hover)}
+.cfx-topology-scenario-panel{display:grid;gap:8px;max-width:760px;margin:0 0 12px;padding:10px 12px;border:1px solid rgba(148,163,184,.42);border-radius:8px;background:rgba(255,255,255,.88);box-shadow:0 10px 24px rgba(15,23,42,.07);color:#0f172a}
+.cfx-topology-scenario-panel__summary{display:grid;gap:2px}
+.cfx-topology-scenario-panel__title{font:700 14px/1.25 __CFX_FONT_FAMILY__;color:var(--cfx-topology-scenario-color,#0f172a)}
+.cfx-topology-scenario-panel__meta{font:500 12px/1.35 __CFX_FONT_FAMILY__;color:#475569}
+.cfx-topology-scenario-panel__controls{display:flex;flex-wrap:wrap;gap:6px}
+.cfx-topology-scenario-panel__controls button{min-height:28px;padding:4px 9px;border:1px solid rgba(148,163,184,.4);border-radius:6px;background:#fff;color:#0f172a;cursor:pointer;font:700 11px/1 __CFX_FONT_FAMILY__}
+.cfx-topology-scenario-panel__controls button:hover,.cfx-topology-scenario-panel__controls button:focus-visible,.cfx-topology-scenario-panel__controls button[aria-pressed='true']{border-color:var(--cfx-topology-scenario-color,#2563eb);color:var(--cfx-topology-scenario-color,#2563eb);background:#eff6ff}
+.cfx-topology-scenario-panel__steps{display:flex;flex-wrap:wrap;gap:6px;margin:0;padding:0;list-style:none}
+.cfx-topology-scenario-panel__steps li{display:flex;align-items:center;gap:6px;min-height:24px;padding:3px 8px;border:1px solid rgba(148,163,184,.34);border-radius:6px;background:rgba(248,250,252,.82);cursor:pointer;font:700 11px/1.2 __CFX_FONT_FAMILY__;color:#0f172a}
+.cfx-topology-scenario-panel__steps li:before{content:attr(data-cfx-scenario-step-index);display:inline-grid;place-items:center;width:16px;height:16px;border-radius:50%;background:var(--cfx-topology-scenario-color,#2563eb);color:#fff;font-size:10px}
+.cfx-topology-scenario-panel__steps li[aria-current='step']{border-color:var(--cfx-topology-scenario-color,#2563eb);background:#eff6ff;color:#0f172a}
+.cfx-topology-force-controls{display:grid;gap:8px;margin:0 0 12px;padding:10px 12px;border:1px solid rgba(148,163,184,.42);border-radius:8px;background:rgba(255,255,255,.9);box-shadow:0 10px 24px rgba(15,23,42,.07);color:#0f172a}
+.cfx-topology-force-controls__row{display:grid;grid-template-columns:minmax(180px,1fr) minmax(118px,.25fr) minmax(140px,.35fr);gap:8px}
+.cfx-topology-force-controls input[type='search'],.cfx-topology-force-controls select{min-width:0;height:32px;border:1px solid rgba(148,163,184,.48);border-radius:6px;background:#fff;color:#0f172a;padding:0 9px;font:600 12px/1 __CFX_FONT_FAMILY__}
+.cfx-topology-force-controls__toggles{display:flex;flex-wrap:wrap;gap:8px 12px;align-items:center}
+.cfx-topology-force-controls label{display:inline-flex;gap:6px;align-items:center;font:700 11px/1 __CFX_FONT_FAMILY__;color:#334155}
+.cfx-topology-force-controls output{font:600 11px/1.35 __CFX_FONT_FAMILY__;color:#64748b}
+.cfx-topology-controls{display:flex;flex-wrap:wrap;align-items:center;gap:4px;padding:4px;border:1px solid var(--cfx-topology-control-border);border-radius:8px;background:var(--cfx-topology-control-panel-bg);box-shadow:var(--cfx-topology-control-shadow);backdrop-filter:blur(10px)}
+.cfx-topology-wrapper[data-cfx-viewport-controls='true'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-export-controls='true'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-fullscreen-control='true'] .cfx-topology-viewport{padding-top:48px}
+.cfx-topology-wrapper[data-cfx-controls-placement='left-rail'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-controls-placement='right-rail'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-controls-placement='bottom-left'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-controls-placement='bottom-right'] .cfx-topology-viewport{padding-top:0}
+.cfx-topology-wrapper[data-cfx-controls-placement='left-rail'] .cfx-topology-viewport{padding-left:48px}
+.cfx-topology-wrapper[data-cfx-controls-placement='right-rail'] .cfx-topology-viewport{padding-right:48px}
+.cfx-topology-controls button,.cfx-topology-scenarios button,.cfx-topology-scenario-panel__controls button{appearance:none;display:inline-flex;align-items:center;justify-content:center;gap:6px;min-width:32px;height:32px;border:1px solid var(--cfx-topology-control-border);border-radius:6px;background:var(--cfx-topology-control-bg);color:var(--cfx-topology-control-text);box-shadow:none;cursor:pointer;font:700 12px/1 __CFX_FONT_FAMILY__;letter-spacing:0;transition:background-color .14s ease,border-color .14s ease,color .14s ease,box-shadow .14s ease,transform .14s ease}
+.cfx-topology-controls button svg{width:16px;height:16px;display:block;fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;pointer-events:none}
+.cfx-topology-controls button span{font-size:11px;line-height:1;pointer-events:none}
+.cfx-topology-controls button[data-cfx-topology-export],.cfx-topology-scenarios button{min-width:42px;padding:0 10px}
+.cfx-topology-controls button:hover,.cfx-topology-controls button:focus-visible,.cfx-topology-controls button[aria-pressed='true'],.cfx-topology-scenarios button:hover,.cfx-topology-scenarios button:focus-visible,.cfx-topology-scenarios button[aria-pressed='true'],.cfx-topology-scenario-panel__controls button:hover,.cfx-topology-scenario-panel__controls button:focus-visible,.cfx-topology-scenario-panel__controls button[aria-pressed='true']{border-color:var(--cfx-topology-control-border-hover);color:var(--cfx-topology-control-text);background:var(--cfx-topology-control-bg-hover);box-shadow:var(--cfx-topology-control-focus)}
+.cfx-topology-controls button:active,.cfx-topology-scenarios button:active,.cfx-topology-scenario-panel__controls button:active{transform:translateY(1px)}
+.cfx-topology-wrapper:fullscreen{width:100vw!important;max-width:none!important;height:100vh!important;margin:0!important;padding:16px;box-sizing:border-box;background:var(--cfx-topology-background,#fff);overflow:auto}
+.cfx-topology-wrapper:fullscreen .cfx-topology-viewport{min-height:calc(100vh - 32px)}
+.cfx-topology-scenario-panel,.cfx-topology-force-controls{border-color:var(--cfx-topology-control-border);background:var(--cfx-topology-control-panel-bg);color:var(--cfx-topology-control-text);box-shadow:var(--cfx-topology-control-shadow);backdrop-filter:blur(10px)}
+.cfx-topology-selection-panel{position:absolute;z-index:4;right:12px;top:12px;bottom:12px;width:min(320px,calc(100% - 24px));display:grid;align-content:start;gap:10px;padding:12px;border:1px solid var(--cfx-topology-control-border);border-radius:8px;background:var(--cfx-topology-control-panel-bg);color:var(--cfx-topology-control-text);box-shadow:var(--cfx-topology-control-shadow);backdrop-filter:blur(12px);overflow:auto}
+.cfx-topology-selection-panel[hidden]{display:none}
+.cfx-topology-selection-panel__head{display:grid;gap:5px;padding-bottom:8px;border-bottom:1px solid var(--cfx-topology-control-border)}
+.cfx-topology-selection-panel__eyebrow{font:700 10px/1 __CFX_FONT_FAMILY__;text-transform:uppercase;letter-spacing:.04em;color:var(--cfx-topology-control-muted)}
+.cfx-topology-selection-panel__title{font:700 14px/1.25 __CFX_FONT_FAMILY__;color:var(--cfx-topology-control-text)}
+.cfx-topology-selection-panel__status{justify-self:start;min-height:20px;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--cfx-topology-selection-status-color,var(--cfx-topology-accent,#2563eb)) 13%,transparent);color:var(--cfx-topology-selection-status-color,var(--cfx-topology-control-text));font:800 10px/1 __CFX_FONT_FAMILY__}
+.cfx-topology-selection-panel__facts{display:grid;grid-template-columns:auto 1fr;gap:6px 10px;margin:0;font:600 11px/1.35 __CFX_FONT_FAMILY__;color:var(--cfx-topology-control-text)}
+.cfx-topology-selection-panel__facts dt{color:var(--cfx-topology-control-muted)}
+.cfx-topology-selection-panel__facts dd{margin:0;min-width:0;overflow-wrap:anywhere;text-align:right}
+.cfx-topology-selection-panel__meta,.cfx-topology-selection-panel__related{display:grid;gap:6px;font:600 11px/1.35 __CFX_FONT_FAMILY__;color:var(--cfx-topology-control-text)}
+.cfx-topology-selection-panel__meta:empty,.cfx-topology-selection-panel__related:empty{display:none}
+.cfx-topology-selection-panel__row{display:flex;justify-content:space-between;gap:10px;padding:6px 0;border-top:1px solid color-mix(in srgb,var(--cfx-topology-control-border) 72%,transparent)}
+.cfx-topology-selection-panel__row span:first-child{color:var(--cfx-topology-control-muted)}
+.cfx-topology-selection-panel__row span:last-child{min-width:0;text-align:right;overflow-wrap:anywhere}
+.cfx-topology-scenario-panel__meta,.cfx-topology-force-controls label,.cfx-topology-force-controls output{color:var(--cfx-topology-control-muted)}
+.cfx-topology-force-controls input[type='search'],.cfx-topology-force-controls select{border-color:var(--cfx-topology-control-border);background:var(--cfx-topology-control-bg);color:var(--cfx-topology-control-text)}
+.cfx-topology-controls button:hover,.cfx-topology-controls button:focus-visible,.cfx-topology-controls button[aria-pressed='true'],.cfx-topology-scenarios button:hover,.cfx-topology-scenarios button:focus-visible,.cfx-topology-scenarios button[aria-pressed='true']{border-color:var(--cfx-topology-scenario-color,var(--cfx-topology-control-border-hover,#2563eb));color:var(--cfx-topology-control-text,#0f172a);background:var(--cfx-topology-control-bg-hover,#eff6ff)}
+.cfx-topology-wrapper[data-cfx-viewport-controls='true'] .cfx-topology-viewport{cursor:grab}
+.cfx-topology-wrapper[data-cfx-viewport-controls='true'][data-cfx-topology-dragging='true'] .cfx-topology-viewport{cursor:grabbing}
+.cfx-topology-wrapper [data-cfx-role='topology-node'],.cfx-topology-wrapper [data-cfx-role='topology-edge'],.cfx-topology-wrapper [data-cfx-role='topology-group']{cursor:pointer}
+.cfx-topology-wrapper .cfx-topology-html-selected{filter:drop-shadow(0 10px 18px rgba(37,99,235,.22))}
+.cfx-topology-wrapper .cfx-topology-html-muted{opacity:.32}
+.cfx-topology-wrapper .cfx-topology-html-related{opacity:1}
+.cfx-topology-wrapper .cfx-topology-html-hovered{filter:drop-shadow(0 8px 16px rgba(15,23,42,.16))}
+.cfx-topology-wrapper .cfx-topology-html-hover-muted{opacity:.42}
+.cfx-topology-wrapper .cfx-topology-html-hover-related{opacity:1}
+.cfx-topology-wrapper .cfx-topology-html-scenario-muted{opacity:.18}
+.cfx-topology-wrapper .cfx-topology-html-scenario-active{opacity:1;filter:drop-shadow(0 10px 18px rgba(37,99,235,.18))}
+.cfx-topology-wrapper .cfx-topology-html-scenario-active .cfx-topology__edge{stroke:var(--cfx-topology-active-scenario-color,#2563eb)!important;stroke-width:5!important}
+.cfx-topology-wrapper .cfx-topology-html-scenario-active .cfx-topology__node-card{stroke:var(--cfx-topology-active-scenario-color,#2563eb)!important;stroke-width:2.4!important}
+.cfx-topology-wrapper .cfx-topology-html-scenario-preview-muted{opacity:.34}
+.cfx-topology-wrapper .cfx-topology-html-scenario-preview{opacity:1;filter:drop-shadow(0 8px 14px rgba(15,23,42,.16))}
+.cfx-topology-wrapper .cfx-topology-html-scenario-preview .cfx-topology__edge{stroke:var(--cfx-topology-preview-scenario-color,#2563eb)!important;stroke-width:4!important}
+.cfx-topology-wrapper .cfx-topology-html-scenario-preview .cfx-topology__node-card{stroke:var(--cfx-topology-preview-scenario-color,#2563eb)!important;stroke-width:2!important}
+.cfx-topology-wrapper .cfx-topology-html-scenario-step-muted{opacity:.38}
+.cfx-topology-wrapper .cfx-topology-html-scenario-step-active{opacity:1;filter:drop-shadow(0 10px 18px rgba(15,23,42,.2))}
+.cfx-topology-wrapper .cfx-topology-html-scenario-step-active .cfx-topology__edge{stroke-width:6!important}
+.cfx-topology-wrapper .cfx-topology-html-scenario-step-active .cfx-topology__node-card{stroke-width:3!important}
+.cfx-topology-wrapper .cfx-topology-html-force-hidden{display:none!important}
+.cfx-topology-wrapper .cfx-topology-html-force-faded{opacity:.12!important}
+.cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-muted,.cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-hover-muted{opacity:.06!important}
+.cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-related .cfx-topology__edge,.cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-hover-related .cfx-topology__edge{opacity:.92!important;stroke-width:3.2!important}
+.cfx-topology-wrapper[data-cfx-force-focus='true'] [data-cfx-role='topology-edge-label'].cfx-topology-html-force-focus-label{display:block!important;opacity:1!important}
+.cfx-topology-wrapper[data-cfx-force-moving-edges='true'] .cfx-topology-html-force-moving .cfx-topology__edge,.cfx-topology-wrapper[data-cfx-force-moving-edges='true'] .cfx-topology-html-force-moving .cfx-topology__edge--premium-layer{opacity:.08!important}
+.cfx-topology-wrapper[data-cfx-force-moving-edges='true'] [data-cfx-role='topology-edge-label']{display:none!important}
+@media (max-width:720px){.cfx-topology-force-controls__row{grid-template-columns:1fr}.cfx-topology-force-controls{padding:9px}.cfx-topology-selection-panel{top:auto;left:12px;max-height:42%;width:auto}}

--- a/ChartForgeX/Topology/TopologyHtmlAssets.cs
+++ b/ChartForgeX/Topology/TopologyHtmlAssets.cs
@@ -5,11 +5,20 @@ namespace ChartForgeX.Topology;
 
 internal static class TopologyHtmlAssets
 {
+    private const string StyleResourceName = "ChartForgeX.Topology.Assets.topology.css";
     private const string InteractionScriptResourceName = "ChartForgeX.Topology.Assets.topology-interaction.js";
+    private const string IconStencilBrowserStyleResourceName = "ChartForgeX.Topology.Assets.topology-icon-stencil-browser.css";
+    private const string IconStencilBrowserScriptResourceName = "ChartForgeX.Topology.Assets.topology-icon-stencil-browser.js";
 
+    private static readonly Lazy<string> StyleResource = new Lazy<string>(() => ReadResource(StyleResourceName));
     private static readonly Lazy<string> InteractionScriptResource = new Lazy<string>(() => ReadResource(InteractionScriptResourceName));
+    private static readonly Lazy<string> IconStencilBrowserStyleResource = new Lazy<string>(() => ReadResource(IconStencilBrowserStyleResourceName));
+    private static readonly Lazy<string> IconStencilBrowserScriptResource = new Lazy<string>(() => ReadResource(IconStencilBrowserScriptResourceName));
 
+    internal static string Style => StyleResource.Value;
     internal static string InteractionScript => InteractionScriptResource.Value;
+    internal static string IconStencilBrowserStyle => IconStencilBrowserStyleResource.Value;
+    internal static string IconStencilBrowserScript => IconStencilBrowserScriptResource.Value;
 
     private static string ReadResource(string resourceName)
     {

--- a/ChartForgeX/Topology/TopologyHtmlRenderer.cs
+++ b/ChartForgeX/Topology/TopologyHtmlRenderer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using ChartForgeX.Html;
 using static ChartForgeX.Topology.TopologyRenderPrimitives;
 
@@ -273,147 +272,18 @@ public sealed partial class TopologyHtmlRenderer {
     }
 
     private static string StyleSheet(string cssPrefix, string fontFamily, string background, bool includePageShell = true) {
-        var stylesheet = new StringBuilder();
+        var stylesheet = string.Empty;
         if (includePageShell) {
-            stylesheet.Append(HtmlSurfacePolish.ReportBodyCss(background, fontFamily, "24px"));
+            stylesheet += HtmlSurfacePolish.ReportBodyCss(background, fontFamily, "24px");
         }
 
-        stylesheet
-            .Append(".cfx-topology-wrapper{margin:0 auto;overflow:visible}")
-            .Append(".cfx-topology-wrapper{--cfx-topology-control-bg:rgba(255,255,255,.94);--cfx-topology-control-bg-hover:#eff6ff;--cfx-topology-control-text:#1e3a8a;--cfx-topology-control-muted:#475569;--cfx-topology-control-border:rgba(37,99,235,.28);--cfx-topology-control-border-hover:var(--cfx-topology-accent,#2563eb);--cfx-topology-control-shadow:0 10px 24px rgba(15,23,42,.12);--cfx-topology-control-panel-bg:rgba(255,255,255,.78);--cfx-topology-control-focus:0 0 0 3px rgba(37,99,235,.18);--cfx-topology-accent:#2563eb}")
-            .Append("@media (prefers-color-scheme:dark){.cfx-topology-wrapper{--cfx-topology-control-bg:rgba(15,23,42,.9);--cfx-topology-control-bg-hover:rgba(37,99,235,.24);--cfx-topology-control-text:#dbeafe;--cfx-topology-control-muted:#a8b8cc;--cfx-topology-control-border:rgba(148,163,184,.32);--cfx-topology-control-shadow:0 12px 28px rgba(0,0,0,.35);--cfx-topology-control-panel-bg:rgba(15,23,42,.74);--cfx-topology-control-focus:0 0 0 3px rgba(96,165,250,.26);--cfx-topology-accent:#60a5fa}}")
-            .Append(".cfx-topology-viewport{position:relative}")
-            .Append(".cfx-topology-wrapper svg{max-width:100%;height:auto;display:block;overflow:visible}")
-            .Append(".cfx-topology-wrapper[data-cfx-viewport-controls='true'] .cfx-topology-viewport{overflow:hidden;touch-action:none}")
-            .Append(".cfx-topology-wrapper[data-cfx-viewport-controls='true'] .cfx-topology-viewport>svg{transform:translate(var(--cfx-topology-pan-x,0),var(--cfx-topology-pan-y,0)) scale(var(--cfx-topology-zoom,1));transform-origin:center center;transition:transform .12s ease;will-change:transform}")
-            .Append(".cfx-topology-controls{position:absolute;z-index:5;top:12px;left:12px;display:grid;gap:6px}")
-            .Append(".cfx-topology-wrapper[data-cfx-controls-placement='top-right'] .cfx-topology-controls{left:auto;right:12px}")
-            .Append(".cfx-topology-wrapper[data-cfx-controls-placement='bottom-left'] .cfx-topology-controls{top:auto;bottom:12px}")
-            .Append(".cfx-topology-wrapper[data-cfx-controls-placement='bottom-right'] .cfx-topology-controls{top:auto;right:12px;bottom:12px;left:auto}")
-            .Append(".cfx-topology-wrapper[data-cfx-controls-placement='left-rail'] .cfx-topology-controls,.cfx-topology-wrapper[data-cfx-controls-placement='right-rail'] .cfx-topology-controls{top:12px;bottom:auto;display:flex;flex-direction:column}")
-            .Append(".cfx-topology-wrapper[data-cfx-controls-placement='right-rail'] .cfx-topology-controls{right:12px;left:auto}")
-            .Append(".cfx-topology-controls button,.cfx-topology-scenarios button{min-width:34px;height:34px;border:1px solid rgba(37,99,235,.28);border-radius:6px;background:rgba(255,255,255,.92);color:#1e3a8a;cursor:pointer;font:700 12px/1 ")
-            .Append(fontFamily)
-            .Append(";box-shadow:0 8px 18px rgba(15,23,42,.1)}")
-            .Append(".cfx-topology-scenarios{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 10px;align-items:center}")
-            .Append(".cfx-topology-scenarios button{height:32px;padding:0 12px;border-color:color-mix(in srgb,var(--cfx-topology-scenario-color,#2563eb) 32%,transparent);color:#0f172a}")
-            .Append(".cfx-topology-scenarios button:before{content:'';display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:7px;background:var(--cfx-topology-scenario-color,#64748b)}")
-            .Append(".cfx-topology-scenarios label{display:inline-flex;align-items:center;gap:7px;min-height:30px;padding:0 10px;border:1px solid var(--cfx-topology-control-border);border-radius:6px;background:var(--cfx-topology-control-bg);color:var(--cfx-topology-control-text);cursor:pointer;font:700 12px/1 ")
-            .Append(fontFamily)
-            .Append("}")
-            .Append(".cfx-topology-scenarios input[type='checkbox']{width:14px;height:14px;margin:0;accent-color:var(--cfx-topology-scenario-color,var(--cfx-topology-accent,#2563eb))}")
-            .Append(".cfx-topology-scenarios label:has(input:checked){border-color:var(--cfx-topology-scenario-color,var(--cfx-topology-accent,#2563eb));background:var(--cfx-topology-control-bg-hover)}")
-            .Append(".cfx-topology-scenario-panel{display:grid;gap:8px;max-width:760px;margin:0 0 12px;padding:10px 12px;border:1px solid rgba(148,163,184,.42);border-radius:8px;background:rgba(255,255,255,.88);box-shadow:0 10px 24px rgba(15,23,42,.07);color:#0f172a}")
-            .Append(".cfx-topology-scenario-panel__summary{display:grid;gap:2px}")
-            .Append(".cfx-topology-scenario-panel__title{font:700 14px/1.25 ")
-            .Append(fontFamily)
-            .Append(";color:var(--cfx-topology-scenario-color,#0f172a)}")
-            .Append(".cfx-topology-scenario-panel__meta{font:500 12px/1.35 ")
-            .Append(fontFamily)
-            .Append(";color:#475569}")
-            .Append(".cfx-topology-scenario-panel__controls{display:flex;flex-wrap:wrap;gap:6px}")
-            .Append(".cfx-topology-scenario-panel__controls button{min-height:28px;padding:4px 9px;border:1px solid rgba(148,163,184,.4);border-radius:6px;background:#fff;color:#0f172a;cursor:pointer;font:700 11px/1 ")
-            .Append(fontFamily)
-            .Append("}")
-            .Append(".cfx-topology-scenario-panel__controls button:hover,.cfx-topology-scenario-panel__controls button:focus-visible,.cfx-topology-scenario-panel__controls button[aria-pressed='true']{border-color:var(--cfx-topology-scenario-color,#2563eb);color:var(--cfx-topology-scenario-color,#2563eb);background:#eff6ff}")
-            .Append(".cfx-topology-scenario-panel__steps{display:flex;flex-wrap:wrap;gap:6px;margin:0;padding:0;list-style:none}")
-            .Append(".cfx-topology-scenario-panel__steps li{display:flex;align-items:center;gap:6px;min-height:24px;padding:3px 8px;border:1px solid rgba(148,163,184,.34);border-radius:6px;background:rgba(248,250,252,.82);cursor:pointer;font:700 11px/1.2 ")
-            .Append(fontFamily)
-            .Append(";color:#0f172a}")
-            .Append(".cfx-topology-scenario-panel__steps li:before{content:attr(data-cfx-scenario-step-index);display:inline-grid;place-items:center;width:16px;height:16px;border-radius:50%;background:var(--cfx-topology-scenario-color,#2563eb);color:#fff;font-size:10px}")
-            .Append(".cfx-topology-scenario-panel__steps li[aria-current='step']{border-color:var(--cfx-topology-scenario-color,#2563eb);background:#eff6ff;color:#0f172a}")
-            .Append(".cfx-topology-force-controls{display:grid;gap:8px;margin:0 0 12px;padding:10px 12px;border:1px solid rgba(148,163,184,.42);border-radius:8px;background:rgba(255,255,255,.9);box-shadow:0 10px 24px rgba(15,23,42,.07);color:#0f172a}")
-            .Append(".cfx-topology-force-controls__row{display:grid;grid-template-columns:minmax(180px,1fr) minmax(118px,.25fr) minmax(140px,.35fr);gap:8px}")
-            .Append(".cfx-topology-force-controls input[type='search'],.cfx-topology-force-controls select{min-width:0;height:32px;border:1px solid rgba(148,163,184,.48);border-radius:6px;background:#fff;color:#0f172a;padding:0 9px;font:600 12px/1 ")
-            .Append(fontFamily)
-            .Append("}")
-            .Append(".cfx-topology-force-controls__toggles{display:flex;flex-wrap:wrap;gap:8px 12px;align-items:center}")
-            .Append(".cfx-topology-force-controls label{display:inline-flex;gap:6px;align-items:center;font:700 11px/1 ")
-            .Append(fontFamily)
-            .Append(";color:#334155}")
-            .Append(".cfx-topology-force-controls output{font:600 11px/1.35 ")
-            .Append(fontFamily)
-            .Append(";color:#64748b}")
-            .Append(".cfx-topology-controls{display:flex;flex-wrap:wrap;align-items:center;gap:4px;padding:4px;border:1px solid var(--cfx-topology-control-border);border-radius:8px;background:var(--cfx-topology-control-panel-bg);box-shadow:var(--cfx-topology-control-shadow);backdrop-filter:blur(10px)}")
-            .Append(".cfx-topology-wrapper[data-cfx-viewport-controls='true'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-export-controls='true'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-fullscreen-control='true'] .cfx-topology-viewport{padding-top:48px}")
-            .Append(".cfx-topology-wrapper[data-cfx-controls-placement='left-rail'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-controls-placement='right-rail'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-controls-placement='bottom-left'] .cfx-topology-viewport,.cfx-topology-wrapper[data-cfx-controls-placement='bottom-right'] .cfx-topology-viewport{padding-top:0}")
-            .Append(".cfx-topology-wrapper[data-cfx-controls-placement='left-rail'] .cfx-topology-viewport{padding-left:48px}")
-            .Append(".cfx-topology-wrapper[data-cfx-controls-placement='right-rail'] .cfx-topology-viewport{padding-right:48px}")
-            .Append(".cfx-topology-controls button,.cfx-topology-scenarios button,.cfx-topology-scenario-panel__controls button{appearance:none;display:inline-flex;align-items:center;justify-content:center;gap:6px;min-width:32px;height:32px;border:1px solid var(--cfx-topology-control-border);border-radius:6px;background:var(--cfx-topology-control-bg);color:var(--cfx-topology-control-text);box-shadow:none;cursor:pointer;font:700 12px/1 ")
-            .Append(fontFamily)
-            .Append(";letter-spacing:0;transition:background-color .14s ease,border-color .14s ease,color .14s ease,box-shadow .14s ease,transform .14s ease}")
-            .Append(".cfx-topology-controls button svg{width:16px;height:16px;display:block;fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;pointer-events:none}")
-            .Append(".cfx-topology-controls button span{font-size:11px;line-height:1;pointer-events:none}")
-            .Append(".cfx-topology-controls button[data-cfx-topology-export],.cfx-topology-scenarios button{min-width:42px;padding:0 10px}")
-            .Append(".cfx-topology-controls button:hover,.cfx-topology-controls button:focus-visible,.cfx-topology-controls button[aria-pressed='true'],.cfx-topology-scenarios button:hover,.cfx-topology-scenarios button:focus-visible,.cfx-topology-scenarios button[aria-pressed='true'],.cfx-topology-scenario-panel__controls button:hover,.cfx-topology-scenario-panel__controls button:focus-visible,.cfx-topology-scenario-panel__controls button[aria-pressed='true']{border-color:var(--cfx-topology-control-border-hover);color:var(--cfx-topology-control-text);background:var(--cfx-topology-control-bg-hover);box-shadow:var(--cfx-topology-control-focus)}")
-            .Append(".cfx-topology-controls button:active,.cfx-topology-scenarios button:active,.cfx-topology-scenario-panel__controls button:active{transform:translateY(1px)}")
-            .Append(".cfx-topology-wrapper:fullscreen{width:100vw!important;max-width:none!important;height:100vh!important;margin:0!important;padding:16px;box-sizing:border-box;background:var(--cfx-topology-background,#fff);overflow:auto}")
-            .Append(".cfx-topology-wrapper:fullscreen .cfx-topology-viewport{min-height:calc(100vh - 32px)}")
-            .Append(".cfx-topology-scenario-panel,.cfx-topology-force-controls{border-color:var(--cfx-topology-control-border);background:var(--cfx-topology-control-panel-bg);color:var(--cfx-topology-control-text);box-shadow:var(--cfx-topology-control-shadow);backdrop-filter:blur(10px)}")
-            .Append(".cfx-topology-selection-panel{position:absolute;z-index:4;right:12px;top:12px;bottom:12px;width:min(320px,calc(100% - 24px));display:grid;align-content:start;gap:10px;padding:12px;border:1px solid var(--cfx-topology-control-border);border-radius:8px;background:var(--cfx-topology-control-panel-bg);color:var(--cfx-topology-control-text);box-shadow:var(--cfx-topology-control-shadow);backdrop-filter:blur(12px);overflow:auto}")
-            .Append(".cfx-topology-selection-panel[hidden]{display:none}")
-            .Append(".cfx-topology-selection-panel__head{display:grid;gap:5px;padding-bottom:8px;border-bottom:1px solid var(--cfx-topology-control-border)}")
-            .Append(".cfx-topology-selection-panel__eyebrow{font:700 10px/1 ")
-            .Append(fontFamily)
-            .Append(";text-transform:uppercase;letter-spacing:.04em;color:var(--cfx-topology-control-muted)}")
-            .Append(".cfx-topology-selection-panel__title{font:700 14px/1.25 ")
-            .Append(fontFamily)
-            .Append(";color:var(--cfx-topology-control-text)}")
-            .Append(".cfx-topology-selection-panel__status{justify-self:start;min-height:20px;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--cfx-topology-selection-status-color,var(--cfx-topology-accent,#2563eb)) 13%,transparent);color:var(--cfx-topology-selection-status-color,var(--cfx-topology-control-text));font:800 10px/1 ")
-            .Append(fontFamily)
-            .Append("}")
-            .Append(".cfx-topology-selection-panel__facts{display:grid;grid-template-columns:auto 1fr;gap:6px 10px;margin:0;font:600 11px/1.35 ")
-            .Append(fontFamily)
-            .Append(";color:var(--cfx-topology-control-text)}")
-            .Append(".cfx-topology-selection-panel__facts dt{color:var(--cfx-topology-control-muted)}")
-            .Append(".cfx-topology-selection-panel__facts dd{margin:0;min-width:0;overflow-wrap:anywhere;text-align:right}")
-            .Append(".cfx-topology-selection-panel__meta,.cfx-topology-selection-panel__related{display:grid;gap:6px;font:600 11px/1.35 ")
-            .Append(fontFamily)
-            .Append(";color:var(--cfx-topology-control-text)}")
-            .Append(".cfx-topology-selection-panel__meta:empty,.cfx-topology-selection-panel__related:empty{display:none}")
-            .Append(".cfx-topology-selection-panel__row{display:flex;justify-content:space-between;gap:10px;padding:6px 0;border-top:1px solid color-mix(in srgb,var(--cfx-topology-control-border) 72%,transparent)}")
-            .Append(".cfx-topology-selection-panel__row span:first-child{color:var(--cfx-topology-control-muted)}")
-            .Append(".cfx-topology-selection-panel__row span:last-child{min-width:0;text-align:right;overflow-wrap:anywhere}")
-            .Append(".cfx-topology-scenario-panel__meta,.cfx-topology-force-controls label,.cfx-topology-force-controls output{color:var(--cfx-topology-control-muted)}")
-            .Append(".cfx-topology-force-controls input[type='search'],.cfx-topology-force-controls select{border-color:var(--cfx-topology-control-border);background:var(--cfx-topology-control-bg);color:var(--cfx-topology-control-text)}")
-            .Append(".cfx-topology-controls button:hover,.cfx-topology-controls button:focus-visible,.cfx-topology-controls button[aria-pressed='true'],.cfx-topology-scenarios button:hover,.cfx-topology-scenarios button:focus-visible,.cfx-topology-scenarios button[aria-pressed='true']{border-color:var(--cfx-topology-scenario-color,var(--cfx-topology-control-border-hover,#2563eb));color:var(--cfx-topology-control-text,#0f172a);background:var(--cfx-topology-control-bg-hover,#eff6ff)}")
-            .Append(".cfx-topology-wrapper[data-cfx-viewport-controls='true'] .cfx-topology-viewport{cursor:grab}")
-            .Append(".cfx-topology-wrapper[data-cfx-viewport-controls='true'][data-cfx-topology-dragging='true'] .cfx-topology-viewport{cursor:grabbing}")
-            .Append(".cfx-topology-wrapper [data-cfx-role='topology-node'],.cfx-topology-wrapper [data-cfx-role='topology-edge'],.cfx-topology-wrapper [data-cfx-role='topology-group']{cursor:pointer}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-selected{filter:drop-shadow(0 10px 18px rgba(37,99,235,.22))}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-muted{opacity:.32}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-related{opacity:1}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-hovered{filter:drop-shadow(0 8px 16px rgba(15,23,42,.16))}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-hover-muted{opacity:.42}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-hover-related{opacity:1}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-muted{opacity:.18}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-active{opacity:1;filter:drop-shadow(0 10px 18px rgba(37,99,235,.18))}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-active .cfx-topology__edge{stroke:var(--cfx-topology-active-scenario-color,#2563eb)!important;stroke-width:5!important}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-active .cfx-topology__node-card{stroke:var(--cfx-topology-active-scenario-color,#2563eb)!important;stroke-width:2.4!important}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-preview-muted{opacity:.34}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-preview{opacity:1;filter:drop-shadow(0 8px 14px rgba(15,23,42,.16))}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-preview .cfx-topology__edge{stroke:var(--cfx-topology-preview-scenario-color,#2563eb)!important;stroke-width:4!important}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-preview .cfx-topology__node-card{stroke:var(--cfx-topology-preview-scenario-color,#2563eb)!important;stroke-width:2!important}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-step-muted{opacity:.38}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-step-active{opacity:1;filter:drop-shadow(0 10px 18px rgba(15,23,42,.2))}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-step-active .cfx-topology__edge{stroke-width:6!important}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-scenario-step-active .cfx-topology__node-card{stroke-width:3!important}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-force-hidden{display:none!important}")
-            .Append(".cfx-topology-wrapper .cfx-topology-html-force-faded{opacity:.12!important}")
-            .Append(".cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-muted,.cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-hover-muted{opacity:.06!important}")
-            .Append(".cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-related .cfx-topology__edge,.cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-hover-related .cfx-topology__edge{opacity:.92!important;stroke-width:3.2!important}")
-            .Append(".cfx-topology-wrapper[data-cfx-force-focus='true'] [data-cfx-role='topology-edge-label'].cfx-topology-html-force-focus-label{display:block!important;opacity:1!important}")
-            .Append(".cfx-topology-wrapper[data-cfx-force-moving-edges='true'] .cfx-topology-html-force-moving .cfx-topology__edge,.cfx-topology-wrapper[data-cfx-force-moving-edges='true'] .cfx-topology-html-force-moving .cfx-topology__edge--premium-layer{opacity:.08!important}")
-            .Append(".cfx-topology-wrapper[data-cfx-force-moving-edges='true'] [data-cfx-role='topology-edge-label']{display:none!important}")
-            .Append("@media (max-width:720px){.cfx-topology-force-controls__row{grid-template-columns:1fr}.cfx-topology-force-controls{padding:9px}.cfx-topology-selection-panel{top:auto;left:12px;max-height:42%;width:auto}}");
+        stylesheet += TopologyHtmlAssets.Style.Replace("__CFX_FONT_FAMILY__", fontFamily);
         if (includePageShell) {
-            stylesheet
-                .Append(HtmlSurfacePolish.ResponsiveCenteredBodyCss)
-                .Append(HtmlSurfacePolish.PrintBodyCss("0", ".cfx-topology-wrapper{width:100%;max-width:none}.cfx-topology-wrapper svg{width:100%;height:auto}.cfx-topology-scenarios,.cfx-topology-scenario-panel{display:none}"));
+            stylesheet += HtmlSurfacePolish.ResponsiveCenteredBodyCss;
+            stylesheet += HtmlSurfacePolish.PrintBodyCss("0", ".cfx-topology-wrapper{width:100%;max-width:none}.cfx-topology-wrapper svg{width:100%;height:auto}.cfx-topology-scenarios,.cfx-topology-scenario-panel{display:none}");
         }
 
-        var css = stylesheet.ToString();
-        return css
+        return stylesheet
             .Replace(".cfx-topology-wrapper", "." + cssPrefix + "-wrapper")
             .Replace(".cfx-topology-viewport", "." + cssPrefix + "-viewport")
             .Replace(".cfx-topology-controls", "." + cssPrefix + "-controls")

--- a/ChartForgeX/Topology/TopologyIconStencilBrowser.cs
+++ b/ChartForgeX/Topology/TopologyIconStencilBrowser.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using ChartForgeX.Html;
 
 namespace ChartForgeX.Topology;
@@ -201,134 +200,9 @@ public static class TopologyIconStencilBrowserExtensions {
             .EndElement().Line();
     }
 
-    private static string StyleSheet() {
-        return """
-body{margin:0;background:#f6f8fb;color:#0f172a;font-family:Inter,Segoe UI,system-ui,sans-serif}.cfx-icon-browser{min-height:100vh;padding:24px;box-sizing:border-box}.cfx-icon-browser__header{display:flex;gap:24px;align-items:flex-start;justify-content:space-between;max-width:1500px;margin:0 auto 18px}.cfx-icon-browser__eyebrow{margin:0 0 6px;color:#2563eb;font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.04em}.cfx-icon-browser h1{margin:0;font-size:28px;letter-spacing:0}.cfx-icon-browser__subtitle{margin:6px 0 0;max-width:760px;color:#475569;font-size:14px}.cfx-icon-browser__search{display:grid;grid-template-columns:minmax(260px,360px) auto;gap:8px 12px;align-items:center}.cfx-icon-browser__search input{grid-column:1 / -1;height:40px;border:1px solid #cbd5e1;border-radius:8px;background:white;padding:0 12px;font:500 14px/1 Inter,Segoe UI,system-ui,sans-serif;color:#0f172a;box-shadow:0 8px 20px rgba(15,23,42,.05)}.cfx-icon-browser__search span{font-size:13px;font-weight:800;color:#0f172a}.cfx-icon-browser__search small{justify-self:end;color:#64748b}.cfx-icon-browser__shell{max-width:1500px;margin:0 auto;display:grid;grid-template-columns:240px minmax(0,1fr) 280px;gap:16px;align-items:start}.cfx-icon-browser__sidebar,.cfx-icon-browser__inspector{background:#fff;border:1px solid #dbe3ef;border-radius:10px;box-shadow:0 12px 28px rgba(15,23,42,.06);padding:14px;position:sticky;top:16px}.cfx-icon-browser__sidebar section+section{margin-top:18px}.cfx-icon-browser h2{margin:0 0 10px;font-size:13px}.cfx-icon-browser button{width:100%;height:34px;border:1px solid transparent;border-radius:7px;background:transparent;color:#334155;font:700 12px/1 Inter,Segoe UI,system-ui,sans-serif;display:flex;align-items:center;justify-content:space-between;gap:8px;padding:0 10px;cursor:pointer;text-align:left}.cfx-icon-browser button:hover,.cfx-icon-browser button[aria-pressed='true']{background:#eff6ff;border-color:#bfdbfe;color:#1d4ed8}.cfx-icon-browser button small{color:#64748b}.cfx-icon-browser__workspace{min-width:0}.cfx-icon-browser__filters{display:flex;gap:8px;align-items:center;overflow:auto;padding:0 0 10px}.cfx-icon-browser__filters button{width:auto;white-space:nowrap;background:#fff;border-color:#dbe3ef}.cfx-icon-browser__palette{background:#fff;border:1px solid #dbe3ef;border-radius:10px;padding:12px;box-shadow:0 12px 28px rgba(15,23,42,.06);overflow:auto}.cfx-icon-browser__palette svg{min-width:980px}.cfx-icon-browser__palette [data-cfx-role='topology-node']{cursor:pointer}.cfx-icon-browser__palette .cfx-icon-browser-hidden{display:none}.cfx-icon-browser__palette .cfx-icon-browser-selected{filter:drop-shadow(0 12px 18px rgba(37,99,235,.25))}.cfx-icon-browser__inspector h2{font-size:18px;margin:0 0 14px}.cfx-icon-browser__inspector dl{display:grid;grid-template-columns:82px minmax(0,1fr);gap:8px 10px;margin:0}.cfx-icon-browser__inspector dt{color:#64748b;font-size:12px}.cfx-icon-browser__inspector dd{margin:0;color:#0f172a;font-size:12px;font-weight:700;overflow-wrap:anywhere}.cfx-icon-browser__hint{margin:16px 0 0;color:#64748b;font-size:12px;line-height:1.45}@media(max-width:1100px){.cfx-icon-browser__header{display:block}.cfx-icon-browser__search{margin-top:14px}.cfx-icon-browser__shell{grid-template-columns:1fr}.cfx-icon-browser__sidebar,.cfx-icon-browser__inspector{position:static}.cfx-icon-browser__sidebar{display:grid;grid-template-columns:1fr 1fr;gap:14px}.cfx-icon-browser__sidebar section+section{margin-top:0}}@media(max-width:640px){.cfx-icon-browser{padding:16px}.cfx-icon-browser__sidebar{grid-template-columns:1fr}.cfx-icon-browser__search{grid-template-columns:1fr}.cfx-icon-browser h1{font-size:24px}}
-""";
-    }
+    private static string StyleSheet() => TopologyHtmlAssets.IconStencilBrowserStyle;
 
-    private static string Script() {
-        return """
-(() => {
-  const root = document.querySelector('[data-cfx-icon-browser="true"]');
-  if (!root) return;
-  const search = root.querySelector('[data-cfx-icon-search]');
-  const count = root.querySelector('[data-cfx-icon-count]');
-  const nodes = Array.from(root.querySelectorAll('[data-cfx-role="topology-node"]'));
-  const badges = Array.from(root.querySelectorAll('[data-cfx-role="topology-node-status"]'));
-  const groups = Array.from(root.querySelectorAll('[data-cfx-role="topology-group"]'));
-  const state = { vendor: '', pack: '', category: '', search: search ? search.value.toLowerCase().trim() : '' };
-  const attr = (element, name) => element.getAttribute(name) || '';
-  const meta = (element, key) => attr(element, 'data-cfx-meta-' + key);
-  const detail = name => root.querySelector('[data-cfx-icon-detail="' + name + '"]');
-  const setText = (name, value) => { const target = detail(name); if (target) target.textContent = value || '-'; };
-  const textFor = element => [
-    attr(element, 'data-node-icon-id'),
-    attr(element, 'data-node-icon-label'),
-    attr(element, 'data-node-icon-pack'),
-    attr(element, 'data-node-icon-shape'),
-    attr(element, 'data-node-kind'),
-    meta(element, 'category'),
-    meta(element, 'vendor'),
-    meta(element, 'pack-label'),
-    meta(element, 'icon-tags'),
-    meta(element, 'icon-source-path'),
-    meta(element, 'pack-source-url'),
-    meta(element, 'pack-source-license')
-  ].join(' ').toLowerCase();
-  const nodeVisible = node => {
-    if (state.vendor && meta(node, 'vendor') !== state.vendor) return false;
-    if (state.pack && attr(node, 'data-node-icon-pack') !== state.pack) return false;
-    if (state.category && meta(node, 'category') !== state.category) return false;
-    return !state.search || textFor(node).includes(state.search);
-  };
-  const syncButtons = kind => {
-    root.querySelectorAll('[data-cfx-icon-filter="' + kind + '"]').forEach(button => {
-      button.setAttribute('aria-pressed', attr(button, 'data-cfx-icon-filter-value') === state[kind] ? 'true' : 'false');
-    });
-  };
-  const apply = () => {
-    let visible = 0;
-    let firstVisible = null;
-    const visibleNodeIds = new Set();
-    const visibleByPack = new Set();
-    for (const node of nodes) {
-      const show = nodeVisible(node);
-      node.classList.toggle('cfx-icon-browser-hidden', !show);
-      if (show) {
-        visible++;
-        if (!firstVisible) firstVisible = node;
-        visibleNodeIds.add(attr(node, 'data-node-id'));
-        visibleByPack.add(attr(node, 'data-node-icon-pack'));
-      }
-    }
-    for (const badge of badges) badge.classList.toggle('cfx-icon-browser-hidden', !visibleNodeIds.has(attr(badge, 'data-node-id')));
-    for (const group of groups) {
-      const pack = attr(group, 'data-group-icon-id').split(':')[0] || meta(group, 'packid');
-      group.classList.toggle('cfx-icon-browser-hidden', pack && !visibleByPack.has(pack));
-    }
-    if (count) count.textContent = visible + ' icons';
-    if (firstVisible && (state.search || state.vendor || state.pack || state.category)) {
-      window.requestAnimationFrame(() => firstVisible.scrollIntoView({ block: 'nearest', inline: 'center' }));
-    }
-  };
-  const select = node => {
-    nodes.forEach(item => item.classList.toggle('cfx-icon-browser-selected', item === node));
-    const payload = {
-      iconId: attr(node, 'data-node-icon-id'),
-      iconPack: attr(node, 'data-node-icon-pack'),
-      iconLabel: attr(node, 'data-node-icon-label'),
-      iconShape: attr(node, 'data-node-icon-shape'),
-      iconArtwork: attr(node, 'data-node-icon-artwork') || meta(node, 'icon-artwork'),
-      nodeKind: attr(node, 'data-node-kind'),
-      category: meta(node, 'category'),
-      vendor: meta(node, 'vendor'),
-      packLabel: meta(node, 'pack-label'),
-      tags: meta(node, 'icon-tags'),
-      sourcePath: meta(node, 'icon-source-path'),
-      sourceUrl: meta(node, 'pack-source-url'),
-      sourceRevision: meta(node, 'icon-source-revision') || meta(node, 'pack-source-revision'),
-      sourceLicense: meta(node, 'pack-source-license'),
-      sourceLicenseUrl: meta(node, 'pack-source-licenseurl')
-    };
-    setText('label', payload.iconLabel);
-    setText('id', payload.iconId);
-    setText('pack', payload.packLabel || payload.iconPack);
-    setText('vendor', payload.vendor);
-    setText('category', payload.category);
-    setText('shape', payload.iconShape);
-    setText('artwork', payload.iconArtwork || 'fallback shape');
-    setText('source', payload.sourcePath || payload.sourceUrl);
-    setText('revision', payload.sourceRevision);
-    setText('license', payload.sourceLicense);
-    root.dispatchEvent(new CustomEvent('cfx-icon-browser-select', { bubbles: true, detail: payload }));
-  };
-  root.querySelectorAll('[data-cfx-icon-filter]').forEach(button => {
-    button.addEventListener('click', () => {
-      const kind = attr(button, 'data-cfx-icon-filter');
-      state[kind] = attr(button, 'data-cfx-icon-filter-value');
-      syncButtons(kind);
-      apply();
-    });
-  });
-  if (search) search.addEventListener('input', () => {
-    state.search = search.value.toLowerCase().trim();
-    apply();
-  });
-  nodes.forEach(node => {
-    node.setAttribute('tabindex', '0');
-    node.addEventListener('click', () => select(node));
-    node.addEventListener('keydown', event => {
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        select(node);
-      }
-    });
-  });
-  apply();
-})();
-""";
-    }
+    private static string Script() => TopologyHtmlAssets.IconStencilBrowserScript;
 
     private static TopologyIconCatalogQuery ToQuery(TopologyIconStencilBrowserOptions options) {
         var query = new TopologyIconCatalogQuery {


### PR DESCRIPTION
## Summary
- move topology HTML stylesheet into an embedded CSS asset
- move topology icon stencil browser CSS and JS into embedded assets
- keep renderer C# focused on loading assets and applying dynamic prefix/font templating

## Validation
- dotnet build .\\ChartForgeX\\ChartForgeX.csproj -c Release -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false
- dotnet test .\\ChartForgeX.Tests\\ChartForgeX.Tests.csproj -c Release --filter SmokeCasePasses -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false
- dotnet test .\\ChartForgeX.sln -c Release -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false
- git diff --check
- git diff --cached --check