### PR TITLE
Update undici lockfile for security advisory

### DIFF
--- a/ChartForgeX.Markup.VSCode/package-lock.json
+++ b/ChartForgeX.Markup.VSCode/package-lock.json
@@ -4315,9 +4315,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Update the transitive `undici` lockfile entry from 7.25.0 to 7.28.0 in `ChartForgeX.Markup.VSCode/package-lock.json`
- Address Dependabot alert #16 / GHSA-vmh5-mc38-953g for the VS Code extension packaging dependency graph

## Validation
- `npm ci`
- `npm audit --omit=dev --audit-level=moderate`
- `npm run compile`
- `npm run package`