### PR TITLE
Update dompurify for security advisory

### DIFF
--- a/tests/mermaid-conformance/package-lock.json
+++ b/tests/mermaid-conformance/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "chartforgex-mermaid-conformance",
       "dependencies": {
-        "dompurify": "3.4.9",
+        "dompurify": "3.4.11",
         "jsdom": "27.3.0",
         "mermaid": "11.15.0"
       }
@@ -1134,9 +1134,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
-      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/tests/mermaid-conformance/package.json
+++ b/tests/mermaid-conformance/package.json
@@ -6,7 +6,7 @@
     "validate": "node validate-mermaid.mjs"
   },
   "dependencies": {
-    "dompurify": "3.4.9",
+    "dompurify": "3.4.11",
     "jsdom": "27.3.0",
     "mermaid": "11.15.0"
   }


### PR DESCRIPTION
## Summary
- Update `dompurify` from 3.4.9 to 3.4.11 in `tests/mermaid-conformance`
- Address Dependabot alert #17 for the Mermaid conformance lockfile

## Validation
- `npm ci`
- `npm audit --omit=dev --audit-level=moderate`
- `npm run validate`