### PR TITLE
Improve topology HTML interactivity assets

### DIFF
--- a/Build/Sync-InteractiveAssets.ps1
+++ b/Build/Sync-InteractiveAssets.ps1
@@ -1,0 +1,51 @@
+param(
+    [switch] $Check
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+
+$assets = @(
+    @{
+        Source = 'ChartForgeX/Topology/Assets/topology-interaction.source'
+        Target = 'ChartForgeX/Topology/Assets/topology-interaction.js'
+    },
+    @{
+        Source = 'ChartForgeX.Interactivity.Html/Assets/interactive.source'
+        Target = 'ChartForgeX.Interactivity.Html/Assets/interactive.js'
+    }
+)
+
+function Join-AssetSource {
+    param([string] $SourcePath)
+
+    $parts = Get-ChildItem -Path $SourcePath -Filter '*.js' -File |
+        Sort-Object Name
+
+    if ($parts.Count -eq 0) {
+        throw "No JavaScript source fragments found in '$SourcePath'."
+    }
+
+    $content = foreach ($part in $parts) {
+        [System.IO.File]::ReadAllText($part.FullName).Replace("`r`n", "`n").Replace("`r", "`n").TrimEnd("`n")
+    }
+
+    ($content -join "`n") + "`n"
+}
+
+foreach ($asset in $assets) {
+    $sourcePath = Join-Path $root $asset.Source
+    $targetPath = Join-Path $root $asset.Target
+    $generated = Join-AssetSource -SourcePath $sourcePath
+
+    if ($Check) {
+        $current = [System.IO.File]::ReadAllText($targetPath).Replace("`r`n", "`n").Replace("`r", "`n")
+        if ($current -ne $generated) {
+            throw "Generated asset is out of date: $($asset.Target). Run Build/Sync-InteractiveAssets.ps1."
+        }
+
+        continue
+    }
+
+    [System.IO.File]::WriteAllText($targetPath, $generated, [System.Text.UTF8Encoding]::new($false))
+}

--- a/ChartForgeX.Interactivity.Html/Assets/interactive.source/00-bootstrap-tooltip.js
+++ b/ChartForgeX.Interactivity.Html/Assets/interactive.source/00-bootstrap-tooltip.js
@@ -1,0 +1,219 @@
+(() => {
+  const featureAliases = {
+    ReportReview: ['Tooltips', 'Selection', 'LegendToggles', 'KeyboardNavigation', 'Crosshair', 'CompareMarkers']
+  };
+  const featureTokens = (root) => (root.dataset.cfxInteractionFeatures || '')
+    .split(',')
+    .map((feature) => feature.trim())
+    .filter(Boolean);
+  const hasFeature = (root, name) => featureTokens(root).some((feature) => feature.toLowerCase() === name.toLowerCase()
+    || (featureAliases[feature] || []).some((alias) => alias.toLowerCase() === name.toLowerCase()));
+  const targetSelector = '.cfx-interactive-region,[data-cfx-label],[data-cfx-point],[data-cfx-series],[data-cfx-role="legend-item"]';
+  const lassoSelector = '.cfx-interactive-region,[data-cfx-label],[data-cfx-point]';
+  const isInteractiveTarget = (node) => (node.dataset ? node.dataset.cfxRole : '') === 'legend-item' || !node.closest('[data-cfx-role="legend-item"]');
+  const interactiveTargets = (root) => Array.from(root.querySelectorAll(targetSelector)).filter(isInteractiveTarget);
+  const text = (node) => {
+    const data = node.dataset || {};
+    const aria = node.getAttribute('aria-label');
+    if (aria) return aria;
+    const label = data.cfxLabel || data.cfxText || '';
+    const parts = [];
+    if (label) parts.push(label);
+    else if (data.cfxRole) parts.push(data.cfxRole.replace(/-/g, ' '));
+    if (data.cfxSeries !== undefined && !label) parts.push('Series ' + data.cfxSeries);
+    if (data.cfxPoint !== undefined) parts.push('Point ' + data.cfxPoint);
+    const value = data.cfxValue || data.cfxY || data.cfxEnd || data.cfxTarget || '';
+    if (value) parts.push('Value ' + value);
+    return parts.join(' / ');
+  };
+  const targetIdentity = (node) => {
+    const data = node.dataset || {};
+    return {
+      id: data.cfxId || node.id || '',
+      role: data.cfxRole || '',
+      label: data.cfxLabel || data.cfxText || node.getAttribute('aria-label') || '',
+      series: data.cfxSeries,
+      point: data.cfxPoint,
+      value: data.cfxValue || data.cfxY || data.cfxEnd || '',
+      kind: data.cfxKind || ''
+    };
+  };
+  const metaLabel = (attributeName) => attributeName
+    .replace(/^data-cfx-meta-/i, '')
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+  const metadataRows = (node) => Array.from(node.attributes || [])
+    .filter((attribute) => attribute.name.toLowerCase().indexOf('data-cfx-meta-') === 0 && attribute.value !== '')
+    .map((attribute) => ({ name: metaLabel(attribute.name), value: attribute.value }));
+  const tooltipRows = (node) => {
+    const data = node.dataset || {};
+    const rows = [];
+    const push = (name, value) => {
+      if (value !== undefined && value !== null && value !== '') rows.push({ name, value: String(value) });
+    };
+    push('Role', data.cfxRole ? data.cfxRole.replace(/-/g, ' ') : '');
+    push('Series', data.cfxSeries);
+    push('Point', data.cfxPoint);
+    push('X', data.cfxX || data.cfxCategory || data.cfxDate || data.cfxStart);
+    push('Y', data.cfxY || data.cfxValue);
+    push('End', data.cfxEnd);
+    push('Target', data.cfxTarget);
+    push('Status', data.cfxStatus);
+    push('Kind', data.cfxKind);
+    push('Percent', data.cfxPercent);
+    push('Delta', data.cfxDelta);
+    push('Range', data.cfxLower && data.cfxUpper ? data.cfxLower + ' - ' + data.cfxUpper : '');
+    metadataRows(node).forEach((row) => push(row.name, row.value));
+    return rows;
+  };
+  const renderTip = (tip, node) => {
+    const label = text(node);
+    if (!label) return false;
+    tip.replaceChildren();
+    const title = document.createElement('div');
+    title.className = 'cfx-tooltip__title';
+    title.textContent = label;
+    tip.appendChild(title);
+    const rows = tooltipRows(node);
+    if (rows.length) {
+      const list = document.createElement('dl');
+      list.className = 'cfx-tooltip__meta';
+      rows.forEach((row) => {
+        const term = document.createElement('dt');
+        term.textContent = row.name;
+        const value = document.createElement('dd');
+        value.textContent = row.value;
+        list.appendChild(term);
+        list.appendChild(value);
+      });
+      tip.appendChild(list);
+    }
+    return true;
+  };
+  const showTip = (root, tip, node, event) => {
+    if (!hasFeature(root, 'Tooltips')) return;
+    if (root.dataset.cfxTooltipPinned === 'true') return;
+    if (!renderTip(tip, node)) return;
+    tip.hidden = false;
+    moveTip(tip, event, node);
+  };
+  const moveTip = (tip, event, node) => {
+    if (!event || tip.hidden) return;
+    let clientX = event.clientX;
+    let clientY = event.clientY;
+    if ((!Number.isFinite(clientX) || !Number.isFinite(clientY)) && node && node.getBoundingClientRect) {
+      const rect = node.getBoundingClientRect();
+      clientX = rect.left + rect.width / 2;
+      clientY = rect.top + rect.height / 2;
+    }
+    if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) {
+      clientX = 24;
+      clientY = 24;
+    }
+    const tipWidth = tip.offsetWidth || 0;
+    const tipHeight = tip.offsetHeight || 0;
+    const maxX = Math.max(8, window.innerWidth - tipWidth - 8);
+    const maxY = Math.max(8, window.innerHeight - tipHeight - 8);
+    const x = Math.max(8, Math.min(maxX, clientX + 14));
+    const y = Math.max(8, Math.min(maxY, clientY + 14));
+    tip.style.left = x + 'px';
+    tip.style.top = y + 'px';
+  };
+  const targetKey = (target) => target ? [target.id || '', target.role || '', target.label || '', target.series ?? '', target.point ?? '', target.value || '', target.kind || ''].join('|') : '';
+  const compareItems = (root) => {
+    const items = [];
+    const seen = new Set();
+    root.querySelectorAll('.cfx-selected').forEach((node) => {
+      const target = targetIdentity(node);
+      const key = targetKey(target);
+      if (!key || seen.has(key)) return;
+      seen.add(key);
+      items.push({ label: text(node) || target.label || target.role || target.id || 'Target', target });
+    });
+    return items;
+  };
+  const selectedTargets = (root) => compareItems(root).map((item) => item.target);
+  const renderCompare = (root) => {
+    const tray = root.querySelector('[data-cfx-compare-tray]');
+    if (!tray || !hasFeature(root, 'CompareMarkers')) return [];
+    const items = compareItems(root);
+    tray.replaceChildren();
+    if (!items.length) {
+      tray.hidden = true;
+      root.removeAttribute('data-cfx-compare-count');
+      return items;
+    }
+    tray.hidden = false;
+    root.dataset.cfxCompareCount = String(items.length);
+    const summary = document.createElement('div');
+    summary.className = 'cfx-compare-tray__summary';
+    summary.textContent = 'Compare ' + items.length;
+    tray.appendChild(summary);
+    items.slice(0, 6).forEach((item, index) => {
+      const chip = document.createElement('button');
+      chip.className = 'cfx-compare-chip';
+      chip.type = 'button';
+      chip.textContent = item.label;
+      chip.dataset.cfxCompareIndex = String(index);
+      chip.title = item.label;
+      chip.addEventListener('click', () => {
+        clearHover(root, false, false);
+        if (applyHoverByTarget(root, item.target)) {
+          recordFocusTrail(root, item.target, true, true);
+          emitHostEvent(root, 'cfxhover', { label: item.label, target: item.target });
+        }
+      });
+      tray.appendChild(chip);
+    });
+    if (items.length > 6) {
+      const more = document.createElement('span');
+      more.className = 'cfx-compare-tray__more';
+      more.textContent = '+' + (items.length - 6);
+      tray.appendChild(more);
+    }
+    const clear = document.createElement('button');
+    clear.className = 'cfx-compare-clear';
+    clear.type = 'button';
+    clear.textContent = 'Clear';
+    clear.setAttribute('data-cfx-compare-clear', 'true');
+    clear.addEventListener('click', () => {
+      clearSelections(root);
+      publishCompare(root, true);
+    });
+    tray.appendChild(clear);
+    return items;
+  };
+  const publishCompare = (root, sync) => {
+    const items = renderCompare(root);
+    if (!hasFeature(root, 'CompareMarkers')) return items;
+    const targets = items.map((item) => item.target);
+    emitHostEvent(root, 'cfxcompare', { count: targets.length, targets });
+    if (sync !== false) emitSync(root, { action: 'compare', count: targets.length, targets });
+    return items;
+  };
+  const hideTip = (root, tip, force) => {
+    if (!tip || (!force && root.dataset.cfxTooltipPinned === 'true')) return;
+    tip.hidden = true;
+    tip.classList.remove('cfx-tooltip--pinned');
+    root.removeAttribute('data-cfx-tooltip-pinned');
+    root.removeAttribute('data-cfx-pinned-target');
+  };
+  const pinTip = (root, tip, node, event) => {
+    if (!hasFeature(root, 'Tooltips') || !renderTip(tip, node)) return;
+    const target = targetIdentity(node);
+    const key = targetKey(target);
+    const pinned = root.dataset.cfxTooltipPinned === 'true' && root.dataset.cfxPinnedTarget === key;
+    if (pinned) {
+      hideTip(root, tip, true);
+      emitHostEvent(root, 'cfxtooltip', { pinned: false, target });
+      return;
+    }
+    tip.hidden = false;
+    tip.classList.add('cfx-tooltip--pinned');
+    root.dataset.cfxTooltipPinned = 'true';
+    root.dataset.cfxPinnedTarget = key;
+    moveTip(tip, event, node);
+    emitHostEvent(root, 'cfxtooltip', { pinned: true, label: text(node), target });
+  };

--- a/ChartForgeX.Interactivity.Html/Assets/interactive.source/20-viewport-export-state.js
+++ b/ChartForgeX.Interactivity.Html/Assets/interactive.source/20-viewport-export-state.js
@@ -1,0 +1,167 @@
+  const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+  const getState = (root) => ({
+    zoom: Number(root.dataset.cfxZoom || '1'),
+    panX: Number(root.dataset.cfxPanX || '0'),
+    panY: Number(root.dataset.cfxPanY || '0')
+  });
+  const applyViewport = (root, state) => {
+    state.zoom = clamp(state.zoom, 0.5, 6);
+    state.panX = clamp(state.panX, -4000, 4000);
+    state.panY = clamp(state.panY, -4000, 4000);
+    root.dataset.cfxZoom = state.zoom.toFixed(3);
+    root.dataset.cfxPanX = state.panX.toFixed(1);
+    root.dataset.cfxPanY = state.panY.toFixed(1);
+    const stage = root.querySelector('.cfx-stage');
+    if (!stage) return;
+    stage.style.setProperty('--cfx-zoom', state.zoom);
+    stage.style.setProperty('--cfx-pan-x', state.panX + 'px');
+    stage.style.setProperty('--cfx-pan-y', state.panY + 'px');
+  };
+  const sameGroup = (root, peer) => root !== peer && root.dataset.cfxInteractionGroup && root.dataset.cfxInteractionGroup === peer.dataset.cfxInteractionGroup;
+  const emitHostEvent = (root, name, detail) => {
+    root.dispatchEvent(new CustomEvent(name, { detail: Object.assign({ chartId: root.dataset.cfxChartId || '' }, detail || {}) }));
+  };
+  const emitSync = (root, payload) => {
+    if (!hasFeature(root, 'SynchronizedCharts') || !root.dataset.cfxInteractionGroup) return;
+    const detail = Object.assign({ chartId: root.dataset.cfxChartId || '', group: root.dataset.cfxInteractionGroup }, payload);
+    root.dispatchEvent(new CustomEvent('cfxsync', { detail }));
+    document.querySelectorAll('.cfx-interactive-chart').forEach((peer) => {
+      if (sameGroup(root, peer) && hasFeature(peer, 'SynchronizedCharts')) applySync(peer, detail);
+    });
+  };
+  const applyMode = (root, mode) => {
+    root.dataset.cfxMode = mode || '';
+    root.querySelectorAll('[data-cfx-mode-button]').forEach((button) => {
+      button.setAttribute('aria-pressed', button.dataset.cfxModeButton === root.dataset.cfxMode ? 'true' : 'false');
+    });
+  };
+  const setMode = (root, mode) => applyMode(root, root.dataset.cfxMode === mode ? '' : mode);
+  const resetViewport = (root) => {
+    applyViewport(root, { zoom: 1, panX: 0, panY: 0 });
+    root.dataset.cfxBrush = '';
+    root.dataset.cfxMode = '';
+    root.querySelectorAll('[data-cfx-mode-button]').forEach((button) => button.setAttribute('aria-pressed', 'false'));
+  };
+  const storeInteractionState = (root, snapshot) => {
+    try {
+      root.dataset.cfxInteractionSnapshot = JSON.stringify(snapshot);
+    } catch {
+      root.removeAttribute('data-cfx-interaction-snapshot');
+    }
+  };
+  const captureInteractionState = (root, source) => {
+    const snapshot = {
+      version: 1,
+      chartId: root.dataset.cfxChartId || '',
+      source: source || '',
+      viewport: getState(root),
+      mode: root.dataset.cfxMode || '',
+      brush: root.dataset.cfxBrush || '',
+      selectedTargets: selectedTargets(root),
+      compareCount: Number(root.dataset.cfxCompareCount || '0'),
+      scenario: {
+        id: root.dataset.cfxActiveScenario || '',
+        stepIndex: root.dataset.cfxActiveScenarioStep || '',
+        progress: root.dataset.cfxScenarioProgress || '',
+        playback: root.dataset.cfxScenarioPlayback || ''
+      }
+    };
+    storeInteractionState(root, snapshot);
+    return snapshot;
+  };
+  const publishInteractionState = (root, source, sync) => {
+    if (!hasFeature(root, 'StateBookmarks')) return null;
+    const snapshot = captureInteractionState(root, source || 'host');
+    emitHostEvent(root, 'cfxstate', { source: source || 'host', snapshot });
+    if (sync !== false) emitSync(root, { action: 'state', state: snapshot });
+    return snapshot;
+  };
+  const applyInteractionState = (root, snapshot, emit, sync) => {
+    if (!snapshot || !hasFeature(root, 'StateBookmarks')) return;
+    if (snapshot.viewport) applyViewport(root, Object.assign({}, snapshot.viewport));
+    if (snapshot.mode !== undefined) applyMode(root, snapshot.mode || '');
+    if (snapshot.brush !== undefined) root.dataset.cfxBrush = snapshot.brush || '';
+    const scenario = snapshot.scenario || {};
+    if (scenario.id !== undefined) {
+      setScenario(root, scenario.id || '', false, false);
+      if (scenario.id && scenario.stepIndex !== undefined && scenario.stepIndex !== '') setScenarioStep(root, scenario.stepIndex, false, false);
+      const route = scenarioRoute(root, root.dataset.cfxActiveScenario || '');
+      if (scenario.playback === 'playing' && route && route.steps.length) {
+        const current = Number(root.dataset.cfxActiveScenarioStep || '-1');
+        const next = Number.isFinite(current) && current + 1 < route.steps.length ? current + 1 : 0;
+        startScenarioPlayback(root, route, next, false, false);
+      } else if (scenario.playback) {
+        setScenarioPlaybackState(root, scenario.playback, route, false);
+      }
+    }
+    applySelectionSetByTargets(root, snapshot.selectedTargets || [], true);
+    renderCompare(root);
+    storeInteractionState(root, snapshot);
+    if (emit !== false) emitHostEvent(root, 'cfxstateapplied', { snapshot });
+    if (sync !== false) emitSync(root, { action: 'state', state: snapshot });
+  };
+  const zoomBy = (root, factor) => {
+    if (!hasFeature(root, 'Zoom')) return;
+    const state = getState(root);
+    state.zoom *= factor;
+    applyViewport(root, state);
+    emitHostEvent(root, 'cfxviewport', { state: getState(root) });
+    emitSync(root, { action: 'viewport', state: getState(root) });
+  };
+  const serializeSvg = (root) => {
+    const svg = root.querySelector('.cfx-stage svg');
+    return svg ? { svg, data: new XMLSerializer().serializeToString(svg) } : null;
+  };
+  const downloadBlob = (root, blob, extension, format) => {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = (root.dataset.cfxChartId || 'chart') + '.' + extension;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+    emitHostEvent(root, 'cfxexport', { format });
+  };
+  const svgSize = (svg) => {
+    const viewBox = svg.viewBox && svg.viewBox.baseVal ? svg.viewBox.baseVal : null;
+    const rect = svg.getBoundingClientRect ? svg.getBoundingClientRect() : { width: 0, height: 0 };
+    const width = Math.max(1, Math.round((viewBox && viewBox.width) || (svg.width && svg.width.baseVal ? svg.width.baseVal.value : 0) || rect.width || 800));
+    const height = Math.max(1, Math.round((viewBox && viewBox.height) || (svg.height && svg.height.baseVal ? svg.height.baseVal.value : 0) || rect.height || 450));
+    return { width, height };
+  };
+  const exportSvg = (root) => {
+    if (!hasFeature(root, 'Export')) return;
+    const serialized = serializeSvg(root);
+    if (!serialized) return;
+    downloadBlob(root, new Blob([serialized.data], { type: 'image/svg+xml;charset=utf-8' }), 'svg', 'svg');
+  };
+  const exportPng = (root) => {
+    if (!hasFeature(root, 'Export')) return;
+    const serialized = serializeSvg(root);
+    if (!serialized) return;
+    const source = new Blob([serialized.data], { type: 'image/svg+xml;charset=utf-8' });
+    const sourceUrl = URL.createObjectURL(source);
+    const image = new Image();
+    image.onload = () => {
+      const size = svgSize(serialized.svg);
+      const scale = Math.max(1, Math.ceil(window.devicePixelRatio || 1));
+      const canvas = document.createElement('canvas');
+      canvas.width = size.width * scale;
+      canvas.height = size.height * scale;
+      const context = canvas.getContext('2d');
+      if (!context) {
+        URL.revokeObjectURL(sourceUrl);
+        return;
+      }
+      context.setTransform(scale, 0, 0, scale, 0, 0);
+      context.clearRect(0, 0, size.width, size.height);
+      context.drawImage(image, 0, 0, size.width, size.height);
+      canvas.toBlob((blob) => {
+        URL.revokeObjectURL(sourceUrl);
+        if (blob) downloadBlob(root, blob, 'png', 'png');
+      }, 'image/png');
+    };
+    image.onerror = () => URL.revokeObjectURL(sourceUrl);
+    image.src = sourceUrl;
+  };

--- a/ChartForgeX.Interactivity.Html/Assets/interactive.source/40-selection-hover-sync.js
+++ b/ChartForgeX.Interactivity.Html/Assets/interactive.source/40-selection-hover-sync.js
@@ -1,0 +1,412 @@
+  const setSeriesMuted = (root, series, muted) => {
+    root.querySelectorAll('[data-cfx-series]').forEach((node) => {
+      if ((node.dataset ? node.dataset.cfxSeries : undefined) !== series) return;
+      const role = node.dataset ? node.dataset.cfxRole || '' : '';
+      if (role.indexOf('legend') === 0) {
+        node.dataset.cfxMuted = muted ? 'true' : 'false';
+        return;
+      }
+      node.classList.toggle('cfx-series-muted', muted);
+    });
+  };
+  const setSeriesIsolation = (root, series, isolated) => {
+    root.querySelectorAll('[data-cfx-series]').forEach((node) => {
+      const data = node.dataset || {};
+      const role = data.cfxRole || '';
+      const sameSeries = data.cfxSeries === series;
+      if (role.indexOf('legend') === 0) {
+        if (isolated && sameSeries) {
+          data.cfxIsolated = 'true';
+          node.setAttribute('aria-current', 'true');
+        } else {
+          delete data.cfxIsolated;
+          node.removeAttribute('aria-current');
+        }
+        return;
+      }
+      node.classList.toggle('cfx-series-isolated-in', isolated && sameSeries);
+      node.classList.toggle('cfx-series-isolated-out', isolated && !sameSeries);
+    });
+    if (isolated) root.dataset.cfxIsolatedSeries = series;
+    else root.removeAttribute('data-cfx-isolated-series');
+  };
+  const toggleSeriesFocus = (root, item, emit, sync) => {
+    if (!hasFeature(root, 'LegendToggles')) return;
+    const series = item.dataset.cfxSeries;
+    if (series === undefined) return;
+    const isolated = root.dataset.cfxIsolatedSeries !== series;
+    setSeriesIsolation(root, series, isolated);
+    emitHostEvent(root, 'cfxseriesfocus', { series, isolated });
+    if (sync !== false) emitSync(root, { action: 'series-focus', series, isolated });
+  };
+  const toggleSeries = (root, item) => {
+    if (!hasFeature(root, 'LegendToggles')) return;
+    const series = item.dataset.cfxSeries;
+    if (series === undefined) return;
+    if (root.dataset.cfxIsolatedSeries) setSeriesIsolation(root, series, false);
+    const muted = item.dataset.cfxMuted !== 'true';
+    setSeriesMuted(root, series, muted);
+    emitHostEvent(root, 'cfxseries', { series, muted });
+    emitSync(root, { action: 'series', series, muted });
+  };
+  const toggleSelection = (root, node) => {
+    if (!hasFeature(root, 'Selection')) return;
+    const selected = !node.classList.contains('cfx-selected');
+    setNodeSelected(node, selected);
+    const target = targetIdentity(node);
+    emitHostEvent(root, 'cfxselect', { label: text(node), selected, target });
+    emitSync(root, { action: 'selection', label: text(node), selected, target });
+    publishCompare(root, true);
+  };
+  const setNodeSelected = (node, selected) => {
+    node.classList.toggle('cfx-selected', selected);
+    node.setAttribute('aria-selected', selected ? 'true' : 'false');
+  };
+  const setNodeHovered = (node, hovered, related) => {
+    node.classList.toggle('cfx-hovered', hovered);
+    node.classList.toggle('cfx-hover-related', related && !hovered);
+  };
+  const targetRelated = (node, target) => {
+    if (!target) return false;
+    const data = node.dataset || {};
+    if (target.series !== undefined && data.cfxSeries === String(target.series)) return true;
+    if (target.point !== undefined && data.cfxPoint === String(target.point)) return true;
+    if (target.label && (data.cfxLabel === target.label || data.cfxText === target.label || node.getAttribute('aria-label') === target.label)) return true;
+    return false;
+  };
+  const clearHover = (root, emit, sync) => {
+    root.removeAttribute('data-cfx-hovering');
+    root.removeAttribute('data-cfx-hover-label');
+    root.removeAttribute('data-cfx-hover-key');
+    clearReveals(root, 'hover');
+    clearReveals(root, 'crosshair');
+    clearReveals(root, 'navigate');
+    root.querySelectorAll('.cfx-hovered,.cfx-hover-related').forEach((node) => node.classList.remove('cfx-hovered', 'cfx-hover-related'));
+    if (emit !== false) emitHostEvent(root, 'cfxhoverclear', {});
+    if (sync !== false) emitSync(root, { action: 'hover-clear' });
+  };
+  const applyHoverByTarget = (root, target) => {
+    if (!target) return false;
+    let matched = false;
+    root.querySelectorAll(targetSelector).forEach((node) => {
+      const hovered = matchesTargetIdentity(node, target);
+      const related = !hovered && targetRelated(node, target);
+      if (hovered || related) matched = true;
+      setNodeHovered(node, hovered, related);
+    });
+    if (matched) {
+      root.dataset.cfxHovering = 'true';
+      root.dataset.cfxHoverLabel = target.label || target.role || target.id || '';
+    }
+    return matched;
+  };
+  const clearFocusTrail = (root) => {
+    root._cfxFocusTrail = [];
+    root.removeAttribute('data-cfx-trail-count');
+    root.querySelectorAll('.cfx-trail').forEach((node) => {
+      node.classList.remove('cfx-trail');
+      delete node.dataset.cfxTrailIndex;
+    });
+  };
+  const applyFocusTrail = (root, trail) => {
+    clearFocusTrail(root);
+    const targets = (trail || []).slice(0, 5);
+    if (!targets.length || !hasFeature(root, 'FocusTrail')) return [];
+    root._cfxFocusTrail = targets;
+    root.dataset.cfxTrailCount = String(targets.length);
+    targets.forEach((target, index) => {
+      root.querySelectorAll(targetSelector).forEach((node) => {
+        if (!matchesTargetIdentity(node, target)) return;
+        node.classList.add('cfx-trail');
+        node.dataset.cfxTrailIndex = String(index + 1);
+      });
+    });
+    return targets;
+  };
+  const recordFocusTrail = (root, target, emit, sync) => {
+    if (!target || !hasFeature(root, 'FocusTrail')) return [];
+    const key = targetKey(target);
+    if (!key) return [];
+    const existing = root._cfxFocusTrail || [];
+    const trail = [target, ...existing.filter((item) => targetKey(item) !== key)].slice(0, 5);
+    applyFocusTrail(root, trail);
+    if (emit !== false) emitHostEvent(root, 'cfxtrail', { target, trail, count: trail.length });
+    if (sync !== false) emitSync(root, { action: 'trail', target, trail, count: trail.length });
+    return trail;
+  };
+  const revealLayer = (root) => {
+    let layer = root.querySelector('[data-cfx-reveal-layer]');
+    if (layer) return layer;
+    const stage = root.querySelector('.cfx-stage');
+    if (!stage) return null;
+    layer = document.createElement('div');
+    layer.className = 'cfx-reveal-layer';
+    layer.dataset.cfxRevealLayer = 'true';
+    layer.setAttribute('aria-live', 'polite');
+    layer.hidden = true;
+    stage.appendChild(layer);
+    return layer;
+  };
+  const clearReveals = (root, source) => {
+    if (source && root.dataset.cfxRevealSource && root.dataset.cfxRevealSource !== source) return;
+    const layer = root.querySelector('[data-cfx-reveal-layer]');
+    if (layer) {
+      layer.replaceChildren();
+      layer.hidden = true;
+    }
+    root.removeAttribute('data-cfx-reveal-count');
+    root.removeAttribute('data-cfx-reveal-source');
+  };
+  const revealText = (node, target) => {
+    const data = node.dataset || {};
+    if (data.cfxLabel || data.cfxText) return data.cfxLabel || data.cfxText;
+    if (target && target.label) return target.label;
+    if (data.cfxSeries !== undefined && data.cfxPoint === undefined) return 'Series ' + data.cfxSeries;
+    if (data.cfxPoint !== undefined) return text(node);
+    return text(node) || (target ? target.role || target.id : '') || 'Target';
+  };
+  const revealNodes = (root, nodes, emit, sync, source) => {
+    if (!hasFeature(root, 'RevealLabels')) return [];
+    const layer = revealLayer(root);
+    const stage = root.querySelector('.cfx-stage');
+    if (!layer || !stage) return [];
+    const stageRect = stage.getBoundingClientRect();
+    const shown = [];
+    const seen = new Set();
+    layer.replaceChildren();
+    layer.hidden = false;
+    (nodes || []).forEach((node) => {
+      if (!node || !stage.contains(node) || node.closest('[data-cfx-role="legend-item"]')) return;
+      const target = targetIdentity(node);
+      const labelText = revealText(node, target);
+      const key = [labelText, target.series ?? '', target.point ?? '', target.value || ''].join('|');
+      if (!key || seen.has(key) || shown.length >= 6) return;
+      const rect = node.getBoundingClientRect();
+      if (!rect.width && !rect.height) return;
+      seen.add(key);
+      const label = document.createElement('span');
+      label.className = 'cfx-reveal-label';
+      label.textContent = labelText;
+      label.dataset.cfxRevealIndex = String(shown.length + 1);
+      label.title = label.textContent;
+      label.style.left = (rect.left + rect.width / 2 - stageRect.left) + 'px';
+      label.style.top = (rect.top - stageRect.top) + 'px';
+      layer.appendChild(label);
+      const halfWidth = label.offsetWidth / 2;
+      const maxX = Math.max(8 + halfWidth, stageRect.width - halfWidth - 8);
+      const maxY = Math.max(0, stageRect.height - label.offsetHeight - 8);
+      label.style.left = clamp(rect.left + rect.width / 2 - stageRect.left, 8 + halfWidth, maxX) + 'px';
+      label.style.top = clamp(rect.top - stageRect.top - label.offsetHeight - 8, 8, maxY) + 'px';
+      shown.push(target);
+    });
+    if (!shown.length) {
+      clearReveals(root);
+      return [];
+    }
+    root.dataset.cfxRevealCount = String(shown.length);
+    if (source) root.dataset.cfxRevealSource = source;
+    else root.removeAttribute('data-cfx-reveal-source');
+    if (emit !== false) emitHostEvent(root, 'cfxreveal', { target: shown[0], targets: shown, count: shown.length, source: source || '' });
+    if (sync !== false) emitSync(root, { action: 'reveal', target: shown[0], targets: shown, count: shown.length, source: source || '' });
+    return shown;
+  };
+  const revealTargets = (root, targets, emit, sync, source) => {
+    if (!targets || !targets.length) return [];
+    const nodes = [];
+    const seen = new Set();
+    targets.forEach((target) => {
+      root.querySelectorAll(targetSelector).forEach((node) => {
+        if (!matchesTargetIdentity(node, target)) return;
+        const key = targetKey(targetIdentity(node));
+        if (!key || seen.has(key)) return;
+        seen.add(key);
+        nodes.push(node);
+      });
+    });
+    return revealNodes(root, nodes, emit, sync, source);
+  };
+  const setHover = (root, node, emit, sync) => {
+    const target = targetIdentity(node);
+    clearHover(root, false, false);
+    applyHoverByTarget(root, target);
+    root.dataset.cfxHoverKey = targetKey(target);
+    recordFocusTrail(root, target, emit, sync);
+    revealNodes(root, [node], emit, sync, 'hover');
+    if (emit !== false) emitHostEvent(root, 'cfxhover', { label: text(node), target });
+    if (sync !== false) emitSync(root, { action: 'hover', label: text(node), target });
+  };
+  const hideCrosshair = (root, crosshair) => {
+    if (crosshair) crosshair.hidden = true;
+    root.removeAttribute('data-cfx-crosshair');
+  };
+  const nearestPoint = (root, event) => {
+    const stage = root.querySelector('.cfx-stage');
+    if (!stage) return null;
+    const stageRect = stage.getBoundingClientRect();
+    if (event.clientX < stageRect.left || event.clientX > stageRect.right || event.clientY < stageRect.top || event.clientY > stageRect.bottom) return null;
+    let best = null;
+    root.querySelectorAll('[data-cfx-point]').forEach((node) => {
+      if (node.closest('[data-cfx-role="legend-item"]') || node.classList.contains('cfx-series-muted')) return;
+      const box = node.getBoundingClientRect();
+      if (!box.width && !box.height) return;
+      const x = box.left + box.width / 2;
+      const y = box.top + box.height / 2;
+      const dx = x - event.clientX;
+      const dy = y - event.clientY;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      if (!best || distance < best.distance) best = { node, x, y, distance };
+    });
+    return best && best.distance <= 120 ? best : null;
+  };
+  const showCrosshair = (root, crosshair, point, event, emit) => {
+    if (!crosshair || !point) return;
+    const stage = root.querySelector('.cfx-stage');
+    if (!stage) return;
+    const rect = stage.getBoundingClientRect();
+    crosshair.hidden = false;
+    crosshair.style.setProperty('--cfx-crosshair-x', (point.x - rect.left) + 'px');
+    crosshair.style.setProperty('--cfx-crosshair-y', (point.y - rect.top) + 'px');
+    const label = crosshair.querySelector('[data-cfx-crosshair-label]');
+    if (label) label.textContent = text(point.node);
+    const target = targetIdentity(point.node);
+    root.dataset.cfxCrosshair = targetKey(target);
+    if (emit !== false) {
+      emitHostEvent(root, 'cfxcrosshair', { label: text(point.node), target, x: event.clientX, y: event.clientY });
+      emitSync(root, { action: 'crosshair', label: text(point.node), target });
+    }
+  };
+  const updateNearestPoint = (root, crosshair, tip, event) => {
+    if (!hasFeature(root, 'Crosshair')) return;
+    const point = nearestPoint(root, event);
+    if (!point) {
+      hideCrosshair(root, crosshair);
+      clearHover(root, true, true);
+      return;
+    }
+    const target = targetIdentity(point.node);
+    const key = targetKey(target);
+    if (root.dataset.cfxHoverKey !== key) {
+      setHover(root, point.node, true, true);
+      showCrosshair(root, crosshair, point, event, true);
+      showTip(root, tip, point.node, event);
+    } else {
+      showCrosshair(root, crosshair, point, event, false);
+      moveTip(tip, event, point.node);
+    }
+  };
+  const focusAdjacentTarget = (root, node, key) => {
+    const targets = interactiveTargets(root);
+    if (!targets.length) return false;
+    const current = Math.max(0, targets.indexOf(node));
+    let next = current;
+    if (key === 'Home') next = 0;
+    else if (key === 'End') next = targets.length - 1;
+    else if (key === 'ArrowLeft' || key === 'ArrowUp') next = current <= 0 ? targets.length - 1 : current - 1;
+    else if (key === 'ArrowRight' || key === 'ArrowDown') next = current >= targets.length - 1 ? 0 : current + 1;
+    else return false;
+    const targetNode = targets[next];
+    if (!targetNode) return false;
+    if (targetNode.focus) {
+      try { targetNode.focus({ preventScroll: true }); } catch { targetNode.focus(); }
+    }
+    const target = targetIdentity(targetNode);
+    emitHostEvent(root, 'cfxnavigate', { label: text(targetNode), target, index: next, count: targets.length, key });
+    emitSync(root, { action: 'navigate', label: text(targetNode), target, index: next, count: targets.length, key });
+    return true;
+  };
+  const applySelectionByLabel = (root, label, selected) => {
+    if (!label) return;
+    root.querySelectorAll(targetSelector).forEach((node) => {
+      if (text(node) === label) setNodeSelected(node, selected);
+    });
+  };
+  const matchesTargetIdentity = (node, target) => {
+    if (!target) return false;
+    const data = node.dataset || {};
+    if (target.id && (node.id === target.id || data.cfxId === target.id)) return true;
+    if (target.series !== undefined && target.point !== undefined && data.cfxSeries === String(target.series) && data.cfxPoint === String(target.point)) return true;
+    if (target.series !== undefined && target.point === undefined && data.cfxSeries === String(target.series) && target.role && data.cfxRole === target.role) return true;
+    if (target.role && data.cfxRole === target.role && target.label && (data.cfxLabel === target.label || data.cfxText === target.label || node.getAttribute('aria-label') === target.label)) return true;
+    if (target.role && data.cfxRole === target.role && target.value && (data.cfxValue === target.value || data.cfxY === target.value || data.cfxEnd === target.value)) return true;
+    return false;
+  };
+  const applySelectionByTarget = (root, target, selected) => {
+    if (!target) return false;
+    let matched = false;
+    root.querySelectorAll(targetSelector).forEach((node) => {
+      if (!matchesTargetIdentity(node, target)) return;
+      matched = true;
+      setNodeSelected(node, selected);
+    });
+    return matched;
+  };
+  const clearSelections = (root) => {
+    root.querySelectorAll('.cfx-selected').forEach((node) => {
+      node.classList.remove('cfx-selected');
+      node.removeAttribute('aria-selected');
+    });
+  };
+  const applySelectionSetByTargets = (root, targets, replace) => {
+    if (replace !== false) clearSelections(root);
+    let count = 0;
+    (targets || []).forEach((target) => {
+      if (applySelectionByTarget(root, target, true)) count++;
+    });
+    return count;
+  };
+  const nodeCenterInRect = (node, rect) => {
+    const box = node.getBoundingClientRect();
+    if (!box.width && !box.height) return null;
+    const x = box.left + box.width / 2;
+    const y = box.top + box.height / 2;
+    if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) return null;
+    return { x, y };
+  };
+  const selectTargetsInBox = (root, rect, append) => {
+    if (!hasFeature(root, 'Selection')) return [];
+    if (!append) clearSelections(root);
+    const targets = [];
+    root.querySelectorAll(lassoSelector).forEach((node) => {
+      if (node.closest('[data-cfx-role="legend-item"]')) return;
+      if (!nodeCenterInRect(node, rect)) return;
+      setNodeSelected(node, true);
+      targets.push(targetIdentity(node));
+    });
+    return targets;
+  };
+  const applySync = (root, detail) => {
+    if (!detail || detail.chartId === root.dataset.cfxChartId) return;
+    if (detail.action === 'viewport' && detail.state) applyViewport(root, detail.state);
+    else if (detail.action === 'brush') root.dataset.cfxBrush = detail.bounds || '';
+    else if (detail.action === 'selection') {
+      if (!applySelectionByTarget(root, detail.target, detail.selected === true)) applySelectionByLabel(root, detail.label || '', detail.selected === true);
+      renderCompare(root);
+    } else if (detail.action === 'lasso') {
+      applySelectionSetByTargets(root, detail.targets || [], detail.replace !== false);
+      renderCompare(root);
+    } else if (detail.action === 'compare') {
+      applySelectionSetByTargets(root, detail.targets || [], true);
+      renderCompare(root);
+    }
+    else if (detail.action === 'hover') {
+      clearHover(root, false, false);
+      applyHoverByTarget(root, detail.target);
+      revealTargets(root, [detail.target], false, false, detail.source || 'hover');
+    } else if (detail.action === 'hover-clear') clearHover(root, false, false);
+    else if (detail.action === 'crosshair' || detail.action === 'navigate') {
+      clearHover(root, false, false);
+      applyHoverByTarget(root, detail.target);
+      revealTargets(root, [detail.target], false, false, detail.action);
+    }
+    else if (detail.action === 'trail') applyFocusTrail(root, detail.trail || []);
+    else if (detail.action === 'reveal') revealTargets(root, detail.targets || [], false, false, detail.source || '');
+    else if (detail.action === 'reveal-clear') clearReveals(root, detail.source || '');
+    else if (detail.action === 'state') applyInteractionState(root, detail.state, false, false);
+    else if (detail.action === 'series' && detail.series !== undefined) setSeriesMuted(root, detail.series, detail.muted === true);
+    else if (detail.action === 'series-focus') setSeriesIsolation(root, detail.series || '', detail.isolated === true);
+    else if (detail.action === 'scenario') setScenario(root, detail.scenarioId || '', false, false);
+    else if (detail.action === 'scenario-step') {
+      if (detail.scenarioId && root.dataset.cfxActiveScenario !== detail.scenarioId) setScenario(root, detail.scenarioId, false, false);
+      setScenarioStep(root, detail.index, false, false);
+    }
+  };

--- a/ChartForgeX.Interactivity.Html/Assets/interactive.source/60-scenarios.js
+++ b/ChartForgeX.Interactivity.Html/Assets/interactive.source/60-scenarios.js
@@ -1,0 +1,269 @@
+  const readJson = (value, fallback) => {
+    try {
+      const parsed = JSON.parse(value || '');
+      return parsed === null || parsed === undefined ? fallback : parsed;
+    } catch {
+      return fallback;
+    }
+  };
+  const scenarioUrlParam = (root, name) => {
+    if (root.dataset.cfxDeepLinkState !== 'true') return '';
+    try {
+      const params = new URL(window.location.href).searchParams;
+      return params.get(scenarioUrlKey(root, name)) || params.get(name) || '';
+    } catch { return ''; }
+  };
+  const scenarioUrlKey = (root, name) => {
+    const chartId = (root.dataset.cfxChartId || 'chart').replace(/[^a-z0-9_.-]+/gi, '-').replace(/^-+|-+$/g, '') || 'chart';
+    return 'cfx-' + chartId + '-' + name;
+  };
+  const syncScenarioUrl = (root, scenarioId, stepIndex) => {
+    if (root.dataset.cfxDeepLinkState !== 'true' || !window.history || !window.history.replaceState) return;
+    try {
+      const url = new URL(window.location.href);
+      const scenarioKey = scenarioUrlKey(root, 'scenario');
+      const stepKey = scenarioUrlKey(root, 'scenarioStep');
+      scenarioId ? url.searchParams.set(scenarioKey, scenarioId) : url.searchParams.delete(scenarioKey);
+      stepIndex === undefined || stepIndex === null || stepIndex === '' ? url.searchParams.delete(stepKey) : url.searchParams.set(stepKey, stepIndex);
+      url.searchParams.delete('scenario');
+      url.searchParams.delete('scenarioStep');
+      window.history.replaceState(window.history.state, '', url);
+    } catch { }
+  };
+  const scenarioButton = (root, scenarioId) => Array.from(root.querySelectorAll('[data-cfx-scenario]')).find((button) => (button.dataset.cfxScenario || '') === scenarioId) || null;
+  const scenarioRoute = (root, scenarioId) => {
+    const button = scenarioButton(root, scenarioId);
+    if (!button || !scenarioId) return null;
+    return {
+      id: scenarioId,
+      label: button.dataset.cfxScenarioLabel || button.textContent.trim(),
+      description: button.dataset.cfxScenarioDescription || '',
+      color: button.dataset.cfxScenarioColor || '',
+      steps: readJson(button.dataset.cfxScenarioSteps || '[]', []),
+      metadata: readJson(button.dataset.cfxScenarioMetadata || '{}', {})
+    };
+  };
+  const scenarioTargetMatches = (node, step) => {
+    const data = node.dataset || {};
+    const kind = step.targetKind || '';
+    const target = step.targetId || '';
+    if (kind === 'series' && data.cfxSeries === target) return true;
+    if (kind === 'point' && data.cfxPoint === target) return true;
+    if (kind === 'point' && data.cfxSeries !== undefined && data.cfxPoint !== undefined && (data.cfxSeries + ':' + data.cfxPoint === target || data.cfxSeries + '.' + data.cfxPoint === target)) return true;
+    if (kind === 'annotation' && (data.cfxRole || '').indexOf('annotation') === 0 && (data.cfxLabel === target || data.cfxKind === target || data.cfxValue === target || data.cfxId === target || node.id === target)) return true;
+    if (kind === 'element' && (data.cfxId === target || node.id === target)) return true;
+    if (data.cfxRole === kind && (data.cfxLabel === target || data.cfxText === target || data.cfxValue === target || data.cfxY === target)) return true;
+    return false;
+  };
+  const scenarioTargetCandidates = (root, route) => {
+    const candidates = new Set(root.querySelectorAll('.cfx-interactive-region,[data-cfx-label],[data-cfx-role],[data-cfx-series],[data-cfx-point],[data-cfx-id]'));
+    const elementIds = new Set((route ? route.steps : [])
+      .filter((step) => (step.targetKind || '') === 'element' && step.targetId)
+      .map((step) => step.targetId));
+    if (elementIds.size) {
+      root.querySelectorAll('[id]').forEach((node) => {
+        if (!elementIds.has(node.id) || node.closest('defs')) return;
+        if (node.querySelector('.cfx-interactive-region,[data-cfx-label],[data-cfx-role],[data-cfx-series],[data-cfx-point],[data-cfx-id]')) return;
+        candidates.add(node);
+      });
+    }
+    return Array.from(candidates);
+  };
+  const scenarioTargets = (root, route, stepIndex) => {
+    const matches = new Set();
+    if (!route) return matches;
+    const steps = stepIndex === undefined || stepIndex === null ? route.steps : route.steps.filter((_, index) => index === Number(stepIndex));
+    scenarioTargetCandidates(root, route).forEach((node) => {
+      if (steps.some((step) => scenarioTargetMatches(node, step))) matches.add(node);
+    });
+    return matches;
+  };
+  const renderScenarioPanel = (root, route) => {
+    const panel = root.querySelector('[data-cfx-scenario-panel]');
+    if (!panel) return;
+    const title = panel.querySelector('[data-cfx-scenario-panel-title]');
+    const meta = panel.querySelector('[data-cfx-scenario-panel-meta]');
+    const steps = panel.querySelector('[data-cfx-scenario-panel-steps]');
+    if (!route) {
+      panel.removeAttribute('data-cfx-panel-active-scenario');
+      panel.style.removeProperty('--cfx-scenario-color');
+      if (title) title.textContent = 'All';
+      if (meta) meta.textContent = 'All chart data visible';
+      if (steps) steps.replaceChildren();
+      return;
+    }
+    panel.setAttribute('data-cfx-panel-active-scenario', route.id);
+    if (route.color) panel.style.setProperty('--cfx-scenario-color', route.color);
+    else panel.style.removeProperty('--cfx-scenario-color');
+    if (title) title.textContent = route.label || route.id;
+    if (meta) {
+      const pairs = Object.entries(route.metadata || {}).slice(0, 2).map(([key, value]) => key + ': ' + value);
+      meta.textContent = [route.description, route.steps.length ? route.steps.length + ' steps' : '', ...pairs].filter(Boolean).join(' / ');
+    }
+    if (steps) {
+      steps.replaceChildren();
+      route.steps.forEach((step, index) => {
+        const item = document.createElement('li');
+        item.setAttribute('data-cfx-scenario-step-index', String(index + 1));
+        item.setAttribute('data-cfx-scenario-target-kind', step.targetKind || '');
+        item.setAttribute('data-cfx-scenario-target-id', step.targetId || '');
+        item.setAttribute('role', 'button');
+        item.setAttribute('tabindex', '0');
+        item.textContent = step.label || step.targetId || '';
+        steps.appendChild(item);
+      });
+    }
+  };
+  const updateScenarioProgress = (root, route, stepIndex) => {
+    const progress = root.querySelector('[data-cfx-scenario-progress]');
+    const count = route && route.steps ? route.steps.length : 0;
+    const hasStep = stepIndex !== undefined && stepIndex !== null && stepIndex !== '';
+    const current = count && hasStep ? clamp(Number(stepIndex) + 1, 0, count) : 0;
+    const percent = count ? Math.round((current / count) * 100) : 0;
+    const label = 'Step ' + current + ' / ' + count;
+    if (progress) {
+      progress.hidden = !count;
+      progress.style.setProperty('--cfx-scenario-progress', percent + '%');
+      progress.setAttribute('aria-valuemax', String(count));
+      progress.setAttribute('aria-valuenow', String(current));
+      progress.setAttribute('aria-valuetext', label);
+      const textNode = progress.querySelector('[data-cfx-scenario-progress-text]');
+      if (textNode) textNode.textContent = label;
+    }
+    if (count) root.dataset.cfxScenarioProgress = current + '/' + count;
+    else root.removeAttribute('data-cfx-scenario-progress');
+    return { current, count, percent, label };
+  };
+  const clearScenarioStep = (root) => {
+    const route = scenarioRoute(root, root.dataset.cfxActiveScenario || '');
+    root.removeAttribute('data-cfx-active-scenario-step');
+    root.querySelectorAll('.cfx-scenario-step-active,.cfx-scenario-step-muted').forEach((node) => node.classList.remove('cfx-scenario-step-active', 'cfx-scenario-step-muted'));
+    root.querySelectorAll('[data-cfx-scenario-step-index]').forEach((node) => node.removeAttribute('aria-current'));
+    updateScenarioProgress(root, route, null);
+  };
+  const setScenarioStep = (root, stepIndex, emit, sync) => {
+    const route = scenarioRoute(root, root.dataset.cfxActiveScenario || '');
+    if (!route || !route.steps.length) return;
+    const index = clamp(Number(stepIndex) || 0, 0, route.steps.length - 1);
+    const targets = scenarioTargets(root, route, index);
+    root.dataset.cfxActiveScenarioStep = String(index);
+    root.querySelectorAll('.cfx-scenario-active').forEach((node) => {
+      const active = targets.has(node);
+      node.classList.toggle('cfx-scenario-step-active', active);
+      node.classList.toggle('cfx-scenario-step-muted', !active);
+    });
+    root.querySelectorAll('[data-cfx-scenario-step-index]').forEach((node) => {
+      node.getAttribute('data-cfx-scenario-step-index') === String(index + 1) ? node.setAttribute('aria-current', 'step') : node.removeAttribute('aria-current');
+    });
+    const progress = updateScenarioProgress(root, route, index);
+    const trail = Array.from(targets).map((node) => targetIdentity(node)).slice(0, 5);
+    if (trail.length && hasFeature(root, 'FocusTrail')) {
+      applyFocusTrail(root, trail);
+      if (emit !== false) emitHostEvent(root, 'cfxtrail', { target: trail[0], trail, count: trail.length, source: 'scenario-step' });
+      if (sync !== false) emitSync(root, { action: 'trail', target: trail[0], trail, count: trail.length, source: 'scenario-step' });
+    }
+    revealNodes(root, Array.from(targets), emit, sync, 'scenario-step');
+    syncScenarioUrl(root, route.id, index);
+    if (emit !== false) emitHostEvent(root, 'cfxscenariostep', { scenarioId: route.id, index, step: route.steps[index], progress });
+    if (sync !== false) emitSync(root, { action: 'scenario-step', scenarioId: route.id, index, progress });
+  };
+  const setScenario = (root, scenarioId, emit, sync) => {
+    const route = scenarioRoute(root, scenarioId);
+    const previousPlayback = root.dataset.cfxScenarioPlayback || '';
+    stopScenarioPlayback(root, 'idle', emit !== false && previousPlayback && previousPlayback !== 'idle');
+    clearScenarioStep(root);
+    clearReveals(root);
+    root.querySelectorAll('.cfx-scenario-active,.cfx-scenario-muted').forEach((node) => node.classList.remove('cfx-scenario-active', 'cfx-scenario-muted'));
+    root.querySelectorAll('[data-cfx-scenario]').forEach((button) => button.setAttribute('aria-pressed', (button.dataset.cfxScenario || '') === (route ? route.id : '') ? 'true' : 'false'));
+    if (!route) {
+      root.removeAttribute('data-cfx-active-scenario');
+      renderScenarioPanel(root, null);
+      updateScenarioProgress(root, null, null);
+      syncScenarioUrl(root, '', '');
+      if (emit !== false) emitHostEvent(root, 'cfxscenarioclear', {});
+      if (sync !== false) emitSync(root, { action: 'scenario', scenarioId: '' });
+      return;
+    }
+    root.dataset.cfxActiveScenario = route.id;
+    if (route.color) root.style.setProperty('--cfx-scenario-color', route.color);
+    else root.style.removeProperty('--cfx-scenario-color');
+    const targets = scenarioTargets(root, route, null);
+    scenarioTargetCandidates(root, route).forEach((node) => {
+      const active = targets.has(node);
+      node.classList.toggle('cfx-scenario-active', active);
+      node.classList.toggle('cfx-scenario-muted', !active);
+    });
+    renderScenarioPanel(root, route);
+    updateScenarioProgress(root, route, null);
+    syncScenarioUrl(root, route.id, '');
+    if (emit !== false) emitHostEvent(root, 'cfxscenario', { scenarioId: route.id, label: route.label, description: route.description, color: route.color, steps: route.steps, metadata: route.metadata });
+    if (sync !== false) emitSync(root, { action: 'scenario', scenarioId: route.id });
+  };
+  const stepScenario = (root, delta) => {
+    const route = scenarioRoute(root, root.dataset.cfxActiveScenario || '');
+    if (!route || !route.steps.length) return;
+    const current = Number(root.dataset.cfxActiveScenarioStep || (delta > 0 ? '-1' : route.steps.length));
+    setScenarioStep(root, current + delta, true, true);
+  };
+  const scenarioPlaybackDelay = (root) => {
+    const delay = Number(root.dataset.cfxScenarioPlaybackDelay || '900');
+    return Number.isFinite(delay) && delay >= 200 ? delay : 900;
+  };
+  const setScenarioPlaybackState = (root, state, route, emit) => {
+    const normalized = state || 'idle';
+    root.dataset.cfxScenarioPlayback = normalized;
+    root.querySelectorAll('[data-cfx-scenario-step-control="play"]').forEach((button) => {
+      const playing = normalized === 'playing';
+      button.setAttribute('aria-pressed', playing ? 'true' : 'false');
+      button.textContent = playing ? (button.dataset.cfxScenarioPauseLabel || 'Pause') : (button.dataset.cfxScenarioPlayLabel || 'Play');
+      button.title = playing ? 'Pause scenario' : 'Play scenario';
+    });
+    if (emit !== false) {
+      emitHostEvent(root, 'cfxscenarioplayback', {
+        state: normalized,
+        scenarioId: route ? route.id : (root.dataset.cfxActiveScenario || ''),
+        stepIndex: root.dataset.cfxActiveScenarioStep || '',
+        progress: root.dataset.cfxScenarioProgress || '',
+        delay: scenarioPlaybackDelay(root)
+      });
+    }
+  };
+  const stopScenarioPlayback = (root, state, emit) => {
+    if (root._cfxScenarioPlayback) window.clearInterval(root._cfxScenarioPlayback);
+    root._cfxScenarioPlayback = null;
+    setScenarioPlaybackState(root, state || 'idle', scenarioRoute(root, root.dataset.cfxActiveScenario || ''), emit);
+  };
+  const playScenario = (root, emit) => {
+    const route = scenarioRoute(root, root.dataset.cfxActiveScenario || '');
+    if (!route || !route.steps.length) return;
+    if (root._cfxScenarioPlayback) {
+      stopScenarioPlayback(root, 'paused', emit);
+      return;
+    }
+    let index = Number(root.dataset.cfxActiveScenarioStep || '-1') + 1;
+    if (!Number.isFinite(index) || index >= route.steps.length) index = 0;
+    startScenarioPlayback(root, route, index, emit, true);
+  };
+  const startScenarioPlayback = (root, route, stepIndex, emit, advanceNow) => {
+    if (!route || !route.steps.length) return;
+    setScenarioPlaybackState(root, 'playing', route, emit);
+    let index = Number(stepIndex);
+    if (!Number.isFinite(index) || index >= route.steps.length) index = 0;
+    root._cfxScenarioPlayback = window.setInterval(() => {
+      if (index >= route.steps.length) {
+        stopScenarioPlayback(root, 'finished', emit);
+        return;
+      }
+      setScenarioStep(root, index++, true, true);
+    }, scenarioPlaybackDelay(root));
+    if (advanceNow !== false) setScenarioStep(root, index++, true, true);
+  };
+  const copyScenarioLink = (root) => {
+    syncScenarioUrl(root, root.dataset.cfxActiveScenario || '', root.dataset.cfxActiveScenarioStep || '');
+    const url = window.location.href;
+    if (navigator.clipboard && navigator.clipboard.writeText) navigator.clipboard.writeText(url).catch(() => {});
+    emitHostEvent(root, 'cfxscenariolink', { url });
+  };
+  document.querySelectorAll('.cfx-interactive-chart').forEach((root) => {
+    if (root.dataset.cfxRuntimeBound === 'true') return;
+    root.dataset.cfxRuntimeBound = 'true';

--- a/ChartForgeX.Interactivity.Html/Assets/interactive.source/80-bindings.js
+++ b/ChartForgeX.Interactivity.Html/Assets/interactive.source/80-bindings.js
@@ -1,0 +1,228 @@
+    const tip = root.querySelector('.cfx-tooltip');
+    const stage = root.querySelector('.cfx-stage');
+    const brush = root.querySelector('.cfx-brush-box');
+    const crosshair = root.querySelector('.cfx-crosshair');
+    const compareTray = root.querySelector('[data-cfx-compare-tray]');
+    if (!tip) return;
+    applyViewport(root, getState(root));
+    renderCompare(root);
+    if (compareTray) compareTray.addEventListener('pointerdown', (event) => event.stopPropagation());
+    if (hasFeature(root, 'StateBookmarks')) {
+      root.addEventListener('cfx-capture-state', (event) => {
+        const detail = event.detail || {};
+        publishInteractionState(root, detail.source || 'host', detail.sync);
+      });
+      root.addEventListener('cfx-apply-state', (event) => {
+        const detail = event.detail || {};
+        applyInteractionState(root, detail.snapshot || detail.state || detail, true, detail.sync);
+      });
+    }
+    const targets = interactiveTargets(root);
+    targets.forEach((node) => {
+      if (!node.hasAttribute('tabindex')) node.setAttribute('tabindex', '0');
+      node.addEventListener('pointerenter', (event) => {
+        setHover(root, node, true, true);
+        showTip(root, tip, node, event);
+      });
+      node.addEventListener('pointermove', (event) => moveTip(tip, event, node));
+      node.addEventListener('pointerleave', () => {
+        clearHover(root, true, true);
+        hideTip(root, tip, false);
+      });
+      node.addEventListener('focus', (event) => {
+        setHover(root, node, true, true);
+        showTip(root, tip, node, event);
+      });
+      node.addEventListener('blur', () => {
+        clearHover(root, true, true);
+        hideTip(root, tip, false);
+      });
+      node.addEventListener('click', (event) => {
+        if ((node.dataset ? node.dataset.cfxRole : '') === 'legend-item') {
+          if (event.shiftKey) toggleSeriesFocus(root, node, true, true);
+          else toggleSeries(root, node);
+        }
+        else {
+          toggleSelection(root, node);
+          pinTip(root, tip, node, event);
+        }
+      });
+      node.addEventListener('keydown', (event) => {
+        if (!hasFeature(root, 'KeyboardNavigation')) return;
+        if ((node.dataset ? node.dataset.cfxRole : '') === 'legend-item' && event.key.toLowerCase() === 'i') {
+          event.preventDefault();
+          toggleSeriesFocus(root, node, true, true);
+          return;
+        }
+        if (focusAdjacentTarget(root, node, event.key)) {
+          event.preventDefault();
+          return;
+        }
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        if ((node.dataset ? node.dataset.cfxRole : '') === 'legend-item' && event.shiftKey) toggleSeriesFocus(root, node, true, true);
+        else node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    });
+    root.querySelectorAll('[data-cfx-zoom]').forEach((button) => {
+      button.addEventListener('click', () => zoomBy(root, button.dataset.cfxZoom === 'in' ? 1.25 : 0.8));
+    });
+    root.querySelectorAll('[data-cfx-mode-button]').forEach((button) => {
+      button.addEventListener('click', () => setMode(root, button.dataset.cfxModeButton || ''));
+    });
+    root.querySelectorAll('[data-cfx-export]').forEach((button) => {
+      button.addEventListener('click', () => {
+        if (button.dataset.cfxExport === 'png') exportPng(root);
+        else exportSvg(root);
+      });
+    });
+    root.querySelectorAll('[data-cfx-scenario]').forEach((button) => {
+      button.addEventListener('click', () => setScenario(root, button.dataset.cfxScenario || '', true));
+    });
+    if (hasFeature(root, 'Scenarios')) {
+      root.addEventListener('cfx-set-scenario', (event) => {
+        const detail = event.detail || {};
+        setScenario(root, detail.scenarioId || '', true, true);
+      });
+      root.addEventListener('cfx-clear-scenario', () => setScenario(root, '', true, true));
+    }
+    if (hasFeature(root, 'StepPlayback')) {
+      root.querySelectorAll('[data-cfx-scenario-step-control]').forEach((button) => {
+        button.addEventListener('click', () => {
+          const action = button.dataset.cfxScenarioStepControl || '';
+          if (action === 'previous') stepScenario(root, -1);
+          else if (action === 'next') stepScenario(root, 1);
+          else if (action === 'play') playScenario(root);
+          else if (action === 'reset') { stopScenarioPlayback(root, 'paused'); clearScenarioStep(root); clearReveals(root); }
+          else if (action === 'link') copyScenarioLink(root);
+        });
+      });
+      root.addEventListener('cfx-set-scenario-step', (event) => {
+        const detail = event.detail || {};
+        if (detail.scenarioId && root.dataset.cfxActiveScenario !== detail.scenarioId) setScenario(root, detail.scenarioId, true, true);
+        const index = detail.index !== undefined ? detail.index : detail.stepIndex;
+        setScenarioStep(root, index, true, true);
+      });
+      root.addEventListener('cfx-clear-scenario-step', () => {
+        stopScenarioPlayback(root, 'paused');
+        clearScenarioStep(root);
+        clearReveals(root);
+      });
+      root.addEventListener('cfx-play-scenario', (event) => {
+        const detail = event.detail || {};
+        if (detail.scenarioId && root.dataset.cfxActiveScenario !== detail.scenarioId) setScenario(root, detail.scenarioId, true, true);
+        playScenario(root);
+      });
+      root.addEventListener('cfx-pause-scenario', () => stopScenarioPlayback(root, 'paused'));
+      const stepsList = root.querySelector('[data-cfx-scenario-panel-steps]');
+      if (stepsList) {
+        const focusStep = (target) => {
+          const item = target instanceof Element ? target.closest('[data-cfx-scenario-step-index]') : null;
+          if (item && stepsList.contains(item)) setScenarioStep(root, Number(item.getAttribute('data-cfx-scenario-step-index')) - 1, true, true);
+        };
+        stepsList.addEventListener('click', (event) => focusStep(event.target));
+        stepsList.addEventListener('keydown', (event) => {
+          if (event.key !== 'Enter' && event.key !== ' ') return;
+          event.preventDefault();
+          focusStep(event.target);
+        });
+      }
+    }
+    if (hasFeature(root, 'Scenarios')) {
+      const initialScenario = scenarioUrlParam(root, 'scenario') || root.dataset.cfxActiveScenario || '';
+      const initialScenarioStep = scenarioUrlParam(root, 'scenarioStep');
+      setScenario(root, initialScenario, false, false);
+      if (hasFeature(root, 'StepPlayback') && initialScenarioStep) setScenarioStep(root, initialScenarioStep, false, false);
+    }
+    if (stage) {
+      stage.addEventListener('wheel', (event) => {
+        if (!hasFeature(root, 'Zoom')) return;
+        event.preventDefault();
+        zoomBy(root, event.deltaY < 0 ? 1.08 : 0.92);
+      }, { passive: false });
+      let drag = null;
+      stage.addEventListener('pointerdown', (event) => {
+        if (event.button !== 0) return;
+        if (root.dataset.cfxMode === 'pan' && hasFeature(root, 'Pan')) {
+          const state = getState(root);
+          drag = { mode: 'pan', id: event.pointerId, x: event.clientX, y: event.clientY, panX: state.panX, panY: state.panY };
+          stage.setPointerCapture(event.pointerId);
+        } else if (root.dataset.cfxMode === 'brush' && hasFeature(root, 'Brush') && brush) {
+          const rect = stage.getBoundingClientRect();
+          drag = { mode: 'brush', id: event.pointerId, left: event.clientX - rect.left, top: event.clientY - rect.top };
+          brush.hidden = false;
+          brush.style.left = drag.left + 'px';
+          brush.style.top = drag.top + 'px';
+          brush.style.width = '0px';
+          brush.style.height = '0px';
+          stage.setPointerCapture(event.pointerId);
+        }
+      });
+      stage.addEventListener('pointermove', (event) => {
+        if (!drag || drag.id !== event.pointerId) {
+          updateNearestPoint(root, crosshair, tip, event);
+          return;
+        }
+        if (drag.mode === 'pan') {
+          applyViewport(root, { zoom: getState(root).zoom, panX: drag.panX + event.clientX - drag.x, panY: drag.panY + event.clientY - drag.y });
+        } else if (drag.mode === 'brush' && brush) {
+          const rect = stage.getBoundingClientRect();
+          const x = clamp(event.clientX - rect.left, 0, rect.width);
+          const y = clamp(event.clientY - rect.top, 0, rect.height);
+          const left = Math.min(drag.left, x);
+          const top = Math.min(drag.top, y);
+          brush.style.left = left + 'px';
+          brush.style.top = top + 'px';
+          brush.style.width = Math.abs(x - drag.left) + 'px';
+          brush.style.height = Math.abs(y - drag.top) + 'px';
+        }
+      });
+      stage.addEventListener('pointerup', (event) => {
+        if (!drag || drag.id !== event.pointerId) return;
+        if (drag.mode === 'brush' && brush) {
+          root.dataset.cfxBrush = [brush.style.left, brush.style.top, brush.style.width, brush.style.height].join(' ');
+          const selectedTargets = selectTargetsInBox(root, brush.getBoundingClientRect(), event.shiftKey);
+          const replaceSelection = !event.shiftKey;
+          emitHostEvent(root, 'cfxbrush', { bounds: root.dataset.cfxBrush });
+          if (selectedTargets.length || replaceSelection) emitHostEvent(root, 'cfxlasso', { bounds: root.dataset.cfxBrush, count: selectedTargets.length, targets: selectedTargets });
+          emitSync(root, { action: 'brush', bounds: root.dataset.cfxBrush });
+          if (selectedTargets.length || replaceSelection) emitSync(root, { action: 'lasso', bounds: root.dataset.cfxBrush, targets: selectedTargets, replace: replaceSelection });
+          publishCompare(root, true);
+        } else if (drag.mode === 'pan') {
+          emitHostEvent(root, 'cfxviewport', { state: getState(root) });
+          emitSync(root, { action: 'viewport', state: getState(root) });
+        }
+        stage.releasePointerCapture(event.pointerId);
+        drag = null;
+      });
+      stage.addEventListener('pointerleave', () => {
+        hideCrosshair(root, crosshair);
+        clearHover(root, true, true);
+        hideTip(root, tip, false);
+      });
+      stage.addEventListener('pointercancel', () => {
+        drag = null;
+        hideCrosshair(root, crosshair);
+        clearHover(root, true, true);
+        hideTip(root, tip, false);
+      });
+    }
+    const reset = root.querySelector('[data-cfx-reset]');
+    if (reset) reset.addEventListener('click', () => {
+      resetViewport(root);
+      emitHostEvent(root, 'cfxreset', {});
+      emitHostEvent(root, 'cfxviewport', { state: getState(root) });
+      emitSync(root, { action: 'viewport', state: getState(root) });
+      clearSelections(root);
+      root.querySelectorAll('.cfx-series-muted').forEach((node) => node.classList.remove('cfx-series-muted'));
+      root.querySelectorAll('[data-cfx-muted]').forEach((node) => node.removeAttribute('data-cfx-muted'));
+      setSeriesIsolation(root, root.dataset.cfxIsolatedSeries || '', false);
+      clearFocusTrail(root);
+      clearReveals(root);
+      if (brush) brush.hidden = true;
+      hideCrosshair(root, crosshair);
+      hideTip(root, tip, true);
+      publishCompare(root, true);
+    });
+  });
+})();

--- a/ChartForgeX.Interactivity.Html/HtmlInteractiveChartRenderer.cs
+++ b/ChartForgeX.Interactivity.Html/HtmlInteractiveChartRenderer.cs
@@ -71,6 +71,39 @@ public sealed class HtmlInteractiveChartRenderer {
         return writer.Build();
     }
 
+    /// <summary>
+    /// Renders the specified chart to an embeddable interactive HTML fragment without stylesheet or script assets.
+    /// </summary>
+    /// <param name="chart">The chart to render.</param>
+    /// <returns>An embeddable interactive HTML fragment that expects the caller to register interactive chart assets.</returns>
+    public string RenderFragmentWithoutAssets(Chart chart) => RenderFragmentWithoutAssets(chart, null);
+
+    /// <summary>
+    /// Renders the specified chart to an embeddable interactive HTML fragment without stylesheet or script assets.
+    /// </summary>
+    /// <param name="chart">The chart to render.</param>
+    /// <param name="configure">An optional configuration callback for the HTML interaction adapter.</param>
+    /// <returns>An embeddable interactive HTML fragment that expects the caller to register interactive chart assets.</returns>
+    public string RenderFragmentWithoutAssets(Chart chart, Action<HtmlChartInteractionOptions>? configure) {
+        if (chart == null) throw new ArgumentNullException(nameof(chart));
+        var options = new HtmlChartInteractionOptions();
+        configure?.Invoke(options);
+        var title = options.PageTitle ?? ChartTitle(chart, "ChartForgeX interactive chart");
+        return BuildChartSection(chart, options, title);
+    }
+
+    /// <summary>
+    /// Builds the stylesheet used by embeddable interactive chart fragments.
+    /// </summary>
+    /// <returns>CSS ready to register once in a host document.</returns>
+    public static string BuildFragmentStyle() => InteractiveFragmentStyle;
+
+    /// <summary>
+    /// Builds the JavaScript runtime used by embeddable interactive chart fragments.
+    /// </summary>
+    /// <returns>JavaScript ready to register once in a host document.</returns>
+    public static string BuildInteractionScript() => InteractiveScript;
+
     internal static string InteractiveStyle => HtmlInteractiveAssets.Style;
 
     internal static string InteractiveFragmentStyle => HtmlInteractiveAssets.Style

--- a/ChartForgeX.Interactivity.Html/InteractiveChartExtensions.cs
+++ b/ChartForgeX.Interactivity.Html/InteractiveChartExtensions.cs
@@ -41,6 +41,21 @@ public static class InteractiveChartExtensions {
     public static string ToInteractiveHtmlFragment(this Chart chart, Action<HtmlChartInteractionOptions>? configure) => new HtmlInteractiveChartRenderer().RenderFragment(chart, configure);
 
     /// <summary>
+    /// Renders a chart to an interactive HTML fragment without stylesheet or script assets.
+    /// </summary>
+    /// <param name="chart">The chart to render.</param>
+    /// <returns>An embeddable interactive HTML fragment that expects the host document to register interactive chart assets.</returns>
+    public static string ToInteractiveHtmlFragmentWithoutAssets(this Chart chart) => new HtmlInteractiveChartRenderer().RenderFragmentWithoutAssets(chart);
+
+    /// <summary>
+    /// Renders a chart to an interactive HTML fragment without stylesheet or script assets.
+    /// </summary>
+    /// <param name="chart">The chart to render.</param>
+    /// <param name="configure">An optional configuration callback for the HTML interaction adapter.</param>
+    /// <returns>An embeddable interactive HTML fragment that expects the host document to register interactive chart assets.</returns>
+    public static string ToInteractiveHtmlFragmentWithoutAssets(this Chart chart, Action<HtmlChartInteractionOptions>? configure) => new HtmlInteractiveChartRenderer().RenderFragmentWithoutAssets(chart, configure);
+
+    /// <summary>
     /// Saves a chart as a self-contained interactive HTML document.
     /// </summary>
     /// <param name="chart">The chart to render.</param>

--- a/ChartForgeX.Tests/SmokeTests/InteractiveAssetSourceTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/InteractiveAssetSourceTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void InteractiveJavaScriptAssetsStayGeneratedFromSourceFragments() {
+        var root = FindRepositoryRoot();
+        var syncScript = Path.Combine(root, "Build", "Sync-InteractiveAssets.ps1");
+        Assert(File.Exists(syncScript), "Interactive JS assets should include a dependency-free source sync script.");
+
+        AssertGeneratedAssetMatchesSource(
+            root,
+            Path.Combine("ChartForgeX", "Topology", "Assets", "topology-interaction.source"),
+            Path.Combine("ChartForgeX", "Topology", "Assets", "topology-interaction.js"));
+
+        AssertGeneratedAssetMatchesSource(
+            root,
+            Path.Combine("ChartForgeX.Interactivity.Html", "Assets", "interactive.source"),
+            Path.Combine("ChartForgeX.Interactivity.Html", "Assets", "interactive.js"));
+    }
+
+    private static void AssertGeneratedAssetMatchesSource(string root, string sourceRelativePath, string targetRelativePath) {
+        var sourceDirectory = Path.Combine(root, sourceRelativePath);
+        var targetPath = Path.Combine(root, targetRelativePath);
+        Assert(Directory.Exists(sourceDirectory), "Interactive JS source fragments should exist: " + sourceRelativePath);
+        Assert(File.Exists(targetPath), "Interactive JS generated output should exist: " + targetRelativePath);
+
+        var parts = Directory.EnumerateFiles(sourceDirectory, "*.js", SearchOption.TopDirectoryOnly)
+            .OrderBy(Path.GetFileName, StringComparer.Ordinal)
+            .ToArray();
+        Assert(parts.Length >= 3, "Interactive JS assets should be split into maintainable source fragments: " + sourceRelativePath);
+
+        var generated = string.Join("\n", parts.Select(part => NormalizeAsset(File.ReadAllText(part)).TrimEnd('\n'))) + "\n";
+        var current = NormalizeAsset(File.ReadAllText(targetPath));
+        Assert(current == generated, "Generated interactive JS asset is out of date: " + targetRelativePath + ". Run Build/Sync-InteractiveAssets.ps1.");
+    }
+
+    private static string NormalizeAsset(string value) => value.Replace("\r\n", "\n").Replace("\r", "\n");
+}

--- a/ChartForgeX.Tests/SmokeTests/InteractivityTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/InteractivityTests.cs
@@ -184,6 +184,18 @@ internal static partial class SmokeTests {
         Assert(fragment.Contains("data-cfx-chart-id=\"embedded-security-posture\"", StringComparison.Ordinal), "Interactive fragments should preserve configured chart ids for host synchronization.");
         Assert(fragment.Contains("cfxRuntimeBound", StringComparison.Ordinal), "Interactive fragments should guard chart roots against duplicate event binding when embedded several times.");
         Assert(fragment.Contains("<script>", StringComparison.Ordinal), "Interactive fragments should include the dependency-free runtime script.");
+        var assetlessFragment = SampleChart().ToInteractiveHtmlFragmentWithoutAssets(options => {
+            options.IdScope = "assetless-security-posture";
+            options.Interaction.ChartId = "assetless-security-posture";
+            options.Interaction.Enable(ChartInteractionFeatures.Zoom | ChartInteractionFeatures.Pan);
+        });
+        Assert(assetlessFragment.Contains("class=\"cfx-interactive-chart\"", StringComparison.Ordinal), "Asset-light interactive fragments should still include the reusable chart section.");
+        Assert(assetlessFragment.Contains("data-cfx-chart-id=\"assetless-security-posture\"", StringComparison.Ordinal), "Asset-light interactive fragments should preserve configured chart ids.");
+        Assert(!assetlessFragment.Contains("data-cfx-interactive-assets=\"true\"", StringComparison.Ordinal), "Asset-light interactive fragments should omit inline interactive chart CSS assets.");
+        Assert(!assetlessFragment.Contains("<script>", StringComparison.Ordinal), "Asset-light interactive fragments should omit the inline interactive chart runtime script.");
+        Assert(HtmlInteractiveChartRenderer.BuildFragmentStyle().Contains(".cfx-interactive-chart, .cfx-interactive-chart * {", StringComparison.Ordinal), "Host-registered interactive chart CSS should remain scoped to chart fragments.");
+        Assert(HtmlInteractiveChartRenderer.BuildInteractionScript().Contains("cfxRuntimeBound", StringComparison.Ordinal), "Host-registered interactive chart runtime should keep duplicate binding guards.");
+        Assert(!HtmlInteractiveChartRenderer.BuildInteractionScript().Contains("<script>", StringComparison.Ordinal), "Host-registered interactive chart runtime should return raw JavaScript for library registration.");
 
         var noReset = SampleChart().ToInteractiveHtmlPage(options => {
             options.IncludeResetButton = false;

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -6,6 +6,7 @@ internal static partial class SmokeTests {
     internal static (string Name, Action Run)[] Tests { get; } = {
         ("Source files stay under architecture line budget", SourceFilesStayUnderArchitectureLineBudget),
         ("Project files keep strict build settings", ProjectFilesKeepStrictBuildSettings),
+        ("Interactive JavaScript assets stay generated from source fragments", InteractiveJavaScriptAssetsStayGeneratedFromSourceFragments),
         ("VS Code markup extension keeps CLI-backed contract", VsCodeMarkupExtensionKeepsCliBackedContract),
         ("Chart-kind traits centralize renderer classification", ChartKindTraitsCentralizeRendererClassification),
         ("Line polish layers stay shared across SVG and PNG", LinePolishLayersStaySharedAcrossSvgAndPng),

--- a/ChartForgeX.Tests/SmokeTests/TopologyHtmlInteractionTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/TopologyHtmlInteractionTests.cs
@@ -125,6 +125,19 @@ internal static partial class SmokeTests {
         Assert(checkboxHtml.Contains("scenarioIdTokens(initialScenario)", StringComparison.Ordinal), "Checkbox scenario mode should restore multi-route filters from URL state.");
         Assert(checkboxHtml.Contains("initialScenarioStep && (scenarioControlMode !== 'checkboxes' || attr(wrapper, 'data-cfx-active-scenario'))", StringComparison.Ordinal), "Checkbox scenario mode should restore route step deep links only when the URL names one active route.");
         Assert(checkboxHtml.Contains("syncScenarioUrl(routes.map(route => route.scenarioId).join(','), '')", StringComparison.Ordinal), "Checkbox scenario mode should serialize route filters into URL state when enabled.");
+
+        var helperCheckboxHtml = chart.ToHtmlPage(new TopologyRenderOptions().WithHtmlScenarioCheckboxes());
+        Assert(helperCheckboxHtml.Contains("data-cfx-interactive=\"true\"", StringComparison.Ordinal), "Scenario checkbox helper should enable the topology HTML runtime.");
+        Assert(helperCheckboxHtml.Contains("data-cfx-topology-scenario-toggle=\"primary\"", StringComparison.Ordinal), "Scenario checkbox helper should render checkbox controls without requiring a separate interaction toggle.");
+
+        var helperPanelHtml = chart.ToHtmlPage(new TopologyRenderOptions().WithHtmlScenarioPanel());
+        Assert(helperPanelHtml.Contains("data-cfx-interactive=\"true\"", StringComparison.Ordinal), "Scenario panel helper should enable the topology HTML runtime.");
+        Assert(helperPanelHtml.Contains("data-cfx-topology-scenario-panel=\"true\"", StringComparison.Ordinal), "Scenario panel helper should render the route panel without requiring a separate interaction toggle.");
+
+        var helperUrlStateHtml = chart.ToHtmlPage(new TopologyRenderOptions().WithHtmlScenarioUrlState());
+        Assert(helperUrlStateHtml.Contains("data-cfx-interactive=\"true\"", StringComparison.Ordinal), "Scenario URL-state helper should enable the topology HTML runtime.");
+        Assert(helperUrlStateHtml.Contains("data-cfx-scenario-url-state=\"true\"", StringComparison.Ordinal), "Scenario URL-state helper should expose query-string route state.");
+        Assert(helperUrlStateHtml.Contains("data-cfx-scenario-step-control=\"link\"", StringComparison.Ordinal), "Scenario URL-state helper should render copy-link controls without requiring a separate interaction toggle.");
     }
 
     private static void TopologyHtmlPagesExposeSelectionInteractions() {
@@ -147,6 +160,7 @@ internal static partial class SmokeTests {
         Assert(html.Contains("cfx-topology-select", StringComparison.Ordinal), "Topology HTML pages should dispatch host-friendly selection events.");
         Assert(html.Contains("data-cfx-selection-kind", StringComparison.Ordinal), "Topology HTML pages should track selected topology element kind.");
         Assert(html.Contains("data-cfx-selection-status", StringComparison.Ordinal), "Topology HTML pages should track selected topology element status.");
+        Assert(html.Contains("label: attr(element, 'data-node-label')", StringComparison.Ordinal), "Topology selection events should expose display labels for host panels.");
         Assert(html.Contains("metadata: collectPrefixed(element, 'data-cfx-meta-')", StringComparison.Ordinal), "Topology selection events should expose metadata attributes as a host-friendly object.");
         Assert(html.Contains("metrics: collectPrefixed(element, 'data-cfx-metric-')", StringComparison.Ordinal), "Topology selection events should expose metric attributes as a host-friendly object.");
         Assert(html.Contains("layoutInference: attr(element, 'data-edge-layout-inference')", StringComparison.Ordinal), "Topology selection events should expose inferred edge layout diagnostics.");
@@ -162,6 +176,13 @@ internal static partial class SmokeTests {
         Assert(html.Contains("event.key === 'ArrowRight'", StringComparison.Ordinal) && html.Contains("focusRelated(element", StringComparison.Ordinal), "Topology HTML pages should support arrow-key navigation across related topology elements.");
         Assert(html.Contains("cfx-topology-set-selection", StringComparison.Ordinal), "Topology HTML pages should allow hosts to drive selection state.");
         Assert(html.Contains("cfx-topology-clear-selection", StringComparison.Ordinal), "Topology HTML pages should allow hosts to clear selection state.");
+        Assert(html.Contains("cfx-topology-set-filter", StringComparison.Ordinal), "Topology HTML pages should allow hosts to drive query, status, group, and kind filters.");
+        Assert(html.Contains("cfx-topology-clear-filter", StringComparison.Ordinal), "Topology HTML pages should allow hosts to clear topology filters.");
+        Assert(html.Contains("cfx-topology-filter", StringComparison.Ordinal), "Topology HTML pages should dispatch host-friendly filter result events.");
+        Assert(html.Contains("cfx-topology-fit-visible", StringComparison.Ordinal), "Topology HTML pages should allow hosts to fit the viewport to visible or selected topology elements.");
+        Assert(html.Contains("fitViewportToElements", StringComparison.Ordinal), "Topology filters should fit the viewport to the remaining visible topology geometry.");
+        Assert(html.Contains("data-cfx-filter-active", StringComparison.Ordinal), "Topology HTML pages should expose host-readable filter activity state.");
+        Assert(html.Contains("cfx-topology-html-filter-hidden", StringComparison.Ordinal), "Topology filters should hide non-matching nodes, edges, labels, and groups without requiring force-graph controls.");
         Assert(html.Contains("cfx-topology-hover", StringComparison.Ordinal), "Topology HTML pages should dispatch host-friendly hover events.");
         Assert(html.Contains("cfx-topology-hover-clear", StringComparison.Ordinal), "Topology HTML pages should dispatch host-friendly hover-clear events.");
         Assert(html.Contains("data-cfx-hover-kind", StringComparison.Ordinal), "Topology HTML pages should track hovered topology element kind.");
@@ -220,6 +241,19 @@ internal static partial class SmokeTests {
         Assert(fragmentHtml.Contains("<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M12 5v14M5 12h14\"", StringComparison.Ordinal), "Topology fragment controls should render icon-style buttons instead of raw text controls.");
         Assert(fragmentHtml.Contains("cfx-topology-select", StringComparison.Ordinal), "Interactive topology fragments should include the topology runtime script.");
         Assert(fragmentHtml.Contains("data-cfx-runtime-bound", StringComparison.Ordinal), "The topology runtime should guard wrappers against duplicate event binding when several fragments are embedded.");
+
+        var assetlessOptions = new TopologyRenderOptions { IncludeLegend = false, EnableHtmlInteractions = true, EnableHtmlViewportControls = true, CssClassPrefix = "report-topology" };
+        var assetlessFragment = CreateSampleTopologyChart().ToHtmlFragmentWithoutAssets(assetlessOptions);
+        var assetlessStyle = TopologyHtmlRenderer.BuildFragmentStyle(assetlessOptions, TopologyTheme.Dark());
+        var assetlessScript = TopologyHtmlRenderer.BuildInteractionScript(assetlessOptions);
+        Assert(assetlessFragment.Contains("class=\"report-topology-wrapper\"", StringComparison.Ordinal), "Asset-light topology fragments should still render the requested wrapper prefix.");
+        Assert(!assetlessFragment.Contains("data-cfx-topology-assets=\"true\"", StringComparison.Ordinal), "Asset-light topology fragments should omit inline topology CSS assets.");
+        Assert(!assetlessFragment.Contains("<script>", StringComparison.Ordinal), "Asset-light topology fragments should omit the inline topology runtime script.");
+        Assert(assetlessStyle.Contains(".report-topology-wrapper{", StringComparison.Ordinal), "Host-registered topology CSS should honor the requested wrapper prefix.");
+        Assert(assetlessStyle.Contains(".report-topology-wrapper[data-cfx-viewport-controls='true']", StringComparison.Ordinal), "Host-registered topology CSS should honor prefixed control selectors.");
+        Assert(!assetlessStyle.Contains(".cfx-topology-wrapper", StringComparison.Ordinal), "Host-registered topology CSS should not leave stale default wrapper selectors for custom prefixes.");
+        Assert(assetlessScript.Contains("document.querySelectorAll('.report-topology-wrapper[data-cfx-interactive=\"true\"]')", StringComparison.Ordinal), "Host-registered topology runtime should honor the requested wrapper prefix.");
+        Assert(!assetlessScript.Contains("<script>", StringComparison.Ordinal), "Host-registered topology runtime should return raw JavaScript for library registration.");
 
         var staticExportHtml = CreateSampleTopologyChart().ToHtmlPage(new TopologyRenderOptions { EnableHtmlInteractions = false, EnableHtmlExportControls = true });
         Assert(staticExportHtml.Contains("data-cfx-export-controls=\"false\"", StringComparison.Ordinal), "Static topology HTML pages should not render export controls.");

--- a/ChartForgeX/Topology/Assets/topology-interaction.js
+++ b/ChartForgeX/Topology/Assets/topology-interaction.js
@@ -330,6 +330,57 @@
       wrapper.dispatchEvent(new CustomEvent('cfx-topology-fit', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), state: viewportState() } }));
       emitViewport();
     };
+    const isViewportVisible = element => {
+      if (!element || !(element instanceof Element)) return false;
+      if (element.classList.contains('cfx-topology-html-filter-hidden') || element.classList.contains('cfx-topology-html-force-hidden')) return false;
+      if (element.closest('.cfx-topology-html-filter-hidden,.cfx-topology-html-force-hidden')) return false;
+      return true;
+    };
+    const elementBounds = element => {
+      try {
+        if (element && element.getBBox) {
+          const box = element.getBBox();
+          if (box && Number.isFinite(box.x) && Number.isFinite(box.y) && box.width > 0 && box.height > 0) return box;
+        }
+      } catch { }
+      return null;
+    };
+    const fitViewportToElements = (elements, emit = true) => {
+      if (!viewportControls) return false;
+      const svg = topologySvg();
+      const viewBox = svg && svg.viewBox && svg.viewBox.baseVal ? svg.viewBox.baseVal : null;
+      if (!svg || !viewBox || viewBox.width <= 0 || viewBox.height <= 0) return false;
+      const boxes = Array.from(elements || []).filter(isViewportVisible).map(elementBounds).filter(box => box);
+      if (!boxes.length) return false;
+      const bounds = boxes.reduce((current, box) => ({
+        x: Math.min(current.x, box.x),
+        y: Math.min(current.y, box.y),
+        right: Math.max(current.right, box.x + box.width),
+        bottom: Math.max(current.bottom, box.y + box.height)
+      }), { x: boxes[0].x, y: boxes[0].y, right: boxes[0].x + boxes[0].width, bottom: boxes[0].y + boxes[0].height });
+      const metrics = viewportMetrics();
+      const unitX = metrics.svgWidth / viewBox.width;
+      const unitY = metrics.svgHeight / viewBox.height;
+      const boundsWidth = Math.max(1, (bounds.right - bounds.x) * unitX);
+      const boundsHeight = Math.max(1, (bounds.bottom - bounds.y) * unitY);
+      const padding = 44;
+      const zoom = clamp(Math.min(metrics.width / (boundsWidth + padding * 2), metrics.availableHeight / (boundsHeight + padding * 2)), 0.5, 3.2);
+      const centerX = (bounds.x + (bounds.right - bounds.x) / 2 - viewBox.x) * unitX;
+      const centerY = (bounds.y + (bounds.bottom - bounds.y) / 2 - viewBox.y) * unitY;
+      const originX = metrics.svgWidth / 2;
+      const originY = metrics.svgHeight / 2;
+      const targetX = metrics.width / 2;
+      const targetY = metrics.availableHeight / 2;
+      const panX = targetX - originX - zoom * (centerX - originX);
+      const panY = targetY - originY - zoom * (centerY - originY);
+      applyViewport({ zoom, panX, panY });
+      if (emit) {
+        wrapper.dispatchEvent(new CustomEvent('cfx-topology-fit', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), state: viewportState(), mode: 'visible', count: boxes.length } }));
+        emitViewport();
+      }
+      return true;
+    };
+    const fitVisibleTopology = (emit = true) => fitViewportToElements(wrapper.querySelectorAll('[data-cfx-role="topology-node"]:not(.cfx-topology-html-filter-hidden):not(.cfx-topology-html-force-hidden)'), emit);
     const markForceGraphMoving = () => {
       if (!forceGraphControls || wrapper.getAttribute('data-cfx-force-hide-moving-edges') !== 'true') return;
       wrapper.setAttribute('data-cfx-force-moving-edges', 'true');
@@ -723,6 +774,7 @@
           ...base,
           kind: 'node',
           id: attr(element, 'data-node-id'),
+          label: attr(element, 'data-node-label'),
           nodeKind: attr(element, 'data-node-kind'),
           groupId: attr(element, 'data-group-id'),
           displayMode: attr(element, 'data-node-display-mode'),
@@ -744,6 +796,7 @@
           ...base,
           kind: 'edge',
           id: attr(element, 'data-edge-id'),
+          label: attr(element, 'data-edge-label'),
           edgeKind: attr(element, 'data-edge-kind'),
           sourceNodeId: attr(element, 'data-source-node-id'),
           targetNodeId: attr(element, 'data-target-node-id'),
@@ -778,6 +831,7 @@
           ...base,
           kind: 'group',
           id: attr(element, 'data-group-id'),
+          label: attr(element, 'data-group-label'),
           symbol: attr(element, 'data-group-symbol'),
           color: attr(element, 'data-group-color'),
           iconId: attr(element, 'data-group-icon-id'),
@@ -925,6 +979,101 @@
       renderSelectionPanel({ ...detail, element });
       delete detail.element;
     };
+    const topologyFilterSearchText = element => [
+      attr(element, 'data-node-id'), attr(element, 'data-node-label'), attr(element, 'data-node-kind'), attr(element, 'data-group-id'),
+      attr(element, 'data-edge-id'), attr(element, 'data-edge-label'), attr(element, 'data-edge-secondary-label'), attr(element, 'data-edge-tertiary-label'), attr(element, 'data-edge-kind'), attr(element, 'data-source-node-id'), attr(element, 'data-target-node-id'),
+      attr(element, 'data-group-label'), attr(element, 'data-group-symbol'), attr(element, 'data-cfx-status'), element.textContent || ''
+    ].join(' ').toLowerCase();
+    const topologyFilterEscape = value => window.CSS && CSS.escape ? CSS.escape(value) : String(value).replace(/["\\]/g, '\\$&');
+    let topologyFilterState = { query: '', status: '', group: '', kind: '', edges: true, labels: true, groups: true };
+    const setTopologyFilterHidden = (selector, predicate) => {
+      wrapper.querySelectorAll(selector).forEach(element => element.classList.toggle('cfx-topology-html-filter-hidden', predicate(element)));
+    };
+    const setTopologyFilterAttributes = detail => {
+      wrapper.setAttribute('data-cfx-filter-query', detail.query || '');
+      wrapper.setAttribute('data-cfx-filter-status', detail.status || '');
+      wrapper.setAttribute('data-cfx-filter-group', detail.group || '');
+      wrapper.setAttribute('data-cfx-filter-kind', detail.kind || '');
+      wrapper.setAttribute('data-cfx-filter-active', detail.active ? 'true' : 'false');
+      wrapper.setAttribute('data-cfx-visible-nodes', String(detail.nodes));
+      wrapper.setAttribute('data-cfx-visible-edges', String(detail.edges));
+    };
+    const applyTopologyFilter = state => {
+      topologyFilterState = Object.assign({}, topologyFilterState, state || {});
+      const query = String(topologyFilterState.query || '').trim().toLowerCase();
+      const status = String(topologyFilterState.status || '').trim();
+      const group = String(topologyFilterState.group || '').trim();
+      const kind = String(topologyFilterState.kind || '').trim();
+      const showEdges = topologyFilterState.edges !== false;
+      const showLabels = topologyFilterState.labels !== false;
+      const showGroups = topologyFilterState.groups !== false;
+      const active = !!(query || status || group || kind || !showEdges || !showLabels || !showGroups);
+      const visibleNodes = new Set();
+      const queryNodes = new Set();
+      const statusNodes = new Set();
+      if (query) {
+        wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+          if (!topologyFilterSearchText(edge).includes(query)) return;
+          queryNodes.add(attr(edge, 'data-source-node-id'));
+          queryNodes.add(attr(edge, 'data-target-node-id'));
+        });
+        wrapper.querySelectorAll('[data-cfx-role="topology-group"]').forEach(groupElement => {
+          if (!topologyFilterSearchText(groupElement).includes(query)) return;
+          const groupId = attr(groupElement, 'data-group-id');
+          wrapper.querySelectorAll('[data-cfx-role="topology-node"][data-group-id="' + topologyFilterEscape(groupId) + '"]').forEach(node => queryNodes.add(attr(node, 'data-node-id')));
+        });
+      }
+      if (status) {
+        wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+          if (attr(edge, 'data-cfx-status') !== status) return;
+          statusNodes.add(attr(edge, 'data-source-node-id'));
+          statusNodes.add(attr(edge, 'data-target-node-id'));
+        });
+      }
+      wrapper.querySelectorAll('[data-cfx-role="topology-node"]').forEach(node => {
+        const nodeId = attr(node, 'data-node-id');
+        const groupOk = !group || attr(node, 'data-group-id') === group;
+        const statusOk = !status || attr(node, 'data-cfx-status') === status || statusNodes.has(nodeId);
+        const kindOk = !kind || attr(node, 'data-node-kind') === kind;
+        const queryOk = !query || topologyFilterSearchText(node).includes(query) || queryNodes.has(nodeId);
+        const visible = groupOk && statusOk && kindOk && queryOk;
+        node.classList.toggle('cfx-topology-html-filter-hidden', !visible);
+        wrapper.querySelectorAll('[data-cfx-role="topology-node-status"][data-node-id="' + topologyFilterEscape(nodeId) + '"]').forEach(statusBadge => statusBadge.classList.toggle('cfx-topology-html-filter-hidden', !visible));
+        if (visible) visibleNodes.add(nodeId);
+      });
+      const nodeById = id => wrapper.querySelector('[data-cfx-role="topology-node"][data-node-id="' + topologyFilterEscape(id) + '"]');
+      setTopologyFilterHidden('[data-cfx-role="topology-edge"]', edge => {
+        const sourceId = attr(edge, 'data-source-node-id');
+        const targetId = attr(edge, 'data-target-node-id');
+        const source = nodeById(sourceId);
+        const target = nodeById(targetId);
+        const endpointsVisible = visibleNodes.has(sourceId) && visibleNodes.has(targetId);
+        const edgeQueryOk = !query || topologyFilterSearchText(edge).includes(query) || (source && topologyFilterSearchText(source).includes(query)) || (target && topologyFilterSearchText(target).includes(query));
+        const edgeStatusOk = !status || attr(edge, 'data-cfx-status') === status || (source && attr(source, 'data-cfx-status') === status) || (target && attr(target, 'data-cfx-status') === status);
+        return !showEdges || !endpointsVisible || !edgeQueryOk || !edgeStatusOk;
+      });
+      setTopologyFilterHidden('[data-cfx-role="topology-edge-label"]', label => !showLabels || !showEdges || !wrapper.querySelector('[data-cfx-role="topology-edge"][data-edge-id="' + topologyFilterEscape(attr(label, 'data-edge-id')) + '"]:not(.cfx-topology-html-filter-hidden):not(.cfx-topology-html-force-hidden)'));
+      setTopologyFilterHidden('[data-cfx-role="topology-group"]', groupElement => {
+        const groupId = attr(groupElement, 'data-group-id');
+        const hasVisibleNodes = !!wrapper.querySelector('[data-cfx-role="topology-node"][data-group-id="' + topologyFilterEscape(groupId) + '"]:not(.cfx-topology-html-filter-hidden):not(.cfx-topology-html-force-hidden)');
+        return !showGroups || !hasVisibleNodes || (group && groupId !== group);
+      });
+      const detail = {
+        chartId: attr(wrapper, 'data-chart-id'),
+        nodes: visibleNodes.size,
+        edges: wrapper.querySelectorAll('[data-cfx-role="topology-edge"]:not(.cfx-topology-html-filter-hidden):not(.cfx-topology-html-force-hidden)').length,
+        query: topologyFilterState.query || '',
+        status,
+        group,
+        kind,
+        active
+      };
+      setTopologyFilterAttributes(detail);
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-filter', { bubbles: true, detail }));
+      if (active && visibleNodes.size) fitVisibleTopology(false);
+      restoreForceFocusLabels();
+    };
+    const clearTopologyFilter = () => applyTopologyFilter({ query: '', status: '', group: '', kind: '', edges: true, labels: true, groups: true });
     const forceSearchText = element => [
       attr(element, 'data-node-id'), attr(element, 'data-node-label'), attr(element, 'data-node-kind'), attr(element, 'data-group-id'),
       attr(element, 'data-edge-id'), attr(element, 'data-edge-label'), attr(element, 'data-edge-secondary-label'), attr(element, 'data-edge-tertiary-label'), attr(element, 'data-edge-kind'), attr(element, 'data-source-node-id'), attr(element, 'data-target-node-id'),
@@ -1005,7 +1154,10 @@
       const edgeCount = wrapper.querySelectorAll('[data-cfx-role="topology-edge"]:not(.cfx-topology-html-force-hidden)').length;
       const summary = forceGraphPanel.querySelector('[data-cfx-force-summary]');
       if (summary) summary.textContent = nodeCount + ' nodes / ' + edgeCount + ' edges visible';
-      wrapper.dispatchEvent(new CustomEvent('cfx-topology-force-filter', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), nodes: nodeCount, edges: edgeCount, query: state.query, status: state.status, group: state.group } }));
+      const detail = { chartId: attr(wrapper, 'data-chart-id'), nodes: nodeCount, edges: edgeCount, query: state.query, status: state.status, group: state.group, kind: '', active: !!(state.query || state.status || state.group || !state.edges || !state.labels || !state.groups) };
+      setTopologyFilterAttributes(detail);
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-filter', { bubbles: true, detail }));
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-force-filter', { bubbles: true, detail }));
       restoreForceFocusLabels();
     };
     const clearForceFocusLabels = () => {
@@ -1126,6 +1278,18 @@
         emitViewport();
       });
       wrapper.addEventListener('cfx-topology-reset-viewport', () => resetViewport());
+      wrapper.addEventListener('cfx-topology-fit-visible', event => {
+        const detail = event.detail || {};
+        if (detail.kind && detail.id) {
+          const element = findSelection(detail);
+          if (element) {
+            fitViewportToElements([element]);
+            return;
+          }
+        }
+
+        fitVisibleTopology();
+      });
       wrapper.addEventListener('click', event => {
         if (isViewportChrome(event.target)) return;
         if (!suppressClick) return;
@@ -1163,6 +1327,8 @@
       });
       applyForceGraphFilters();
     }
+    wrapper.addEventListener('cfx-topology-set-filter', event => applyTopologyFilter(event.detail || {}));
+    wrapper.addEventListener('cfx-topology-clear-filter', () => clearTopologyFilter());
     if (scenarioControls) {
       if (scenarioControlMode === 'checkboxes') {
         wrapper.querySelectorAll('[data-cfx-topology-scenario-toggle]').forEach(input => {

--- a/ChartForgeX/Topology/Assets/topology-interaction.source/00-bootstrap.js
+++ b/ChartForgeX/Topology/Assets/topology-interaction.source/00-bootstrap.js
@@ -1,0 +1,74 @@
+(() => {
+  for (const wrapper of document.querySelectorAll('.cfx-topology-wrapper[data-cfx-interactive="true"]')) {
+    if (wrapper.getAttribute('data-cfx-runtime-bound') === 'true') continue;
+    wrapper.setAttribute('data-cfx-runtime-bound', 'true');
+    const selectables = '[data-cfx-role="topology-node"],[data-cfx-role="topology-edge"],[data-cfx-role="topology-group"]';
+    const viewportControls = wrapper.getAttribute('data-cfx-viewport-controls') === 'true';
+    const exportControls = wrapper.getAttribute('data-cfx-export-controls') === 'true';
+    const fullscreenControl = wrapper.getAttribute('data-cfx-fullscreen-control') === 'true';
+    const scenarioControls = wrapper.getAttribute('data-cfx-scenario-controls') === 'true';
+    const scenarioControlMode = wrapper.getAttribute('data-cfx-scenario-control-mode') || 'buttons';
+    const forceGraphControls = wrapper.getAttribute('data-cfx-force-graph-controls') === 'true';
+    const scenarioUrlState = wrapper.getAttribute('data-cfx-scenario-url-state') === 'true';
+    const scenarioPanel = wrapper.querySelector('[data-cfx-topology-scenario-panel]');
+    const selectionPanel = wrapper.querySelector('[data-cfx-topology-selection-panel]');
+    const forceGraphPanel = wrapper.querySelector('[data-cfx-force-graph-panel]');
+    const syncEnabled = wrapper.getAttribute('data-cfx-sync-enabled') === 'true';
+    const syncGroup = wrapper.getAttribute('data-cfx-sync-group') || '';
+    const viewport = wrapper.querySelector('.cfx-topology-viewport') || wrapper;
+    const topologyRoot = wrapper.querySelector('[data-cfx-role="topology"]');
+    const topologySvg = () => {
+      const root = wrapper.querySelector('[data-cfx-role="topology"]');
+      return root ? root.closest('svg') : (viewport.querySelector(':scope > svg') || wrapper.querySelector('svg'));
+    };
+    let applyingSync = false;
+    let scenarioPlayback = null;
+    let forceGraphMotionTimer = null;
+    const scenarioUrlKey = name => {
+      const chartId = attr(wrapper, 'data-chart-id').replace(/[^a-z0-9_.-]+/gi, '-').replace(/^-+|-+$/g, '') || 'topology';
+      return 'cfx-' + chartId + '-' + name;
+    };
+    const scenarioUrlParam = name => scenarioUrlState ? (() => { try { const params = new URL(window.location.href).searchParams; return params.get(scenarioUrlKey(name)) || params.get(name) || ''; } catch { return ''; } })() : '';
+    const syncScenarioUrl = (scenarioId, stepIndex) => {
+      if (!scenarioUrlState || !window.history || !window.history.replaceState) return;
+      try { const url = new URL(window.location.href); const scenarioKey = scenarioUrlKey('scenario'); const stepKey = scenarioUrlKey('scenarioStep'); scenarioId ? url.searchParams.set(scenarioKey, scenarioId) : url.searchParams.delete(scenarioKey); stepIndex === undefined || stepIndex === null || stepIndex === '' ? url.searchParams.delete(stepKey) : url.searchParams.set(stepKey, stepIndex); url.searchParams.delete('scenario'); url.searchParams.delete('scenarioStep'); window.history.replaceState(window.history.state, '', url); } catch { }
+    };
+    const attr = (element, name) => element.getAttribute(name) || '';
+    const toCamel = value => value.replace(/-([a-z0-9])/g, (_, ch) => ch.toUpperCase());
+    const collectPrefixed = (element, prefix) => {
+      const values = {};
+      for (const attribute of element.attributes) {
+        if (attribute.name.startsWith(prefix)) values[toCamel(attribute.name.slice(prefix.length))] = attribute.value;
+      }
+      return values;
+    };
+    const unique = values => Array.from(new Set(values.filter(value => value)));
+    const scenarioIdTokens = value => unique(String(value || '').split(/[,\s]+/).map(item => item.trim()));
+    const scenarioIds = element => (attr(element, 'data-scenario-ids') || '').split(/\s+/).filter(value => value);
+    const scenarioStepIndices = (element, scenarioId) => (attr(element, 'data-scenario-step-indices') || '').split(/\s+/).filter(value => value.startsWith(scenarioId + ':')).flatMap(value => value.slice(scenarioId.length + 1).split(',').filter(index => index));
+    const findScenarioButton = scenarioId => Array.from(wrapper.querySelectorAll('[data-cfx-topology-scenario],[data-cfx-topology-scenario-toggle]')).find(button => (attr(button, 'data-cfx-topology-scenario') || attr(button, 'data-cfx-topology-scenario-toggle')) === scenarioId) || null;
+    const scenarioSummaries = () => {
+      try {
+        const summaries = JSON.parse(attr(topologyRoot || wrapper, 'data-cfx-scenarios') || '[]');
+        return Array.isArray(summaries) ? summaries : [];
+      } catch {
+        return [];
+      }
+    };
+    const findScenarioSummary = scenarioId => scenarioSummaries().find(scenario => scenario && scenario.id === scenarioId) || null;
+    const scenarioSteps = button => {
+      try {
+        const steps = JSON.parse(attr(button, 'data-cfx-scenario-steps') || '[]');
+        return Array.isArray(steps) ? steps : [];
+      } catch {
+        return [];
+      }
+    };
+    const scenarioMetadata = button => {
+      try {
+        const metadata = JSON.parse(attr(button, 'data-cfx-scenario-metadata') || '{}');
+        return metadata && typeof metadata === 'object' && !Array.isArray(metadata) ? metadata : {};
+      } catch {
+        return {};
+      }
+    };

--- a/ChartForgeX/Topology/Assets/topology-interaction.source/20-scenario-controls.js
+++ b/ChartForgeX/Topology/Assets/topology-interaction.source/20-scenario-controls.js
@@ -1,0 +1,184 @@
+    const scenarioRoute = scenarioId => {
+      if (!scenarioId) return null;
+      const scenarioButton = findScenarioButton(scenarioId);
+      const scenarioSummary = scenarioButton ? null : findScenarioSummary(scenarioId);
+      if (!scenarioButton && !scenarioSummary) return null;
+      const steps = scenarioButton ? scenarioSteps(scenarioButton) : (Array.isArray(scenarioSummary.steps) ? scenarioSummary.steps : []);
+      const metadata = scenarioButton ? scenarioMetadata(scenarioButton) : (scenarioSummary.metadata && typeof scenarioSummary.metadata === 'object' && !Array.isArray(scenarioSummary.metadata) ? scenarioSummary.metadata : {});
+      const nodeIds = new Set();
+      const edgeIds = new Set();
+      const groupIds = new Set();
+      wrapper.querySelectorAll('[data-cfx-role="topology-node"][data-scenario-ids]').forEach(node => {
+        if (!scenarioIds(node).includes(scenarioId)) return;
+        nodeIds.add(attr(node, 'data-node-id'));
+        groupIds.add(attr(node, 'data-group-id'));
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge"][data-scenario-ids]').forEach(edge => {
+        if (!scenarioIds(edge).includes(scenarioId)) return;
+        edgeIds.add(attr(edge, 'data-edge-id'));
+        nodeIds.add(attr(edge, 'data-source-node-id'));
+        nodeIds.add(attr(edge, 'data-target-node-id'));
+        groupIds.add(attr(edge, 'data-source-group-id'));
+        groupIds.add(attr(edge, 'data-target-group-id'));
+      });
+      return {
+        scenarioId,
+        button: scenarioButton,
+        label: scenarioButton ? attr(scenarioButton, 'data-cfx-scenario-label') || scenarioButton.textContent.trim() : scenarioSummary.label || scenarioId,
+        description: scenarioButton ? attr(scenarioButton, 'data-cfx-scenario-description') : scenarioSummary.description || '',
+        color: scenarioButton ? attr(scenarioButton, 'data-cfx-scenario-color') : scenarioSummary.color || '',
+        stepCount: scenarioButton ? Number(attr(scenarioButton, 'data-cfx-scenario-step-count') || '0') : Number(scenarioSummary.stepCount || steps.length || 0),
+        metadata,
+        steps,
+        nodeIds,
+        edgeIds,
+        groupIds
+      };
+    };
+    const renderScenarioPanel = route => {
+      if (!scenarioPanel) return;
+      const title = scenarioPanel.querySelector('[data-cfx-scenario-panel-title]');
+      const meta = scenarioPanel.querySelector('[data-cfx-scenario-panel-meta]');
+      const stepsList = scenarioPanel.querySelector('[data-cfx-scenario-panel-steps]');
+      if (!route) {
+        scenarioPanel.removeAttribute('data-cfx-panel-active-scenario');
+        scenarioPanel.style.removeProperty('--cfx-topology-scenario-color');
+        if (title) title.textContent = 'All';
+        if (meta) meta.textContent = 'All topology routes visible';
+        if (stepsList) stepsList.replaceChildren();
+        return;
+      }
+
+      scenarioPanel.setAttribute('data-cfx-panel-active-scenario', route.scenarioId);
+      if (route.color) scenarioPanel.style.setProperty('--cfx-topology-scenario-color', route.color);
+      else scenarioPanel.style.removeProperty('--cfx-topology-scenario-color');
+      if (title) title.textContent = route.label || route.scenarioId;
+      if (meta) {
+        const metadata = Object.entries(route.metadata).slice(0, 2).map(([key, value]) => key + ': ' + value);
+        const summary = [route.description, route.stepCount ? route.stepCount + ' steps' : '', ...metadata].filter(value => value);
+        meta.textContent = summary.join(' / ');
+      }
+      if (stepsList) {
+        stepsList.replaceChildren();
+        route.steps.forEach(step => {
+          const item = document.createElement('li');
+          item.setAttribute('data-cfx-scenario-step-kind', step.kind || '');
+          item.setAttribute('data-cfx-scenario-step-id', step.id || '');
+          item.setAttribute('data-cfx-scenario-step-index', String((Number(step.index) || 0) + 1));
+          item.setAttribute('role', 'button');
+          item.setAttribute('tabindex', '0');
+          item.textContent = step.label || step.id || '';
+          stepsList.appendChild(item);
+        });
+      }
+    };
+    const clearScenarioPreview = () => {
+      wrapper.style.removeProperty('--cfx-topology-preview-scenario-color');
+      wrapper.querySelectorAll('.cfx-topology-html-scenario-preview,.cfx-topology-html-scenario-preview-muted').forEach(item => {
+        item.classList.remove('cfx-topology-html-scenario-preview', 'cfx-topology-html-scenario-preview-muted');
+      });
+    };
+    const previewScenario = scenarioId => {
+      clearScenarioPreview();
+      if (!scenarioId) return;
+      const route = scenarioRoute(scenarioId);
+      if (!route) return;
+      if (route.color) wrapper.style.setProperty('--cfx-topology-preview-scenario-color', route.color);
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+        const active = route.edgeIds.has(attr(edge, 'data-edge-id'));
+        edge.classList.toggle('cfx-topology-html-scenario-preview', active);
+        edge.classList.toggle('cfx-topology-html-scenario-preview-muted', !active);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge-label"]').forEach(label => {
+        const active = route.edgeIds.has(attr(label, 'data-edge-id'));
+        label.classList.toggle('cfx-topology-html-scenario-preview', active);
+        label.classList.toggle('cfx-topology-html-scenario-preview-muted', !active);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-node"]').forEach(node => {
+        const active = route.nodeIds.has(attr(node, 'data-node-id'));
+        node.classList.toggle('cfx-topology-html-scenario-preview', active);
+        node.classList.toggle('cfx-topology-html-scenario-preview-muted', !active);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-node-status"]').forEach(status => {
+        const active = route.nodeIds.has(attr(status, 'data-node-id'));
+        status.classList.toggle('cfx-topology-html-scenario-preview', active);
+        status.classList.toggle('cfx-topology-html-scenario-preview-muted', !active);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-group"]').forEach(group => {
+        const active = route.groupIds.has(attr(group, 'data-group-id'));
+        group.classList.toggle('cfx-topology-html-scenario-preview', active);
+        group.classList.toggle('cfx-topology-html-scenario-preview-muted', !active);
+      });
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-scenario-preview', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), scenarioId, label: route.label, description: route.description, color: route.color, stepCount: route.stepCount, metadata: route.metadata, steps: route.steps, nodeIds: Array.from(route.nodeIds), edgeIds: Array.from(route.edgeIds), groupIds: Array.from(route.groupIds) } }));
+    };
+    const updateScenarioStepControls = playing => {
+      const hasRoute = !!scenarioRoute(attr(wrapper, 'data-cfx-active-scenario'));
+      wrapper.querySelectorAll('[data-cfx-scenario-step-control]').forEach(button => {
+        button.disabled = !hasRoute;
+        if (attr(button, 'data-cfx-scenario-step-control') === 'play') button.setAttribute('aria-pressed', playing ? 'true' : 'false');
+      });
+    };
+    const clearScenarioStep = () => {
+      wrapper.removeAttribute('data-cfx-active-scenario-step');
+      wrapper.querySelectorAll('.cfx-topology-html-scenario-step-active,.cfx-topology-html-scenario-step-muted').forEach(item => item.classList.remove('cfx-topology-html-scenario-step-active', 'cfx-topology-html-scenario-step-muted'));
+      if (scenarioPanel) scenarioPanel.querySelectorAll('[data-cfx-scenario-step-id]').forEach(item => item.removeAttribute('aria-current'));
+      updateScenarioStepControls(false);
+    };
+    const stopScenarioPlayback = () => {
+      if (scenarioPlayback) window.clearInterval(scenarioPlayback);
+      scenarioPlayback = null;
+      updateScenarioStepControls(false);
+    };
+    const setScenarioStep = (stepIndex, keepPlaying, emit = true, sync = true) => {
+      const route = scenarioRoute(attr(wrapper, 'data-cfx-active-scenario'));
+      if (!route || !route.steps.length) return;
+      const requested = Number(stepIndex);
+      const index = clamp(Number.isFinite(requested) ? requested : 0, 0, route.steps.length - 1);
+      wrapper.setAttribute('data-cfx-active-scenario-step', String(index));
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge"],[data-cfx-role="topology-node"]').forEach(item => {
+        const routeMember = item.classList.contains('cfx-topology-html-scenario-active');
+        const current = routeMember && scenarioStepIndices(item, route.scenarioId).includes(String(index));
+        item.classList.toggle('cfx-topology-html-scenario-step-active', current);
+        item.classList.toggle('cfx-topology-html-scenario-step-muted', routeMember && !current);
+      });
+      if (scenarioPanel) scenarioPanel.querySelectorAll('[data-cfx-scenario-step-id]').forEach(item => {
+        if (attr(item, 'data-cfx-scenario-step-index') === String(index + 1)) item.setAttribute('aria-current', 'step');
+        else item.removeAttribute('aria-current');
+      });
+      if (!keepPlaying) stopScenarioPlayback();
+      if (emit) wrapper.dispatchEvent(new CustomEvent('cfx-topology-scenario-step', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), scenarioId: route.scenarioId, index, step: route.steps[index] } }));
+      syncScenarioUrl(route.scenarioId, index);
+      if (sync) emitSync('scenario-step', { scenarioId: route.scenarioId, index });
+    };
+    const stepScenario = delta => {
+      const route = scenarioRoute(attr(wrapper, 'data-cfx-active-scenario'));
+      if (!route) return;
+      const current = Number(wrapper.getAttribute('data-cfx-active-scenario-step') || (delta > 0 ? '-1' : route.steps.length));
+      setScenarioStep(current + delta, false);
+    };
+    const playScenario = () => {
+      const route = scenarioRoute(attr(wrapper, 'data-cfx-active-scenario'));
+      if (!route || !route.steps.length) return;
+      if (scenarioPlayback) {
+        stopScenarioPlayback();
+        return;
+      }
+      updateScenarioStepControls(true);
+      let index = Number(wrapper.getAttribute('data-cfx-active-scenario-step') || '-1') + 1;
+      if (!Number.isFinite(index) || index >= route.steps.length) index = 0;
+      scenarioPlayback = window.setInterval(() => {
+        if (index >= route.steps.length) {
+          stopScenarioPlayback();
+          return;
+        }
+        setScenarioStep(index++, true);
+      }, 900);
+      setScenarioStep(index++, true);
+    };
+    const copyScenarioLink = () => { syncScenarioUrl(attr(wrapper, 'data-cfx-active-scenario') || attr(wrapper, 'data-cfx-active-scenarios'), wrapper.getAttribute('data-cfx-active-scenario-step') || ''); const url = window.location.href; if (navigator.clipboard && navigator.clipboard.writeText) navigator.clipboard.writeText(url).catch(() => {}); wrapper.dispatchEvent(new CustomEvent('cfx-topology-scenario-link', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), url } })); };
+    const emitFullscreenState = () => wrapper.dispatchEvent(new CustomEvent('cfx-topology-fullscreen', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), fullscreen: document.fullscreenElement === wrapper } }));
+    const setFullscreenState = () => { wrapper.setAttribute('data-cfx-topology-fullscreen', document.fullscreenElement === wrapper ? 'true' : 'false'); emitFullscreenState(); };
+    const toggleFullscreen = () => {
+      if (!document.fullscreenElement && wrapper.requestFullscreen) wrapper.requestFullscreen().catch(() => {});
+      else if (document.fullscreenElement === wrapper && document.exitFullscreen) document.exitFullscreen().catch(() => {});
+    };

--- a/ChartForgeX/Topology/Assets/topology-interaction.source/40-viewport-export-and-scenarios.js
+++ b/ChartForgeX/Topology/Assets/topology-interaction.source/40-viewport-export-and-scenarios.js
@@ -1,0 +1,354 @@
+    const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+    const numberAttr = (name, fallback) => {
+      const value = Number(wrapper.getAttribute(name) || '');
+      return Number.isFinite(value) ? value : fallback;
+    };
+    const viewportState = () => ({
+      zoom: numberAttr('data-cfx-topology-zoom', 1),
+      panX: numberAttr('data-cfx-topology-pan-x', 0),
+      panY: numberAttr('data-cfx-topology-pan-y', 0)
+    });
+    const emitSync = (action, payload) => {
+      if (!syncEnabled || !syncGroup || applyingSync) return;
+      const detail = Object.assign({ chartId: attr(wrapper, 'data-chart-id'), group: syncGroup, action }, payload || {});
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-sync', { bubbles: true, detail }));
+      document.querySelectorAll('.cfx-topology-wrapper[data-cfx-interactive="true"][data-cfx-sync-enabled="true"]').forEach(peer => {
+        if (peer === wrapper || peer.getAttribute('data-cfx-sync-group') !== syncGroup) return;
+        peer.dispatchEvent(new CustomEvent('cfx-topology-apply-sync', { detail }));
+      });
+    };
+    const applyViewport = state => {
+      if (!viewportControls) return;
+      const next = {
+        zoom: clamp(Number(state.zoom) || 1, 0.5, 4),
+        panX: clamp(Number(state.panX) || 0, -4000, 4000),
+        panY: clamp(Number(state.panY) || 0, -4000, 4000)
+      };
+      wrapper.setAttribute('data-cfx-topology-zoom', next.zoom.toFixed(3));
+      wrapper.setAttribute('data-cfx-topology-pan-x', next.panX.toFixed(1));
+      wrapper.setAttribute('data-cfx-topology-pan-y', next.panY.toFixed(1));
+      wrapper.style.setProperty('--cfx-topology-zoom', next.zoom.toFixed(3));
+      wrapper.style.setProperty('--cfx-topology-pan-x', next.panX.toFixed(1) + 'px');
+      wrapper.style.setProperty('--cfx-topology-pan-y', next.panY.toFixed(1) + 'px');
+    };
+    const viewportMetrics = () => {
+      const svg = topologySvg();
+      const viewBox = svg && svg.viewBox && svg.viewBox.baseVal ? svg.viewBox.baseVal : null;
+      const rect = viewport.getBoundingClientRect ? viewport.getBoundingClientRect() : { width: 0, height: 0 };
+      const styles = window.getComputedStyle ? window.getComputedStyle(viewport) : null;
+      const paddingTop = styles ? Number.parseFloat(styles.paddingTop || '0') || 0 : 0;
+      const paddingLeft = styles ? Number.parseFloat(styles.paddingLeft || '0') || 0 : 0;
+      const paddingRight = styles ? Number.parseFloat(styles.paddingRight || '0') || 0 : 0;
+      const paddingBottom = styles ? Number.parseFloat(styles.paddingBottom || '0') || 0 : 0;
+      const width = Math.max(1, rect.width - paddingLeft - paddingRight);
+      const availableHeight = Math.max(1, rect.height - paddingTop - paddingBottom);
+      const svgWidth = Math.max(1, width);
+      const svgHeight = viewBox && viewBox.width > 0 && viewBox.height > 0 ? svgWidth * (viewBox.height / viewBox.width) : Math.max(1, svg ? svg.getBoundingClientRect().height : availableHeight);
+      return { rect, paddingTop, paddingLeft, width, availableHeight, svgWidth, svgHeight };
+    };
+    const emitViewport = () => {
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-viewport', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), state: viewportState() } }));
+      emitSync('viewport', { state: viewportState() });
+    };
+    const zoomBy = (factor, origin) => {
+      const state = viewportState();
+      const nextZoom = clamp(state.zoom * factor, 0.5, 4);
+      const ratio = nextZoom / state.zoom;
+      const metrics = viewportMetrics();
+      const localX = origin && Number.isFinite(origin.clientX) ? origin.clientX - metrics.rect.left : metrics.rect.width / 2;
+      const localY = origin && Number.isFinite(origin.clientY) ? origin.clientY - metrics.rect.top : metrics.rect.height / 2;
+      const centerX = metrics.rect.width / 2;
+      const centerY = metrics.rect.height / 2;
+      const panX = localX - centerX - ratio * (localX - centerX - state.panX);
+      const panY = localY - centerY - ratio * (localY - centerY - state.panY);
+      markForceGraphMoving();
+      applyViewport({ zoom: nextZoom, panX, panY });
+      emitViewport();
+    };
+    const fitViewport = () => {
+      const metrics = viewportMetrics();
+      const scale = clamp(Math.min(1, metrics.width / metrics.svgWidth, metrics.availableHeight / metrics.svgHeight), 0.5, 1);
+      applyViewport({ zoom: scale, panX: 0, panY: 0 });
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-fit', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), state: viewportState() } }));
+      emitViewport();
+    };
+    const isViewportVisible = element => {
+      if (!element || !(element instanceof Element)) return false;
+      if (element.classList.contains('cfx-topology-html-filter-hidden') || element.classList.contains('cfx-topology-html-force-hidden')) return false;
+      if (element.closest('.cfx-topology-html-filter-hidden,.cfx-topology-html-force-hidden')) return false;
+      return true;
+    };
+    const elementBounds = element => {
+      try {
+        if (element && element.getBBox) {
+          const box = element.getBBox();
+          if (box && Number.isFinite(box.x) && Number.isFinite(box.y) && box.width > 0 && box.height > 0) return box;
+        }
+      } catch { }
+      return null;
+    };
+    const fitViewportToElements = (elements, emit = true) => {
+      if (!viewportControls) return false;
+      const svg = topologySvg();
+      const viewBox = svg && svg.viewBox && svg.viewBox.baseVal ? svg.viewBox.baseVal : null;
+      if (!svg || !viewBox || viewBox.width <= 0 || viewBox.height <= 0) return false;
+      const boxes = Array.from(elements || []).filter(isViewportVisible).map(elementBounds).filter(box => box);
+      if (!boxes.length) return false;
+      const bounds = boxes.reduce((current, box) => ({
+        x: Math.min(current.x, box.x),
+        y: Math.min(current.y, box.y),
+        right: Math.max(current.right, box.x + box.width),
+        bottom: Math.max(current.bottom, box.y + box.height)
+      }), { x: boxes[0].x, y: boxes[0].y, right: boxes[0].x + boxes[0].width, bottom: boxes[0].y + boxes[0].height });
+      const metrics = viewportMetrics();
+      const unitX = metrics.svgWidth / viewBox.width;
+      const unitY = metrics.svgHeight / viewBox.height;
+      const boundsWidth = Math.max(1, (bounds.right - bounds.x) * unitX);
+      const boundsHeight = Math.max(1, (bounds.bottom - bounds.y) * unitY);
+      const padding = 44;
+      const zoom = clamp(Math.min(metrics.width / (boundsWidth + padding * 2), metrics.availableHeight / (boundsHeight + padding * 2)), 0.5, 3.2);
+      const centerX = (bounds.x + (bounds.right - bounds.x) / 2 - viewBox.x) * unitX;
+      const centerY = (bounds.y + (bounds.bottom - bounds.y) / 2 - viewBox.y) * unitY;
+      const originX = metrics.svgWidth / 2;
+      const originY = metrics.svgHeight / 2;
+      const targetX = metrics.width / 2;
+      const targetY = metrics.availableHeight / 2;
+      const panX = targetX - originX - zoom * (centerX - originX);
+      const panY = targetY - originY - zoom * (centerY - originY);
+      applyViewport({ zoom, panX, panY });
+      if (emit) {
+        wrapper.dispatchEvent(new CustomEvent('cfx-topology-fit', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), state: viewportState(), mode: 'visible', count: boxes.length } }));
+        emitViewport();
+      }
+      return true;
+    };
+    const fitVisibleTopology = (emit = true) => fitViewportToElements(wrapper.querySelectorAll('[data-cfx-role="topology-node"]:not(.cfx-topology-html-filter-hidden):not(.cfx-topology-html-force-hidden)'), emit);
+    const markForceGraphMoving = () => {
+      if (!forceGraphControls || wrapper.getAttribute('data-cfx-force-hide-moving-edges') !== 'true') return;
+      wrapper.setAttribute('data-cfx-force-moving-edges', 'true');
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => edge.classList.add('cfx-topology-html-force-moving'));
+      if (forceGraphMotionTimer) window.clearTimeout(forceGraphMotionTimer);
+      forceGraphMotionTimer = window.setTimeout(() => {
+        wrapper.removeAttribute('data-cfx-force-moving-edges');
+        wrapper.querySelectorAll('.cfx-topology-html-force-moving').forEach(edge => edge.classList.remove('cfx-topology-html-force-moving'));
+      }, 280);
+    };
+    const resetViewport = () => {
+      applyViewport({ zoom: 1, panX: 0, panY: 0 });
+      wrapper.removeAttribute('data-cfx-topology-dragging');
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-reset', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id') } }));
+      emitViewport();
+    };
+    const setViewportMode = mode => {
+      const next = wrapper.getAttribute('data-cfx-topology-mode') === mode ? '' : mode;
+      if (next) wrapper.setAttribute('data-cfx-topology-mode', next);
+      else wrapper.removeAttribute('data-cfx-topology-mode');
+      wrapper.querySelectorAll('[data-cfx-topology-mode]').forEach(button => button.setAttribute('aria-pressed', attr(button, 'data-cfx-topology-mode') === next ? 'true' : 'false'));
+    };
+    const clearScenario = () => {
+      stopScenarioPlayback();
+      clearScenarioStep();
+      clearScenarioPreview();
+      wrapper.removeAttribute('data-cfx-active-scenario');
+      wrapper.removeAttribute('data-cfx-active-scenarios');
+      wrapper.style.removeProperty('--cfx-topology-active-scenario-color');
+      wrapper.querySelectorAll('.cfx-topology-html-scenario-active,.cfx-topology-html-scenario-muted').forEach(item => {
+        item.classList.remove('cfx-topology-html-scenario-active', 'cfx-topology-html-scenario-muted');
+        item.removeAttribute('data-cfx-active-scenario-step-indices');
+      });
+      wrapper.querySelectorAll('[data-cfx-topology-scenario]').forEach(button => button.setAttribute('aria-pressed', attr(button, 'data-cfx-topology-scenario') ? 'false' : 'true'));
+      wrapper.querySelectorAll('[data-cfx-topology-scenario-toggle]').forEach(input => input.checked = false);
+      updateScenarioStepControls(false);
+      renderScenarioPanel(null);
+      syncScenarioUrl('', '');
+    };
+    const setScenarioFilters = (scenarioIds, emit = true, sync = true) => {
+      clearScenario();
+      const ids = unique((scenarioIds || []).map(value => String(value || '').trim()));
+      if (!ids.length) {
+        if (emit) wrapper.dispatchEvent(new CustomEvent('cfx-topology-scenario-clear', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id') } }));
+        if (sync) emitSync('scenario-filters', { scenarioIds: [] });
+        return;
+      }
+
+      const routes = ids.map(scenarioRoute).filter(route => route);
+      if (!routes.length) {
+        if (emit) wrapper.dispatchEvent(new CustomEvent('cfx-topology-scenario-clear', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id') } }));
+        if (sync) emitSync('scenario-filters', { scenarioIds: [] });
+        return;
+      }
+
+      const nodeIds = new Set();
+      const edgeIds = new Set();
+      const groupIds = new Set();
+      routes.forEach(route => {
+        route.nodeIds.forEach(id => nodeIds.add(id));
+        route.edgeIds.forEach(id => edgeIds.add(id));
+        route.groupIds.forEach(id => groupIds.add(id));
+      });
+      wrapper.setAttribute('data-cfx-active-scenarios', routes.map(route => route.scenarioId).join(' '));
+      if (routes.length === 1) {
+        wrapper.setAttribute('data-cfx-active-scenario', routes[0].scenarioId);
+        if (routes[0].color) wrapper.style.setProperty('--cfx-topology-active-scenario-color', routes[0].color);
+        else wrapper.style.removeProperty('--cfx-topology-active-scenario-color');
+      } else {
+        wrapper.removeAttribute('data-cfx-active-scenario');
+        wrapper.style.removeProperty('--cfx-topology-active-scenario-color');
+      }
+      wrapper.querySelectorAll('[data-cfx-topology-scenario-toggle]').forEach(input => input.checked = routes.some(route => route.scenarioId === attr(input, 'data-cfx-topology-scenario-toggle')));
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+        const active = edgeIds.has(attr(edge, 'data-edge-id'));
+        edge.classList.toggle('cfx-topology-html-scenario-active', active);
+        edge.classList.toggle('cfx-topology-html-scenario-muted', !active);
+        if (active && routes.length === 1) edge.setAttribute('data-cfx-active-scenario-step-indices', scenarioStepIndices(edge, routes[0].scenarioId).join(' '));
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-node"]').forEach(node => {
+        const active = nodeIds.has(attr(node, 'data-node-id'));
+        node.classList.toggle('cfx-topology-html-scenario-active', active);
+        node.classList.toggle('cfx-topology-html-scenario-muted', !active);
+        if (active && routes.length === 1) node.setAttribute('data-cfx-active-scenario-step-indices', scenarioStepIndices(node, routes[0].scenarioId).join(' '));
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge-label"]').forEach(label => {
+        const active = edgeIds.has(attr(label, 'data-edge-id'));
+        label.classList.toggle('cfx-topology-html-scenario-active', active);
+        label.classList.toggle('cfx-topology-html-scenario-muted', !active);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-node-status"]').forEach(status => {
+        const active = nodeIds.has(attr(status, 'data-node-id'));
+        status.classList.toggle('cfx-topology-html-scenario-active', active);
+        status.classList.toggle('cfx-topology-html-scenario-muted', !active);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-group"]').forEach(group => {
+        const active = groupIds.has(attr(group, 'data-group-id'));
+        group.classList.toggle('cfx-topology-html-scenario-active', active);
+        group.classList.toggle('cfx-topology-html-scenario-muted', !active);
+      });
+      renderScenarioPanel(routes.length === 1 ? routes[0] : { ...routes[0], label: routes.length + ' routes enabled', description: routes.map(route => route.label).join(' / '), stepCount: routes.reduce((sum, route) => sum + route.stepCount, 0), steps: routes.flatMap(route => route.steps), metadata: {} });
+      updateScenarioStepControls(false);
+      syncScenarioUrl(routes.map(route => route.scenarioId).join(','), '');
+      if (emit) wrapper.dispatchEvent(new CustomEvent('cfx-topology-scenario-filter', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), scenarioIds: routes.map(route => route.scenarioId), routes: routes.map(route => ({ scenarioId: route.scenarioId, label: route.label, description: route.description, color: route.color, stepCount: route.stepCount })), nodeIds: Array.from(nodeIds), edgeIds: Array.from(edgeIds), groupIds: Array.from(groupIds) } }));
+      if (sync) emitSync('scenario-filters', { scenarioIds: routes.map(route => route.scenarioId) });
+    };
+    const setScenario = (scenarioId, emit = true, sync = true) => {
+      clearScenario();
+      if (!scenarioId) {
+        if (emit) wrapper.dispatchEvent(new CustomEvent('cfx-topology-scenario-clear', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id') } }));
+        if (sync) emitSync('scenario', { scenarioId: '' });
+        return;
+      }
+      const route = scenarioRoute(scenarioId);
+      if (!route) {
+        if (emit) wrapper.dispatchEvent(new CustomEvent('cfx-topology-scenario-clear', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id') } }));
+        if (sync) emitSync('scenario', { scenarioId: '' });
+        return;
+      }
+
+      wrapper.setAttribute('data-cfx-active-scenario', scenarioId);
+      if (scenarioControlMode === 'checkboxes') {
+        wrapper.setAttribute('data-cfx-active-scenarios', scenarioId);
+        wrapper.querySelectorAll('[data-cfx-topology-scenario-toggle]').forEach(input => input.checked = attr(input, 'data-cfx-topology-scenario-toggle') === scenarioId);
+      }
+      if (route.color) wrapper.style.setProperty('--cfx-topology-active-scenario-color', route.color);
+      else wrapper.style.removeProperty('--cfx-topology-active-scenario-color');
+      wrapper.querySelectorAll('[data-cfx-topology-scenario]').forEach(button => button.setAttribute('aria-pressed', attr(button, 'data-cfx-topology-scenario') === scenarioId ? 'true' : 'false'));
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+        const active = route.edgeIds.has(attr(edge, 'data-edge-id'));
+        edge.classList.toggle('cfx-topology-html-scenario-active', active);
+        edge.classList.toggle('cfx-topology-html-scenario-muted', !active);
+        if (active) edge.setAttribute('data-cfx-active-scenario-step-indices', scenarioStepIndices(edge, scenarioId).join(' '));
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-node"]').forEach(node => {
+        const active = route.nodeIds.has(attr(node, 'data-node-id'));
+        node.classList.toggle('cfx-topology-html-scenario-active', active);
+        node.classList.toggle('cfx-topology-html-scenario-muted', !active);
+        if (active) node.setAttribute('data-cfx-active-scenario-step-indices', scenarioStepIndices(node, scenarioId).join(' '));
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge-label"]').forEach(label => {
+        const active = route.edgeIds.has(attr(label, 'data-edge-id'));
+        label.classList.toggle('cfx-topology-html-scenario-active', active);
+        label.classList.toggle('cfx-topology-html-scenario-muted', !active);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-node-status"]').forEach(status => {
+        const active = route.nodeIds.has(attr(status, 'data-node-id'));
+        status.classList.toggle('cfx-topology-html-scenario-active', active);
+        status.classList.toggle('cfx-topology-html-scenario-muted', !active);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-group"]').forEach(group => {
+        const active = route.groupIds.has(attr(group, 'data-group-id'));
+        group.classList.toggle('cfx-topology-html-scenario-active', active);
+        group.classList.toggle('cfx-topology-html-scenario-muted', !active);
+      });
+      renderScenarioPanel(route);
+      clearScenarioStep();
+      updateScenarioStepControls(false);
+      syncScenarioUrl(scenarioId, '');
+      if (emit) wrapper.dispatchEvent(new CustomEvent('cfx-topology-scenario', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), scenarioId, label: route.label, description: route.description, color: route.color, stepCount: route.stepCount, metadata: route.metadata, steps: route.steps, nodeIds: Array.from(route.nodeIds), edgeIds: Array.from(route.edgeIds), groupIds: Array.from(route.groupIds) } }));
+      if (sync) emitSync('scenario', { scenarioId });
+    };
+    const svgElement = () => topologySvg();
+    const exportName = () => (attr(wrapper, 'data-chart-id') || 'topology').replace(/[^a-z0-9_.-]+/gi, '-').replace(/^-+|-+$/g, '') || 'topology';
+    const serializeSvg = () => {
+      const svg = svgElement();
+      if (!svg) return null;
+      const clone = svg.cloneNode(true);
+      const defs = clone.querySelector('defs') || clone.insertBefore(document.createElementNS('http://www.w3.org/2000/svg', 'defs'), clone.firstChild);
+      const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+      style.setAttribute('data-cfx-export-style', 'force-filters');
+      style.textContent = '.cfx-topology-html-force-hidden{display:none!important}';
+      defs.appendChild(style);
+      return { svg, data: new XMLSerializer().serializeToString(clone) };
+    };
+    const emitExport = format => {
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-export', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), format } }));
+    };
+    const downloadBlob = (blob, extension, format) => {
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = exportName() + '.' + extension;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+      emitExport(format);
+    };
+    const svgSize = svg => {
+      const viewBox = svg.viewBox && svg.viewBox.baseVal ? svg.viewBox.baseVal : null;
+      const rect = svg.getBoundingClientRect ? svg.getBoundingClientRect() : { width: 0, height: 0 };
+      const width = Math.max(1, Math.round((viewBox && viewBox.width) || (svg.width && svg.width.baseVal ? svg.width.baseVal.value : 0) || rect.width || 800));
+      const height = Math.max(1, Math.round((viewBox && viewBox.height) || (svg.height && svg.height.baseVal ? svg.height.baseVal.value : 0) || rect.height || 450));
+      return { width, height };
+    };
+    const exportSvg = () => {
+      const serialized = serializeSvg();
+      if (!serialized) return;
+      downloadBlob(new Blob([serialized.data], { type: 'image/svg+xml;charset=utf-8' }), 'svg', 'svg');
+    };
+    const exportPng = () => {
+      const serialized = serializeSvg();
+      if (!serialized) return;
+      const source = new Blob([serialized.data], { type: 'image/svg+xml;charset=utf-8' });
+      const sourceUrl = URL.createObjectURL(source);
+      const image = new Image();
+      image.onload = () => {
+        const size = svgSize(serialized.svg);
+        const scale = Math.max(1, Math.ceil(window.devicePixelRatio || 1));
+        const canvas = document.createElement('canvas');
+        canvas.width = size.width * scale;
+        canvas.height = size.height * scale;
+        const context = canvas.getContext('2d');
+        if (!context) {
+          URL.revokeObjectURL(sourceUrl);
+          return;
+        }
+        context.setTransform(scale, 0, 0, scale, 0, 0);
+        context.clearRect(0, 0, size.width, size.height);
+        context.drawImage(image, 0, 0, size.width, size.height);
+        canvas.toBlob(blob => {
+          URL.revokeObjectURL(sourceUrl);
+          if (blob) downloadBlob(blob, 'png', 'png');
+        }, 'image/png');
+      };
+      image.onerror = () => URL.revokeObjectURL(sourceUrl);
+      image.src = sourceUrl;
+    };

--- a/ChartForgeX/Topology/Assets/topology-interaction.source/60-selection-panel.js
+++ b/ChartForgeX/Topology/Assets/topology-interaction.source/60-selection-panel.js
@@ -1,0 +1,369 @@
+    const edgeIdentity = edge => ({
+      id: attr(edge, 'data-edge-id'),
+      kind: attr(edge, 'data-edge-kind'),
+      status: attr(edge, 'data-cfx-status'),
+      sourceNodeId: attr(edge, 'data-source-node-id'),
+      targetNodeId: attr(edge, 'data-target-node-id'),
+      sourceGroupId: attr(edge, 'data-source-group-id'),
+      targetGroupId: attr(edge, 'data-target-group-id')
+    });
+    const related = detail => {
+      if (detail.kind === 'node') {
+        const edges = Array.from(wrapper.querySelectorAll('[data-cfx-role="topology-edge"]'))
+          .filter(edge => attr(edge, 'data-source-node-id') === detail.id || attr(edge, 'data-target-node-id') === detail.id);
+        return {
+          nodeIds: unique(edges.flatMap(edge => [attr(edge, 'data-source-node-id'), attr(edge, 'data-target-node-id')]).filter(id => id !== detail.id)),
+          edgeIds: edges.map(edge => attr(edge, 'data-edge-id')),
+          groupIds: unique([detail.groupId].concat(edges.flatMap(edge => [attr(edge, 'data-source-group-id'), attr(edge, 'data-target-group-id')]))),
+          edges: edges.map(edgeIdentity)
+        };
+      }
+      if (detail.kind === 'edge') {
+        return {
+          nodeIds: unique([detail.sourceNodeId, detail.targetNodeId]),
+          edgeIds: [detail.id],
+          groupIds: unique([detail.sourceGroupId, detail.targetGroupId]),
+          edges: [edgeIdentity(detail.element)]
+        };
+      }
+      if (detail.kind === 'group') {
+        const nodes = Array.from(wrapper.querySelectorAll('[data-cfx-role="topology-node"]'))
+          .filter(node => attr(node, 'data-group-id') === detail.id);
+        const edges = Array.from(wrapper.querySelectorAll('[data-cfx-role="topology-edge"]'))
+          .filter(edge => attr(edge, 'data-source-group-id') === detail.id || attr(edge, 'data-target-group-id') === detail.id);
+        return {
+          nodeIds: nodes.map(node => attr(node, 'data-node-id')),
+          edgeIds: edges.map(edge => attr(edge, 'data-edge-id')),
+          groupIds: unique(edges.flatMap(edge => [attr(edge, 'data-source-group-id'), attr(edge, 'data-target-group-id')]).filter(id => id !== detail.id)),
+          edges: edges.map(edgeIdentity)
+        };
+      }
+      return { nodeIds: [], edgeIds: [], groupIds: [], edges: [] };
+    };
+    const statusColor = status => {
+      const key = String(status || '').toLowerCase();
+      if (key === 'healthy') return 'var(--cfx-topology-healthy,#16a34a)';
+      if (key === 'warning') return 'var(--cfx-topology-warning,#f97316)';
+      if (key === 'critical') return 'var(--cfx-topology-critical,#ef4444)';
+      if (key === 'disabled') return 'var(--cfx-topology-disabled,#94a3b8)';
+      return 'var(--cfx-topology-unknown,#64748b)';
+    };
+    const panelRowClass = () => {
+      if (!selectionPanel) return 'cfx-topology-selection-panel__row';
+      const base = (selectionPanel.getAttribute('class') || 'cfx-topology-selection-panel').split(/\s+/)[0] || 'cfx-topology-selection-panel';
+      return base + '__row';
+    };
+    const addSelectionRow = (container, label, value) => {
+      if (!container || value === undefined || value === null || value === '') return;
+      const row = document.createElement('div');
+      row.className = panelRowClass();
+      const left = document.createElement('span');
+      const right = document.createElement('span');
+      left.textContent = label;
+      right.textContent = String(value);
+      row.append(left, right);
+      container.appendChild(row);
+    };
+    const setSelectionFacts = (container, rows) => {
+      if (!container) return;
+      container.replaceChildren();
+      rows.forEach(row => {
+        if (!row || row[1] === undefined || row[1] === null || row[1] === '') return;
+        const dt = document.createElement('dt');
+        const dd = document.createElement('dd');
+        dt.textContent = row[0];
+        dd.textContent = String(row[1]);
+        container.append(dt, dd);
+      });
+    };
+    const renderSelectionPanel = detail => {
+      if (!selectionPanel) return;
+      const title = selectionPanel.querySelector('[data-cfx-selection-title]');
+      const kind = selectionPanel.querySelector('[data-cfx-selection-kind]');
+      const status = selectionPanel.querySelector('[data-cfx-selection-status]');
+      const facts = selectionPanel.querySelector('[data-cfx-selection-facts]');
+      const meta = selectionPanel.querySelector('[data-cfx-selection-meta]');
+      const relatedPanel = selectionPanel.querySelector('[data-cfx-selection-related]');
+      if (!detail) {
+        selectionPanel.hidden = true;
+        selectionPanel.style.removeProperty('--cfx-topology-selection-status-color');
+        if (title) title.textContent = 'No item selected';
+        if (kind) kind.textContent = 'Selection';
+        if (status) status.textContent = '';
+        if (facts) facts.replaceChildren();
+        if (meta) meta.replaceChildren();
+        if (relatedPanel) relatedPanel.replaceChildren();
+        return;
+      }
+
+      selectionPanel.hidden = false;
+      selectionPanel.style.setProperty('--cfx-topology-selection-status-color', statusColor(detail.status));
+      const displayTitle = detail.kind === 'node'
+        ? (detail.metadata && detail.metadata.name) || (detail.element ? attr(detail.element, 'data-node-label') : '') || detail.id
+        : detail.kind === 'edge'
+          ? (detail.element ? attr(detail.element, 'data-edge-label') : '') || detail.id
+          : (detail.element ? attr(detail.element, 'data-group-label') : '') || detail.id;
+      if (title) title.textContent = displayTitle || detail.id || 'Selection';
+      if (kind) kind.textContent = detail.kind === 'node' ? (detail.nodeKind || 'Node') : detail.kind === 'edge' ? (detail.edgeKind || 'Edge') : 'Group';
+      if (status) status.textContent = detail.status || '';
+      setSelectionFacts(facts, [
+        ['ID', detail.id],
+        ['Status', detail.status],
+        ['Group', detail.groupId || detail.sourceGroupId || detail.targetGroupId],
+        ['Related nodes', (detail.related && detail.related.nodeIds || []).length],
+        ['Related edges', (detail.related && detail.related.edgeIds || []).length]
+      ]);
+      if (meta) {
+        meta.replaceChildren();
+        Object.entries(detail.metadata || {}).slice(0, 6).forEach(([key, value]) => addSelectionRow(meta, key, value));
+        Object.entries(detail.metrics || {}).slice(0, 4).forEach(([key, value]) => addSelectionRow(meta, key, value));
+      }
+      if (relatedPanel) {
+        relatedPanel.replaceChildren();
+        (detail.related && detail.related.edges || []).slice(0, 5).forEach(edge => {
+          const label = edge.kind || 'Edge';
+          const value = [edge.sourceNodeId, edge.targetNodeId].filter(Boolean).join(' -> ');
+          addSelectionRow(relatedPanel, label, value || edge.id);
+        });
+      }
+    };
+    const clear = () => {
+      wrapper.removeAttribute('data-cfx-selection-kind');
+      wrapper.removeAttribute('data-cfx-selection-id');
+      wrapper.removeAttribute('data-cfx-selection-status');
+      wrapper.querySelectorAll('.cfx-topology-html-selected,.cfx-topology-html-muted,.cfx-topology-html-related').forEach(item => {
+        item.classList.remove('cfx-topology-html-selected', 'cfx-topology-html-muted', 'cfx-topology-html-related');
+        item.removeAttribute('aria-selected');
+      });
+      clearForceFocusLabels();
+      renderSelectionPanel(null);
+    };
+    const clearHover = () => {
+      wrapper.removeAttribute('data-cfx-hover-kind');
+      wrapper.removeAttribute('data-cfx-hover-id');
+      wrapper.querySelectorAll('.cfx-topology-html-hovered,.cfx-topology-html-hover-muted,.cfx-topology-html-hover-related').forEach(item => {
+        item.classList.remove('cfx-topology-html-hovered', 'cfx-topology-html-hover-muted', 'cfx-topology-html-hover-related');
+      });
+      restoreForceFocusLabels();
+    };
+    const identity = element => {
+      const role = element.getAttribute('data-cfx-role') || '';
+      const base = {
+        role,
+        elementId: attr(element, 'id'),
+        status: attr(element, 'data-cfx-status'),
+        selected: attr(element, 'data-cfx-selected') === 'true',
+        metadata: collectPrefixed(element, 'data-cfx-meta-'),
+        metrics: collectPrefixed(element, 'data-cfx-metric-'),
+        element
+      };
+      if (role === 'topology-node') {
+        return {
+          ...base,
+          kind: 'node',
+          id: attr(element, 'data-node-id'),
+          label: attr(element, 'data-node-label'),
+          nodeKind: attr(element, 'data-node-kind'),
+          groupId: attr(element, 'data-group-id'),
+          displayMode: attr(element, 'data-node-display-mode'),
+          badge: attr(element, 'data-node-badge'),
+          color: attr(element, 'data-node-color'),
+          iconId: attr(element, 'data-node-icon-id'),
+          iconPack: attr(element, 'data-node-icon-pack'),
+          iconLabel: attr(element, 'data-node-icon-label'),
+          iconShape: attr(element, 'data-node-icon-shape'),
+          iconArtwork: attr(element, 'data-node-icon-artwork'),
+          artworkSource: attr(element, 'data-node-artwork-source'),
+          longitude: attr(element, 'data-node-longitude'),
+          latitude: attr(element, 'data-node-latitude'),
+          geoVisible: attr(element, 'data-node-geo-visible')
+        };
+      }
+      if (role === 'topology-edge') {
+        return {
+          ...base,
+          kind: 'edge',
+          id: attr(element, 'data-edge-id'),
+          label: attr(element, 'data-edge-label'),
+          edgeKind: attr(element, 'data-edge-kind'),
+          sourceNodeId: attr(element, 'data-source-node-id'),
+          targetNodeId: attr(element, 'data-target-node-id'),
+          sourceGroupId: attr(element, 'data-source-group-id'),
+          targetGroupId: attr(element, 'data-target-group-id'),
+          sourcePort: attr(element, 'data-source-port'),
+          targetPort: attr(element, 'data-target-port'),
+          routeLane: attr(element, 'data-route-lane'),
+          layoutInference: attr(element, 'data-edge-layout-inference'),
+          muted: attr(element, 'data-edge-muted') === 'true',
+          lineStyle: attr(element, 'data-edge-line-style'),
+          route: {
+            strategy: attr(element, 'data-route-strategy'),
+            curve: attr(element, 'data-route-curve'),
+            controlX: attr(element, 'data-route-control-x'),
+            controlY: attr(element, 'data-route-control-y'),
+            corridor: attr(element, 'data-route-corridor'),
+            candidateCount: attr(element, 'data-route-candidate-count'),
+            fallbackReason: attr(element, 'data-route-fallback-reason'),
+            segmentCount: attr(element, 'data-route-segment-count'),
+            obstacleCount: attr(element, 'data-route-obstacle-count'),
+            obstacleHits: attr(element, 'data-route-obstacle-hits'),
+            labelObstacleHits: attr(element, 'data-route-label-obstacle-hits'),
+            overlapScore: attr(element, 'data-route-overlap-score'),
+            offset: attr(element, 'data-route-offset'),
+            waypointCount: attr(element, 'data-waypoint-count')
+          }
+        };
+      }
+      if (role === 'topology-group') {
+        return {
+          ...base,
+          kind: 'group',
+          id: attr(element, 'data-group-id'),
+          label: attr(element, 'data-group-label'),
+          symbol: attr(element, 'data-group-symbol'),
+          color: attr(element, 'data-group-color'),
+          iconId: attr(element, 'data-group-icon-id'),
+          iconPack: attr(element, 'data-group-icon-pack'),
+          iconLabel: attr(element, 'data-group-icon-label'),
+          iconShape: attr(element, 'data-group-icon-shape'),
+          iconArtwork: attr(element, 'data-group-icon-artwork'),
+          longitude: attr(element, 'data-group-longitude'),
+          latitude: attr(element, 'data-group-latitude'),
+          geoVisible: attr(element, 'data-group-geo-visible'),
+          layoutPolicy: attr(element, 'data-group-layout-policy'),
+          appliedLayoutPolicy: attr(element, 'data-group-applied-layout-policy'),
+          callout: {
+            visualRole: attr(element, 'data-cfx-visual-role'),
+            placement: attr(element, 'data-callout-placement'),
+            anchorX: attr(element, 'data-callout-anchor-x'),
+            anchorY: attr(element, 'data-callout-anchor-y'),
+            nodeCount: attr(element, 'data-callout-node-count'),
+            healthyCount: attr(element, 'data-callout-healthy-count'),
+            warningCount: attr(element, 'data-callout-warning-count'),
+            criticalCount: attr(element, 'data-callout-critical-count'),
+            unknownCount: attr(element, 'data-callout-unknown-count'),
+            disabledCount: attr(element, 'data-callout-disabled-count')
+          }
+        };
+      }
+      return { ...base, kind: 'unknown', id: '' };
+    };
+    const findSelection = request => {
+      if (!request || !request.kind || !request.id) return null;
+      return Array.from(wrapper.querySelectorAll(selectables)).find(element => {
+        const detail = identity(element);
+        return detail.kind === request.kind && detail.id === request.id;
+      }) || null;
+    };
+    const elementKey = element => {
+      const detail = identity(element);
+      return detail.kind + ':' + detail.id;
+    };
+    const publicDetail = element => {
+      const detail = identity(element);
+      detail.related = related(detail);
+      delete detail.element;
+      return detail;
+    };
+    const relatedElements = detail => {
+      const items = [];
+      const seen = new Set();
+      const add = (kind, id) => {
+        if (!id) return;
+        const key = kind + ':' + id;
+        if (seen.has(key) || (detail.kind === kind && detail.id === id)) return;
+        const element = findSelection({ kind, id });
+        if (!element) return;
+        seen.add(key);
+        items.push(element);
+      };
+      (detail.related.nodeIds || []).forEach(id => add('node', id));
+      (detail.related.edgeIds || []).forEach(id => add('edge', id));
+      (detail.related.groupIds || []).forEach(id => add('group', id));
+      return items;
+    };
+    const focusRelated = (element, offset) => {
+      const detail = identity(element);
+      detail.related = related(detail);
+      const candidates = relatedElements(detail);
+      if (!candidates.length) return false;
+      const sourceKey = detail.kind + ':' + detail.id;
+      const previousTarget = wrapper.getAttribute('data-cfx-navigation-source') === sourceKey ? wrapper.getAttribute('data-cfx-navigation-target') || '' : '';
+      const previousIndex = candidates.findIndex(candidate => elementKey(candidate) === previousTarget);
+      const nextIndex = previousIndex >= 0 ? (previousIndex + offset + candidates.length) % candidates.length : (offset > 0 ? 0 : candidates.length - 1);
+      const target = candidates[nextIndex];
+      const targetKey = elementKey(target);
+      wrapper.setAttribute('data-cfx-navigation-source', sourceKey);
+      wrapper.setAttribute('data-cfx-navigation-target', targetKey);
+      if (target.focus) target.focus({ preventScroll: true });
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-navigate', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), from: publicDetail(element), to: publicDetail(target) } }));
+      return true;
+    };
+    const applyRelatedClasses = (detail, classPrefix, selfClass) => {
+      const relatedEdges = new Set(detail.related.edgeIds || []);
+      const relatedNodes = new Set(detail.related.nodeIds || []);
+      const relatedGroups = new Set(detail.related.groupIds || []);
+      const relatedClass = classPrefix + 'related';
+      const mutedClass = classPrefix + 'muted';
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+        const isSelf = detail.kind === 'edge' && attr(edge, 'data-edge-id') === detail.id;
+        const isRelated = isSelf || relatedEdges.has(attr(edge, 'data-edge-id'));
+        edge.classList.toggle(relatedClass, isRelated);
+        edge.classList.toggle(mutedClass, !isRelated);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge-label"]').forEach(label => {
+        const isSelf = detail.kind === 'edge' && attr(label, 'data-edge-id') === detail.id;
+        const isRelated = isSelf || relatedEdges.has(attr(label, 'data-edge-id'));
+        label.classList.toggle(relatedClass, isRelated);
+        label.classList.toggle(mutedClass, !isRelated);
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-node"]').forEach(node => {
+        const isSelf = detail.kind === 'node' && attr(node, 'data-node-id') === detail.id;
+        const isRelated = isSelf || relatedNodes.has(attr(node, 'data-node-id'));
+        node.classList.toggle(relatedClass, isRelated);
+        node.classList.toggle(mutedClass, !isRelated && detail.kind !== 'group');
+      });
+      wrapper.querySelectorAll('[data-cfx-role="topology-group"]').forEach(group => {
+        const isSelf = detail.kind === 'group' && attr(group, 'data-group-id') === detail.id;
+        const isRelated = isSelf || relatedGroups.has(attr(group, 'data-group-id'));
+        group.classList.toggle(relatedClass, isRelated);
+      });
+      if (detail.element && selfClass) detail.element.classList.add(selfClass);
+    };
+    const hover = element => {
+      const detail = identity(element);
+      detail.related = related(detail);
+      clearHover();
+      wrapper.setAttribute('data-cfx-hover-kind', detail.kind);
+      wrapper.setAttribute('data-cfx-hover-id', detail.id);
+      applyRelatedClasses(detail, 'cfx-topology-html-hover-', 'cfx-topology-html-hovered');
+      applyForceFocusLabels(detail);
+      delete detail.element;
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-hover', { bubbles: true, detail }));
+    };
+    const select = (element, emit = true, sync = true) => {
+      const detail = identity(element);
+      detail.related = related(detail);
+      clear();
+      wrapper.setAttribute('data-cfx-selection-kind', detail.kind);
+      wrapper.setAttribute('data-cfx-selection-id', detail.id);
+      wrapper.setAttribute('data-cfx-selection-status', detail.status);
+      element.classList.add('cfx-topology-html-selected');
+      element.setAttribute('aria-selected', 'true');
+      applyRelatedClasses({ ...detail, element }, 'cfx-topology-html-', '');
+      applyForceFocusLabels(detail);
+      renderSelectionPanel({ ...detail, element });
+      delete detail.element;
+      if (emit) wrapper.dispatchEvent(new CustomEvent('cfx-topology-select', { bubbles: true, detail }));
+      if (sync) emitSync('selection', { selection: { kind: detail.kind, id: detail.id, status: detail.status } });
+    };
+    const hydrateSelected = element => {
+      const detail = identity(element);
+      detail.related = related(detail);
+      wrapper.setAttribute('data-cfx-selection-kind', detail.kind);
+      wrapper.setAttribute('data-cfx-selection-id', detail.id);
+      wrapper.setAttribute('data-cfx-selection-status', detail.status);
+      element.setAttribute('aria-selected', 'true');
+      renderSelectionPanel({ ...detail, element });
+      delete detail.element;
+    };

--- a/ChartForgeX/Topology/Assets/topology-interaction.source/70-topology-filters.js
+++ b/ChartForgeX/Topology/Assets/topology-interaction.source/70-topology-filters.js
@@ -1,0 +1,95 @@
+    const topologyFilterSearchText = element => [
+      attr(element, 'data-node-id'), attr(element, 'data-node-label'), attr(element, 'data-node-kind'), attr(element, 'data-group-id'),
+      attr(element, 'data-edge-id'), attr(element, 'data-edge-label'), attr(element, 'data-edge-secondary-label'), attr(element, 'data-edge-tertiary-label'), attr(element, 'data-edge-kind'), attr(element, 'data-source-node-id'), attr(element, 'data-target-node-id'),
+      attr(element, 'data-group-label'), attr(element, 'data-group-symbol'), attr(element, 'data-cfx-status'), element.textContent || ''
+    ].join(' ').toLowerCase();
+    const topologyFilterEscape = value => window.CSS && CSS.escape ? CSS.escape(value) : String(value).replace(/["\\]/g, '\\$&');
+    let topologyFilterState = { query: '', status: '', group: '', kind: '', edges: true, labels: true, groups: true };
+    const setTopologyFilterHidden = (selector, predicate) => {
+      wrapper.querySelectorAll(selector).forEach(element => element.classList.toggle('cfx-topology-html-filter-hidden', predicate(element)));
+    };
+    const setTopologyFilterAttributes = detail => {
+      wrapper.setAttribute('data-cfx-filter-query', detail.query || '');
+      wrapper.setAttribute('data-cfx-filter-status', detail.status || '');
+      wrapper.setAttribute('data-cfx-filter-group', detail.group || '');
+      wrapper.setAttribute('data-cfx-filter-kind', detail.kind || '');
+      wrapper.setAttribute('data-cfx-filter-active', detail.active ? 'true' : 'false');
+      wrapper.setAttribute('data-cfx-visible-nodes', String(detail.nodes));
+      wrapper.setAttribute('data-cfx-visible-edges', String(detail.edges));
+    };
+    const applyTopologyFilter = state => {
+      topologyFilterState = Object.assign({}, topologyFilterState, state || {});
+      const query = String(topologyFilterState.query || '').trim().toLowerCase();
+      const status = String(topologyFilterState.status || '').trim();
+      const group = String(topologyFilterState.group || '').trim();
+      const kind = String(topologyFilterState.kind || '').trim();
+      const showEdges = topologyFilterState.edges !== false;
+      const showLabels = topologyFilterState.labels !== false;
+      const showGroups = topologyFilterState.groups !== false;
+      const active = !!(query || status || group || kind || !showEdges || !showLabels || !showGroups);
+      const visibleNodes = new Set();
+      const queryNodes = new Set();
+      const statusNodes = new Set();
+      if (query) {
+        wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+          if (!topologyFilterSearchText(edge).includes(query)) return;
+          queryNodes.add(attr(edge, 'data-source-node-id'));
+          queryNodes.add(attr(edge, 'data-target-node-id'));
+        });
+        wrapper.querySelectorAll('[data-cfx-role="topology-group"]').forEach(groupElement => {
+          if (!topologyFilterSearchText(groupElement).includes(query)) return;
+          const groupId = attr(groupElement, 'data-group-id');
+          wrapper.querySelectorAll('[data-cfx-role="topology-node"][data-group-id="' + topologyFilterEscape(groupId) + '"]').forEach(node => queryNodes.add(attr(node, 'data-node-id')));
+        });
+      }
+      if (status) {
+        wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+          if (attr(edge, 'data-cfx-status') !== status) return;
+          statusNodes.add(attr(edge, 'data-source-node-id'));
+          statusNodes.add(attr(edge, 'data-target-node-id'));
+        });
+      }
+      wrapper.querySelectorAll('[data-cfx-role="topology-node"]').forEach(node => {
+        const nodeId = attr(node, 'data-node-id');
+        const groupOk = !group || attr(node, 'data-group-id') === group;
+        const statusOk = !status || attr(node, 'data-cfx-status') === status || statusNodes.has(nodeId);
+        const kindOk = !kind || attr(node, 'data-node-kind') === kind;
+        const queryOk = !query || topologyFilterSearchText(node).includes(query) || queryNodes.has(nodeId);
+        const visible = groupOk && statusOk && kindOk && queryOk;
+        node.classList.toggle('cfx-topology-html-filter-hidden', !visible);
+        wrapper.querySelectorAll('[data-cfx-role="topology-node-status"][data-node-id="' + topologyFilterEscape(nodeId) + '"]').forEach(statusBadge => statusBadge.classList.toggle('cfx-topology-html-filter-hidden', !visible));
+        if (visible) visibleNodes.add(nodeId);
+      });
+      const nodeById = id => wrapper.querySelector('[data-cfx-role="topology-node"][data-node-id="' + topologyFilterEscape(id) + '"]');
+      setTopologyFilterHidden('[data-cfx-role="topology-edge"]', edge => {
+        const sourceId = attr(edge, 'data-source-node-id');
+        const targetId = attr(edge, 'data-target-node-id');
+        const source = nodeById(sourceId);
+        const target = nodeById(targetId);
+        const endpointsVisible = visibleNodes.has(sourceId) && visibleNodes.has(targetId);
+        const edgeQueryOk = !query || topologyFilterSearchText(edge).includes(query) || (source && topologyFilterSearchText(source).includes(query)) || (target && topologyFilterSearchText(target).includes(query));
+        const edgeStatusOk = !status || attr(edge, 'data-cfx-status') === status || (source && attr(source, 'data-cfx-status') === status) || (target && attr(target, 'data-cfx-status') === status);
+        return !showEdges || !endpointsVisible || !edgeQueryOk || !edgeStatusOk;
+      });
+      setTopologyFilterHidden('[data-cfx-role="topology-edge-label"]', label => !showLabels || !showEdges || !wrapper.querySelector('[data-cfx-role="topology-edge"][data-edge-id="' + topologyFilterEscape(attr(label, 'data-edge-id')) + '"]:not(.cfx-topology-html-filter-hidden):not(.cfx-topology-html-force-hidden)'));
+      setTopologyFilterHidden('[data-cfx-role="topology-group"]', groupElement => {
+        const groupId = attr(groupElement, 'data-group-id');
+        const hasVisibleNodes = !!wrapper.querySelector('[data-cfx-role="topology-node"][data-group-id="' + topologyFilterEscape(groupId) + '"]:not(.cfx-topology-html-filter-hidden):not(.cfx-topology-html-force-hidden)');
+        return !showGroups || !hasVisibleNodes || (group && groupId !== group);
+      });
+      const detail = {
+        chartId: attr(wrapper, 'data-chart-id'),
+        nodes: visibleNodes.size,
+        edges: wrapper.querySelectorAll('[data-cfx-role="topology-edge"]:not(.cfx-topology-html-filter-hidden):not(.cfx-topology-html-force-hidden)').length,
+        query: topologyFilterState.query || '',
+        status,
+        group,
+        kind,
+        active
+      };
+      setTopologyFilterAttributes(detail);
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-filter', { bubbles: true, detail }));
+      if (active && visibleNodes.size) fitVisibleTopology(false);
+      restoreForceFocusLabels();
+    };
+    const clearTopologyFilter = () => applyTopologyFilter({ query: '', status: '', group: '', kind: '', edges: true, labels: true, groups: true });

--- a/ChartForgeX/Topology/Assets/topology-interaction.source/80-force-graph-and-bindings.js
+++ b/ChartForgeX/Topology/Assets/topology-interaction.source/80-force-graph-and-bindings.js
@@ -1,0 +1,363 @@
+    const forceSearchText = element => [
+      attr(element, 'data-node-id'), attr(element, 'data-node-label'), attr(element, 'data-node-kind'), attr(element, 'data-group-id'),
+      attr(element, 'data-edge-id'), attr(element, 'data-edge-label'), attr(element, 'data-edge-secondary-label'), attr(element, 'data-edge-tertiary-label'), attr(element, 'data-edge-kind'), attr(element, 'data-source-node-id'), attr(element, 'data-target-node-id'),
+      attr(element, 'data-group-label'), attr(element, 'data-group-symbol'), element.textContent || ''
+    ].join(' ').toLowerCase();
+    const cssEscape = value => window.CSS && CSS.escape ? CSS.escape(value) : String(value).replace(/["\\]/g, '\\$&');
+    const forceGraphState = () => ({
+      query: ((forceGraphPanel && forceGraphPanel.querySelector('[data-cfx-force-search]')) || {}).value || '',
+      status: ((forceGraphPanel && forceGraphPanel.querySelector('[data-cfx-force-status]')) || {}).value || '',
+      group: ((forceGraphPanel && forceGraphPanel.querySelector('[data-cfx-force-group]')) || {}).value || '',
+      edges: !!(forceGraphPanel && forceGraphPanel.querySelector('[data-cfx-force-toggle="edges"]:checked')),
+      focus: !!(forceGraphPanel && forceGraphPanel.querySelector('[data-cfx-force-toggle="focus"]:checked')),
+      labels: !!(forceGraphPanel && forceGraphPanel.querySelector('[data-cfx-force-toggle="edge-labels"]:checked')),
+      groups: !!(forceGraphPanel && forceGraphPanel.querySelector('[data-cfx-force-toggle="groups"]:checked')),
+      hideMovingEdges: !!(forceGraphPanel && forceGraphPanel.querySelector('[data-cfx-force-toggle="hide-moving-edges"]:checked'))
+    });
+    const setForceHidden = (selector, predicate) => {
+      wrapper.querySelectorAll(selector).forEach(element => element.classList.toggle('cfx-topology-html-force-hidden', predicate(element)));
+    };
+    const applyForceGraphFilters = () => {
+      if (!forceGraphControls || !forceGraphPanel) return;
+      const state = forceGraphState();
+      const query = state.query.trim().toLowerCase();
+      const visibleNodes = new Set();
+      const queryNodes = new Set();
+      const statusNodes = new Set();
+      if (query) {
+        wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+          if (!forceSearchText(edge).includes(query)) return;
+          queryNodes.add(attr(edge, 'data-source-node-id'));
+          queryNodes.add(attr(edge, 'data-target-node-id'));
+        });
+        wrapper.querySelectorAll('[data-cfx-role="topology-group"]').forEach(group => {
+          if (!forceSearchText(group).includes(query)) return;
+          const groupId = attr(group, 'data-group-id');
+          wrapper.querySelectorAll('[data-cfx-role="topology-node"][data-group-id="' + cssEscape(groupId) + '"]').forEach(node => queryNodes.add(attr(node, 'data-node-id')));
+        });
+      }
+      if (state.status) {
+        wrapper.querySelectorAll('[data-cfx-role="topology-edge"]').forEach(edge => {
+          if (attr(edge, 'data-cfx-status') !== state.status) return;
+          statusNodes.add(attr(edge, 'data-source-node-id'));
+          statusNodes.add(attr(edge, 'data-target-node-id'));
+        });
+      }
+      wrapper.setAttribute('data-cfx-force-edges-visible', state.edges ? 'true' : 'false');
+      wrapper.setAttribute('data-cfx-force-focus', state.focus ? 'true' : 'false');
+      wrapper.setAttribute('data-cfx-force-edge-labels-visible', state.labels ? 'true' : 'false');
+      wrapper.setAttribute('data-cfx-force-groups-visible', state.groups ? 'true' : 'false');
+      wrapper.setAttribute('data-cfx-force-hide-moving-edges', state.hideMovingEdges ? 'true' : 'false');
+      wrapper.querySelectorAll('[data-cfx-role="topology-node"]').forEach(node => {
+        const groupOk = !state.group || attr(node, 'data-group-id') === state.group;
+        const statusOk = !state.status || attr(node, 'data-cfx-status') === state.status || statusNodes.has(attr(node, 'data-node-id'));
+        const queryOk = !query || forceSearchText(node).includes(query) || queryNodes.has(attr(node, 'data-node-id'));
+        const visible = groupOk && statusOk && queryOk;
+        node.classList.toggle('cfx-topology-html-force-hidden', !visible);
+        wrapper.querySelectorAll('[data-cfx-role="topology-node-status"][data-node-id="' + cssEscape(attr(node, 'data-node-id')) + '"]').forEach(status => status.classList.toggle('cfx-topology-html-force-hidden', !visible));
+        if (visible) visibleNodes.add(attr(node, 'data-node-id'));
+      });
+      const nodeById = id => wrapper.querySelector('[data-cfx-role="topology-node"][data-node-id="' + cssEscape(id) + '"]');
+      setForceHidden('[data-cfx-role="topology-edge"]', edge => {
+        const sourceId = attr(edge, 'data-source-node-id');
+        const targetId = attr(edge, 'data-target-node-id');
+        const source = nodeById(sourceId);
+        const target = nodeById(targetId);
+        const endpointsVisible = visibleNodes.has(sourceId) && visibleNodes.has(targetId);
+        const edgeQueryOk = !query || forceSearchText(edge).includes(query) || (source && forceSearchText(source).includes(query)) || (target && forceSearchText(target).includes(query));
+        const edgeStatusOk = !state.status || attr(edge, 'data-cfx-status') === state.status || (source && attr(source, 'data-cfx-status') === state.status) || (target && attr(target, 'data-cfx-status') === state.status);
+        return !state.edges || !endpointsVisible || !edgeQueryOk || !edgeStatusOk;
+      });
+      setForceHidden('[data-cfx-role="topology-edge-label"]', label => !state.labels || !state.edges || !wrapper.querySelector('[data-cfx-role="topology-edge"][data-edge-id="' + cssEscape(attr(label, 'data-edge-id')) + '"]:not(.cfx-topology-html-force-hidden)'));
+      setForceHidden('[data-cfx-role="topology-group"]', group => {
+        const groupId = attr(group, 'data-group-id');
+        const hasVisibleNodes = !!wrapper.querySelector('[data-cfx-role="topology-node"][data-group-id="' + cssEscape(groupId) + '"]:not(.cfx-topology-html-force-hidden)');
+        return !state.groups || !hasVisibleNodes || (state.group && groupId !== state.group);
+      });
+      const nodeCount = visibleNodes.size;
+      const edgeCount = wrapper.querySelectorAll('[data-cfx-role="topology-edge"]:not(.cfx-topology-html-force-hidden)').length;
+      const summary = forceGraphPanel.querySelector('[data-cfx-force-summary]');
+      if (summary) summary.textContent = nodeCount + ' nodes / ' + edgeCount + ' edges visible';
+      const detail = { chartId: attr(wrapper, 'data-chart-id'), nodes: nodeCount, edges: edgeCount, query: state.query, status: state.status, group: state.group, kind: '', active: !!(state.query || state.status || state.group || !state.edges || !state.labels || !state.groups) };
+      setTopologyFilterAttributes(detail);
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-filter', { bubbles: true, detail }));
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-force-filter', { bubbles: true, detail }));
+      restoreForceFocusLabels();
+    };
+    const clearForceFocusLabels = () => {
+      if (!forceGraphControls) return;
+      const state = forceGraphPanel ? forceGraphState() : { labels: false };
+      wrapper.querySelectorAll('.cfx-topology-html-force-focus-label').forEach(label => {
+        label.classList.remove('cfx-topology-html-force-focus-label');
+        if (!state.labels) label.classList.add('cfx-topology-html-force-hidden');
+      });
+    };
+    const selectedFocusElement = () => {
+      const kind = wrapper.getAttribute('data-cfx-selection-kind') || '';
+      const id = wrapper.getAttribute('data-cfx-selection-id') || '';
+      return kind && id ? findSelection({ kind, id }) : null;
+    };
+    const restoreForceFocusLabels = () => {
+      if (!forceGraphControls || !forceGraphPanel) return;
+      const selected = selectedFocusElement();
+      if (selected) applyForceFocusLabels(identity(selected));
+      else clearForceFocusLabels();
+    };
+    const applyForceFocusLabels = detail => {
+      if (!forceGraphControls || !forceGraphPanel) return;
+      const state = forceGraphState();
+      if (!state.focus || !state.edges) {
+        clearForceFocusLabels();
+        return;
+      }
+      detail.related = detail.related || related(detail);
+      const edgeIds = new Set(detail.related.edgeIds || []);
+      if (detail.kind === 'edge') edgeIds.add(detail.id);
+      wrapper.querySelectorAll('[data-cfx-role="topology-edge-label"]').forEach(label => {
+        const edgeId = attr(label, 'data-edge-id');
+        const edge = wrapper.querySelector('[data-cfx-role="topology-edge"][data-edge-id="' + cssEscape(edgeId) + '"]:not(.cfx-topology-html-force-hidden)');
+        const active = edgeIds.has(edgeId) && !!edge;
+        label.classList.toggle('cfx-topology-html-force-focus-label', active);
+        if (active) label.classList.remove('cfx-topology-html-force-hidden');
+        else if (!state.labels) label.classList.add('cfx-topology-html-force-hidden');
+      });
+      const summary = forceGraphPanel.querySelector('[data-cfx-force-summary]');
+      if (summary && detail.kind === 'node') summary.textContent = detail.id + ': ' + (detail.related.nodeIds || []).length + ' neighbors / ' + edgeIds.size + ' edges';
+    };
+    wrapper.querySelectorAll(selectables).forEach(element => {
+      if (!element.hasAttribute('tabindex')) element.setAttribute('tabindex', '0');
+      if (!element.hasAttribute('role')) element.setAttribute('role', 'button');
+      element.addEventListener('pointerenter', () => hover(element));
+      element.addEventListener('pointerleave', () => {
+        clearHover();
+        wrapper.dispatchEvent(new CustomEvent('cfx-topology-hover-clear', { bubbles: true }));
+      });
+      element.addEventListener('focus', () => hover(element));
+      element.addEventListener('blur', () => {
+        clearHover();
+        wrapper.dispatchEvent(new CustomEvent('cfx-topology-hover-clear', { bubbles: true }));
+      });
+    });
+    const initiallySelected = Array.from(wrapper.querySelectorAll(selectables)).find(element => attr(element, 'data-cfx-selected') === 'true');
+    if (initiallySelected) hydrateSelected(initiallySelected);
+    else renderSelectionPanel(null);
+    if (viewportControls) {
+      applyViewport(viewportState());
+      wrapper.querySelectorAll('[data-cfx-topology-zoom]').forEach(button => {
+        button.addEventListener('click', () => zoomBy(attr(button, 'data-cfx-topology-zoom') === 'in' ? 1.2 : 0.8333333333));
+      });
+      wrapper.querySelectorAll('[data-cfx-topology-mode]').forEach(button => {
+        button.addEventListener('click', () => setViewportMode(attr(button, 'data-cfx-topology-mode')));
+      });
+      wrapper.querySelectorAll('[data-cfx-topology-fit]').forEach(button => {
+        button.addEventListener('click', () => fitViewport());
+      });
+      wrapper.querySelectorAll('[data-cfx-topology-reset]').forEach(button => {
+        button.addEventListener('click', () => resetViewport());
+      });
+      let drag = null;
+      let suppressClick = false;
+      const isViewportChrome = target => target instanceof Element && target.closest('.cfx-topology-controls,.cfx-topology-scenarios,.cfx-topology-scenario-panel,.cfx-topology-selection-panel,.cfx-topology-force-controls');
+      viewport.addEventListener('wheel', event => {
+        if (isViewportChrome(event.target)) return;
+        event.preventDefault();
+        zoomBy(event.deltaY < 0 ? 1.08 : 0.92, event);
+      }, { passive: false });
+      viewport.addEventListener('pointerdown', event => {
+        if (event.button !== 0) return;
+        if (isViewportChrome(event.target)) return;
+        const state = viewportState();
+        drag = { id: event.pointerId, x: event.clientX, y: event.clientY, panX: state.panX, panY: state.panY, moved: false };
+        wrapper.setAttribute('data-cfx-topology-dragging', 'true');
+        try { if (viewport.setPointerCapture) viewport.setPointerCapture(event.pointerId); } catch { }
+      });
+      viewport.addEventListener('pointermove', event => {
+        if (!drag || drag.id !== event.pointerId) return;
+        const dx = event.clientX - drag.x;
+        const dy = event.clientY - drag.y;
+        if (Math.abs(dx) > 2 || Math.abs(dy) > 2) {
+          drag.moved = true;
+          suppressClick = true;
+          markForceGraphMoving();
+        }
+        applyViewport({ zoom: viewportState().zoom, panX: drag.panX + dx, panY: drag.panY + dy });
+      });
+      viewport.addEventListener('pointerup', event => {
+        if (!drag || drag.id !== event.pointerId) return;
+        try { if (viewport.releasePointerCapture) viewport.releasePointerCapture(event.pointerId); } catch { }
+        if (drag.moved) emitViewport();
+        wrapper.removeAttribute('data-cfx-force-moving-edges');
+        wrapper.removeAttribute('data-cfx-topology-dragging');
+        wrapper.querySelectorAll('.cfx-topology-html-force-moving').forEach(edge => edge.classList.remove('cfx-topology-html-force-moving'));
+        drag = null;
+      });
+      viewport.addEventListener('pointercancel', event => {
+        if (drag && drag.id === event.pointerId) {
+          wrapper.removeAttribute('data-cfx-topology-dragging');
+          drag = null;
+        }
+      });
+      wrapper.addEventListener('cfx-topology-set-viewport', event => {
+        applyViewport(event.detail || {});
+        emitViewport();
+      });
+      wrapper.addEventListener('cfx-topology-reset-viewport', () => resetViewport());
+      wrapper.addEventListener('cfx-topology-fit-visible', event => {
+        const detail = event.detail || {};
+        if (detail.kind && detail.id) {
+          const element = findSelection(detail);
+          if (element) {
+            fitViewportToElements([element]);
+            return;
+          }
+        }
+
+        fitVisibleTopology();
+      });
+      wrapper.addEventListener('click', event => {
+        if (isViewportChrome(event.target)) return;
+        if (!suppressClick) return;
+        suppressClick = false;
+        event.preventDefault();
+        event.stopPropagation();
+      }, true);
+    }
+    if (exportControls) {
+      wrapper.querySelectorAll('[data-cfx-topology-export]').forEach(button => {
+        button.addEventListener('click', () => {
+          if (attr(button, 'data-cfx-topology-export') === 'png') exportPng();
+          else exportSvg();
+        });
+      });
+    }
+    if (fullscreenControl) {
+      wrapper.querySelectorAll('[data-cfx-topology-fullscreen]').forEach(button => {
+        button.addEventListener('click', () => toggleFullscreen());
+      });
+      document.addEventListener('fullscreenchange', setFullscreenState);
+      setFullscreenState();
+    }
+    if (forceGraphControls && forceGraphPanel) {
+      forceGraphPanel.querySelectorAll('input,select').forEach(control => {
+        control.addEventListener('input', applyForceGraphFilters);
+        control.addEventListener('change', applyForceGraphFilters);
+      });
+      wrapper.addEventListener('cfx-topology-force-filter-set', event => {
+        const detail = event.detail || {};
+        if (forceGraphPanel.querySelector('[data-cfx-force-search]') && detail.query !== undefined) forceGraphPanel.querySelector('[data-cfx-force-search]').value = detail.query || '';
+        if (forceGraphPanel.querySelector('[data-cfx-force-status]') && detail.status !== undefined) forceGraphPanel.querySelector('[data-cfx-force-status]').value = detail.status || '';
+        if (forceGraphPanel.querySelector('[data-cfx-force-group]') && detail.group !== undefined) forceGraphPanel.querySelector('[data-cfx-force-group]').value = detail.group || '';
+        applyForceGraphFilters();
+      });
+      applyForceGraphFilters();
+    }
+    wrapper.addEventListener('cfx-topology-set-filter', event => applyTopologyFilter(event.detail || {}));
+    wrapper.addEventListener('cfx-topology-clear-filter', () => clearTopologyFilter());
+    if (scenarioControls) {
+      if (scenarioControlMode === 'checkboxes') {
+        wrapper.querySelectorAll('[data-cfx-topology-scenario-toggle]').forEach(input => {
+          const scenarioId = attr(input, 'data-cfx-topology-scenario-toggle');
+          input.addEventListener('change', () => setScenarioFilters(Array.from(wrapper.querySelectorAll('[data-cfx-topology-scenario-toggle]:checked')).map(item => attr(item, 'data-cfx-topology-scenario-toggle'))));
+          input.addEventListener('pointerenter', () => previewScenario(scenarioId));
+          input.addEventListener('pointerleave', clearScenarioPreview);
+          input.addEventListener('focus', () => previewScenario(scenarioId));
+          input.addEventListener('blur', clearScenarioPreview);
+        });
+      } else {
+        wrapper.querySelectorAll('[data-cfx-topology-scenario]').forEach(button => {
+          const scenarioId = attr(button, 'data-cfx-topology-scenario');
+          button.addEventListener('click', () => setScenario(scenarioId));
+          button.addEventListener('pointerenter', () => previewScenario(scenarioId));
+          button.addEventListener('pointerleave', clearScenarioPreview);
+          button.addEventListener('focus', () => previewScenario(scenarioId));
+          button.addEventListener('blur', clearScenarioPreview);
+        });
+      }
+      wrapper.addEventListener('cfx-topology-set-scenario', event => setScenario((event.detail || {}).scenarioId || ''));
+      wrapper.addEventListener('cfx-topology-set-scenario-filters', event => setScenarioFilters((event.detail || {}).scenarioIds || []));
+      wrapper.addEventListener('cfx-topology-clear-scenario', () => setScenario(''));
+      wrapper.addEventListener('cfx-topology-set-scenario-step', event => setScenarioStep((event.detail || {}).index, false));
+      wrapper.querySelectorAll('[data-cfx-scenario-step-control]').forEach(button => {
+        button.addEventListener('click', () => {
+          const action = attr(button, 'data-cfx-scenario-step-control');
+          if (action === 'previous') stepScenario(-1);
+          else if (action === 'next') stepScenario(1);
+          else if (action === 'play') playScenario();
+          else if (action === 'reset') { stopScenarioPlayback(); clearScenarioStep(); }
+          else if (action === 'link') copyScenarioLink();
+        });
+      });
+      const stepsList = scenarioPanel ? scenarioPanel.querySelector('[data-cfx-scenario-panel-steps]') : null;
+      if (stepsList) {
+        const focusStep = target => { const item = target instanceof Element ? target.closest('[data-cfx-scenario-step-index]') : null; if (item && stepsList.contains(item)) setScenarioStep(Number(attr(item, 'data-cfx-scenario-step-index')) - 1, false); };
+        stepsList.addEventListener('click', event => focusStep(event.target));
+        stepsList.addEventListener('keydown', event => { if (event.key !== 'Enter' && event.key !== ' ') return; event.preventDefault(); focusStep(event.target); });
+      }
+      const initialScenario = scenarioUrlParam('scenario') || attr(wrapper, 'data-cfx-active-scenario');
+      const initialScenarioStep = scenarioUrlParam('scenarioStep');
+      if (scenarioControlMode === 'checkboxes') setScenarioFilters(initialScenario ? scenarioIdTokens(initialScenario) : Array.from(wrapper.querySelectorAll('[data-cfx-topology-scenario-toggle]:checked')).map(item => attr(item, 'data-cfx-topology-scenario-toggle')), false, false);
+      else setScenario(initialScenario, false, false);
+      if (initialScenarioStep && (scenarioControlMode !== 'checkboxes' || attr(wrapper, 'data-cfx-active-scenario'))) setScenarioStep(initialScenarioStep, false, false, false);
+    }
+    wrapper.addEventListener('click', event => {
+      const element = event.target instanceof Element ? event.target.closest(selectables) : null;
+      if (!element || !wrapper.contains(element)) return;
+      event.preventDefault();
+      select(element);
+    });
+    wrapper.addEventListener('keydown', event => {
+      if (event.key === 'Escape') {
+        clear();
+        wrapper.dispatchEvent(new CustomEvent('cfx-topology-clear', { bubbles: true }));
+        emitSync('clear-selection', {});
+        return;
+      }
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown' || event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        const element = event.target instanceof Element ? event.target.closest(selectables) : null;
+        if (!element || !wrapper.contains(element)) return;
+        if (focusRelated(element, event.key === 'ArrowRight' || event.key === 'ArrowDown' ? 1 : -1)) event.preventDefault();
+        return;
+      }
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      const element = event.target instanceof Element ? event.target.closest(selectables) : null;
+      if (!element || !wrapper.contains(element)) return;
+      event.preventDefault();
+      select(element);
+    });
+    wrapper.addEventListener('cfx-topology-set-selection', event => {
+      const element = findSelection(event.detail);
+      if (element) select(element);
+    });
+    wrapper.addEventListener('cfx-topology-clear-selection', () => {
+      clear();
+      wrapper.dispatchEvent(new CustomEvent('cfx-topology-clear', { bubbles: true }));
+      emitSync('clear-selection', {});
+    });
+    wrapper.addEventListener('cfx-topology-apply-sync', event => {
+      const detail = event.detail || {};
+      if (!syncEnabled || !syncGroup || detail.group !== syncGroup) return;
+      applyingSync = true;
+      try {
+        if (detail.action === 'selection' && detail.selection) {
+          const element = findSelection(detail.selection);
+          if (element) select(element);
+        } else if (detail.action === 'clear-selection') {
+          clear();
+          wrapper.dispatchEvent(new CustomEvent('cfx-topology-clear', { bubbles: true }));
+        } else if (detail.action === 'viewport' && detail.state) {
+          applyViewport(detail.state);
+          wrapper.dispatchEvent(new CustomEvent('cfx-topology-viewport', { bubbles: true, detail: { chartId: attr(wrapper, 'data-chart-id'), state: viewportState(), sourceChartId: detail.chartId } }));
+        } else if (detail.action === 'scenario') {
+          setScenario(detail.scenarioId || '');
+        } else if (detail.action === 'scenario-filters') {
+          setScenarioFilters(detail.scenarioIds || []);
+        } else if (detail.action === 'scenario-step') {
+          if (detail.scenarioId && attr(wrapper, 'data-cfx-active-scenario') !== detail.scenarioId) setScenario(detail.scenarioId);
+          setScenarioStep(detail.index, false);
+        }
+      } finally {
+        applyingSync = false;
+      }
+    });
+  }
+})();

--- a/ChartForgeX/Topology/Assets/topology.css
+++ b/ChartForgeX/Topology/Assets/topology.css
@@ -87,6 +87,7 @@
 .cfx-topology-wrapper .cfx-topology-html-scenario-step-active{opacity:1;filter:drop-shadow(0 10px 18px rgba(15,23,42,.2))}
 .cfx-topology-wrapper .cfx-topology-html-scenario-step-active .cfx-topology__edge{stroke-width:6!important}
 .cfx-topology-wrapper .cfx-topology-html-scenario-step-active .cfx-topology__node-card{stroke-width:3!important}
+.cfx-topology-wrapper .cfx-topology-html-filter-hidden{display:none!important}
 .cfx-topology-wrapper .cfx-topology-html-force-hidden{display:none!important}
 .cfx-topology-wrapper .cfx-topology-html-force-faded{opacity:.12!important}
 .cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-muted,.cfx-topology-wrapper[data-cfx-force-focus='true'] .cfx-topology-html-hover-muted{opacity:.06!important}

--- a/ChartForgeX/Topology/TopologyChartExtensions.Rendering.cs
+++ b/ChartForgeX/Topology/TopologyChartExtensions.Rendering.cs
@@ -24,6 +24,14 @@ public static partial class TopologyChartExtensions {
     public static string ToHtmlFragment(this TopologyChart chart, TopologyRenderOptions? options = null) => new TopologyHtmlRenderer().RenderFragment(chart, options);
 
     /// <summary>
+    /// Renders the topology chart to an HTML fragment without renderer-owned stylesheet or script assets.
+    /// </summary>
+    /// <param name="chart">The topology chart.</param>
+    /// <param name="options">Optional render options.</param>
+    /// <returns>An embeddable HTML fragment that expects the host document to register topology HTML assets.</returns>
+    public static string ToHtmlFragmentWithoutAssets(this TopologyChart chart, TopologyRenderOptions? options = null) => new TopologyHtmlRenderer().RenderFragmentWithoutAssets(chart, options);
+
+    /// <summary>
     /// Renders the topology chart to a complete HTML page.
     /// </summary>
     /// <param name="chart">The topology chart.</param>

--- a/ChartForgeX/Topology/TopologyHtmlRenderer.Scripts.cs
+++ b/ChartForgeX/Topology/TopologyHtmlRenderer.Scripts.cs
@@ -4,6 +4,11 @@ public sealed partial class TopologyHtmlRenderer
 {
     private static string InteractionScript(string cssPrefix)
     {
+        return "<script>\n" + InteractionScriptBody(cssPrefix) + "\n</script>";
+    }
+
+    private static string InteractionScriptBody(string cssPrefix)
+    {
         var script = TopologyHtmlAssets.InteractionScript
             .Replace(".cfx-topology-wrapper", "." + cssPrefix + "-wrapper")
             .Replace(".cfx-topology-viewport", "." + cssPrefix + "-viewport")
@@ -13,6 +18,6 @@ public sealed partial class TopologyHtmlRenderer
             .Replace(".cfx-topology-selection-panel", "." + cssPrefix + "-selection-panel")
             .Replace(".cfx-topology-force-controls", "." + cssPrefix + "-force-controls")
             .Replace("cfx-topology-html-", cssPrefix + "-html-");
-        return "<script>\n" + script + "\n</script>";
+        return script;
     }
 }

--- a/ChartForgeX/Topology/TopologyHtmlRenderer.cs
+++ b/ChartForgeX/Topology/TopologyHtmlRenderer.cs
@@ -23,6 +23,16 @@ public sealed partial class TopologyHtmlRenderer {
         return RenderFragmentCore(chart, options, includeAssets: true);
     }
 
+    /// <summary>
+    /// Renders an embeddable HTML fragment without renderer-owned stylesheet or script assets.
+    /// </summary>
+    /// <param name="chart">The topology chart.</param>
+    /// <param name="options">Optional render options.</param>
+    /// <returns>An HTML fragment that expects the caller to register topology HTML assets.</returns>
+    public string RenderFragmentWithoutAssets(TopologyChart chart, TopologyRenderOptions? options = null) {
+        return RenderFragmentCore(chart, options, includeAssets: false);
+    }
+
     private string RenderFragmentCore(TopologyChart chart, TopologyRenderOptions? options, bool includeAssets) {
         if (chart == null) throw new ArgumentNullException(nameof(chart));
         options ??= new TopologyRenderOptions();
@@ -155,6 +165,28 @@ public sealed partial class TopologyHtmlRenderer {
         writer.EndElement().Line()
             .EndElement().Line();
         return writer.Build();
+    }
+
+    /// <summary>
+    /// Builds the renderer-owned stylesheet used by topology HTML fragments.
+    /// </summary>
+    /// <param name="options">Optional render options whose CSS prefix should be honored.</param>
+    /// <param name="theme">Optional topology theme whose font family should be used.</param>
+    /// <returns>CSS ready to register once in a host document.</returns>
+    public static string BuildFragmentStyle(TopologyRenderOptions? options = null, TopologyTheme? theme = null) {
+        options ??= new TopologyRenderOptions();
+        theme ??= TopologyTheme.Light();
+        return StyleSheet(CssClassPrefix(options), CssFontFamily(theme.FontFamily), theme.Background, includePageShell: false);
+    }
+
+    /// <summary>
+    /// Builds the renderer-owned JavaScript runtime used by interactive topology HTML fragments.
+    /// </summary>
+    /// <param name="options">Optional render options whose CSS prefix should be honored.</param>
+    /// <returns>JavaScript ready to register once in a host document.</returns>
+    public static string BuildInteractionScript(TopologyRenderOptions? options = null) {
+        options ??= new TopologyRenderOptions();
+        return InteractionScriptBody(CssClassPrefix(options));
     }
 
     private static void WriteIconButton(HtmlMarkupWriter writer, string dataAttribute, string dataValue, string title, string ariaLabel, bool? pressed, string icon, string? text = null) {

--- a/ChartForgeX/Topology/TopologyRenderOptionsExtensions.cs
+++ b/ChartForgeX/Topology/TopologyRenderOptionsExtensions.cs
@@ -323,6 +323,7 @@ public static class TopologyRenderOptionsExtensions {
     public static TopologyRenderOptions WithHtmlScenarioControls(this TopologyRenderOptions options, bool enabled = true) {
         if (options == null) throw new ArgumentNullException(nameof(options));
         options.EnableHtmlScenarioControls = enabled;
+        if (enabled) options.EnableHtmlInteractions = true;
         return options;
     }
 
@@ -336,6 +337,8 @@ public static class TopologyRenderOptionsExtensions {
         if (options == null) throw new ArgumentNullException(nameof(options));
         TopologyModelGuards.EnumDefined(mode, nameof(mode));
         options.HtmlScenarioControlMode = mode;
+        options.EnableHtmlInteractions = true;
+        options.EnableHtmlScenarioControls = true;
         return options;
     }
 
@@ -356,6 +359,7 @@ public static class TopologyRenderOptionsExtensions {
     public static TopologyRenderOptions WithHtmlScenarioPanel(this TopologyRenderOptions options, bool enabled = true) {
         if (options == null) throw new ArgumentNullException(nameof(options));
         options.EnableHtmlScenarioPanel = enabled;
+        if (enabled) options.EnableHtmlInteractions = true;
         return options;
     }
 
@@ -407,6 +411,7 @@ public static class TopologyRenderOptionsExtensions {
     public static TopologyRenderOptions WithHtmlScenarioUrlState(this TopologyRenderOptions options, bool enabled = true) {
         if (options == null) throw new ArgumentNullException(nameof(options));
         options.EnableHtmlScenarioUrlState = enabled;
+        if (enabled) options.EnableHtmlInteractions = true;
         return options;
     }
 


### PR DESCRIPTION
## Summary
- split interactive ChartForgeX HTML runtime assets into source modules with a bundled output check
- add topology filter events, visible-count metadata, and fit-to-visible viewport behavior
- expose richer topology interaction contracts for downstream HFX adapters while keeping CFX dependency-free

## Validation
- .\Build\Sync-InteractiveAssets.ps1 -Check
- dotnet test .\ChartForgeX.sln -c Release --no-restore
