### PR TITLE
Improve visual canvas info tile layout fitting

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -55,6 +55,25 @@ internal static partial class SmokeTests {
         Assert(constrainedTileSvg.Contains("...", StringComparison.Ordinal), "Single-line VisualCanvas info tile policy should trim overflowing values with an ellipsis.");
         Assert(constrainedTileCanvas.AnalyzeLayout().HasWarnings, "Constrained VisualCanvas info tiles should report layout diagnostics when text is trimmed.");
 
+        var spacedTileSvg = VisualCanvas.Create(360, 112)
+            .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+            .AddInfoTile(12, 12, 300, 82, "PC", "HOST", "DEV  WKS  01")
+            .ToSvg("visual-canvas-spaced-tile-text");
+        Assert(spacedTileSvg.Contains("DEV  WKS  01", StringComparison.Ordinal), "VisualCanvas info tile fitting should preserve intentional spacing when text fits without wrapping.");
+
+        var progressDetailCanvas = VisualCanvas.Create(360, 128)
+            .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+            .AddInfoTile(12, 12, 300, 96, "CPU", "CPU", "Intel Core i7", "Package temperature nominal", progress: 0.23);
+        var progressDetailReport = progressDetailCanvas.AnalyzeLayout();
+        var progressDetailTrimmed = false;
+        var progressDetailTooTall = false;
+        foreach (var diagnostic in progressDetailReport.Diagnostics) {
+            progressDetailTrimmed |= diagnostic.Code == "InfoTileTextTrimmed";
+            progressDetailTooTall |= diagnostic.Code == "InfoTileTextTooTall";
+        }
+
+        Assert(progressDetailTrimmed && !progressDetailTooTall, "Progress info tiles should report omitted detail as fitted text instead of letting text collide with the progress rail.");
+
         var outsideCanvas = VisualCanvas.Create(100, 80)
             .AddInfoTile(80, 20, 60, 44, "I", "LABEL", "VALUE", textFitPolicy: VisualCanvasTextFitPolicy.Wrap);
         Assert(outsideCanvas.AnalyzeLayout().HasWarnings, "VisualCanvas layout diagnostics should detect layers outside the canvas bounds.");

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -39,6 +39,26 @@ internal static partial class SmokeTests {
         Assert(svg.Contains("Power", StringComparison.Ordinal) && svg.Contains("BGInfo", StringComparison.Ordinal), "VisualCanvas hero title should preserve colored title runs.");
         Assert(canvas.ToPng().Length > 64, "VisualCanvas should render PNG output.");
 
+        var resizedTileCanvas = VisualCanvas.Create(620, 220)
+            .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+            .AddInfoTile(24, 24, 520, 150, "OS", "OPERATING SYSTEM", "Windows 11 Enterprise Intune compliance", "cross-site policy drift", surfaceStyle: VisualCanvasInfoTileSurfaceStyle.Raised, iconKind: VisualCanvasInfoTileIconKind.OperatingSystem);
+        var resizedTileSvg = resizedTileCanvas.ToSvg("visual-canvas-resized-tile-text");
+        Assert(resizedTileSvg.Contains("compliance", StringComparison.Ordinal), "Resized VisualCanvas info tiles should preserve long value text across wrapped lines.");
+        Assert(resizedTileSvg.Contains("policy drift", StringComparison.Ordinal), "Resized VisualCanvas info tiles should preserve detail text when height is available.");
+        Assert(resizedTileCanvas.AnalyzeLayout().IsClean, "Resized VisualCanvas info tiles should not report layout diagnostics when text fits.");
+        Assert(resizedTileCanvas.ToPng().Length > 64, "Resized VisualCanvas info tiles should render wrapped text to PNG output.");
+
+        var constrainedTileCanvas = VisualCanvas.Create(230, 120)
+            .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+            .AddInfoTile(12, 12, 160, 72, "OS", "OPERATING SYSTEM", "Windows 11 Enterprise Intune compliance", textFitPolicy: VisualCanvasTextFitPolicy.SingleLineEllipsis);
+        var constrainedTileSvg = constrainedTileCanvas.ToSvg("visual-canvas-constrained-tile-text");
+        Assert(constrainedTileSvg.Contains("...", StringComparison.Ordinal), "Single-line VisualCanvas info tile policy should trim overflowing values with an ellipsis.");
+        Assert(constrainedTileCanvas.AnalyzeLayout().HasWarnings, "Constrained VisualCanvas info tiles should report layout diagnostics when text is trimmed.");
+
+        var outsideCanvas = VisualCanvas.Create(100, 80)
+            .AddInfoTile(80, 20, 60, 44, "I", "LABEL", "VALUE", textFitPolicy: VisualCanvasTextFitPolicy.Wrap);
+        Assert(outsideCanvas.AnalyzeLayout().HasWarnings, "VisualCanvas layout diagnostics should detect layers outside the canvas bounds.");
+
         var cpuChart = Chart.Create()
             .WithSize(220, 120)
             .WithTransparentBackground()
@@ -202,6 +222,7 @@ internal static partial class SmokeTests {
         AssertThrows<ArgumentOutOfRangeException>(() => canvas.PngOutputScale = 5, "VisualCanvas should reject unsupported PNG output scales.");
         AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").Progress = 1.2, "VisualCanvas info tile progress should stay normalized.");
         AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").WithMiniChart(VisualCanvasInfoTileMiniChartKind.Sparkline, new[] { double.NaN }), "VisualCanvas info tile mini charts should reject invalid values.");
+        AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasInfoTileLayer(0, 0, 100, 80, "I", "L", "V").WithTextFitPolicy((VisualCanvasTextFitPolicy)999), "VisualCanvas info tile text fit policy should reject unknown values.");
         AssertThrows<ArgumentException>(() => new VisualCanvasKeyValueBlockLayer(0, 0, 100, 1, Array.Empty<VisualCanvasKeyValueItem>()), "VisualCanvas key/value blocks should require rows.");
         AssertThrows<ArgumentOutOfRangeException>(() => new VisualCanvasKeyValueBlockLayer(0, 0, 100, 1, new[] { VisualCanvasKeyValueItem.Pair("A", "B") }) { LabelFontSize = 0 }, "VisualCanvas key/value blocks should reject invalid font sizes.");
         AssertThrows<ArgumentOutOfRangeException>(() => VisualCanvas.Create(24, 24).AddImage(0, 0, 12, 12, rgba: new byte[] { 0, 0, 0, 255 }, sourceWidth: 1, sourceHeight: 1, fit: (VisualCanvasImageFit)999), "VisualCanvas image fit should reject unknown values.");

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -118,10 +118,12 @@ public sealed class PngVisualCanvasRenderer {
         VisualCanvas.ValidateEnum(tile.SurfaceStyle, nameof(tile.SurfaceStyle));
         VisualCanvas.ValidateEnum(tile.IconKind, nameof(tile.IconKind));
         VisualCanvas.ValidateEnum(tile.MiniChartKind, nameof(tile.MiniChartKind));
-        var x = Math.Round(tile.X);
-        var y = Math.Round(tile.Y);
-        var width = Math.Round(tile.Width);
-        var height = Math.Round(tile.Height);
+        VisualCanvas.ValidateEnum(tile.TextFitPolicy, nameof(tile.TextFitPolicy));
+        var metrics = VisualCanvasInfoTileTextLayout.CalculateMetrics(tile);
+        var x = metrics.X;
+        var y = metrics.Y;
+        var width = metrics.Width;
+        var height = metrics.Height;
         var radius = Math.Min(16, height * 0.18);
         var isRaised = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Raised;
         var isFilled = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Glass || isRaised;
@@ -145,10 +147,10 @@ public sealed class PngVisualCanvasRenderer {
         if (isFilled) {
             canvas.StrokeRoundedRect(x + 2.5, y + 2.5, Math.Max(1, width - 5), Math.Max(1, height - 5), Math.Max(1, radius - 2), theme.TileInnerStroke, 1);
         }
-        var padX = Math.Max(20, Math.Min(28, width * 0.06));
-        var iconBox = Math.Max(44, Math.Min(54, height - 34));
-        var iconX = x + padX;
-        var iconY = y + (height - iconBox) / 2;
+        var padX = metrics.PadX;
+        var iconBox = metrics.IconBox;
+        var iconX = metrics.IconX;
+        var iconY = metrics.IconY;
         var iconRadius = Math.Min(13, iconBox * 0.25);
         if (isFilled) {
             canvas.FillRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, accent.WithOpacity(isRaised ? 0.25 : 0.18));
@@ -157,32 +159,31 @@ public sealed class PngVisualCanvasRenderer {
             canvas.StrokeRoundedRect(iconX, iconY, iconBox, iconBox, iconRadius, accent.WithOpacity(0.38), 1);
         }
         DrawTileIcon(canvas, tile.IconKind, tile.Icon, iconX, iconY, iconBox, accent);
-        var textX = iconX + iconBox + 22;
-        var hasMiniChart = tile.MiniChartKind != VisualCanvasInfoTileMiniChartKind.None && tile.MiniChartValues.Count > 0;
-        var chartW = hasMiniChart ? Math.Min(width * 0.24, Math.Max(82, width * 0.20)) : 0;
-        var chartX = x + width - padX - chartW;
-        var chartY = y + Math.Max(24, height * 0.30);
-        var chartH = Math.Max(28, Math.Min(46, height * 0.42));
-        var textMax = hasMiniChart ? Math.Max(24, chartX - textX - 16) : Math.Max(24, width - (textX - x) - padX);
-        var labelFont = 14.0;
-        var valueFont = height < 92 ? 21.0 : 22.0;
-        var detailFont = 13.0;
-        var hasDetail = tile.Detail.Length > 0;
-        var labelY = y + (hasDetail ? 17 : Math.Max(18, (height - 52) / 2));
-        var valueY = labelY + 25;
-        var detailY = valueY + 25;
-        canvas.DrawTextEmphasized(textX, labelY, FitText(tile.Label, labelFont, textMax, true), theme.TileLabelColor, labelFont);
-        canvas.DrawTextEmphasized(textX, valueY, FitText(tile.Value, valueFont, textMax, true), theme.TileValueColor, valueFont);
-        if (hasDetail) canvas.DrawText(textX, detailY, FitText(tile.Detail, detailFont, textMax, false), theme.TileDetailColor, detailFont);
+        var textX = metrics.TextX;
+        var chartW = metrics.ChartWidth;
+        var chartX = metrics.ChartX;
+        foreach (var line in VisualCanvasInfoTileTextLayout.BuildResult(tile, metrics.Y, metrics.Height, metrics.TextX, metrics.TextMax).Lines) {
+            var color = TileTextColor(line.Role, theme);
+            if (line.Emphasized) canvas.DrawTextEmphasized(line.X, line.Y, line.Text, color, line.FontSize);
+            else canvas.DrawText(line.X, line.Y, line.Text, color, line.FontSize);
+        }
         if (tile.Progress.HasValue) {
             var railX = textX;
             var railY = y + height - 16;
-            var railW = hasMiniChart ? Math.Max(24, chartX - railX - 16) : Math.Max(24, width - (railX - x) - padX);
+            var railW = metrics.HasMiniChart ? Math.Max(24, chartX - railX - 16) : Math.Max(24, width - (railX - x) - padX);
             canvas.FillRoundedRect(railX, railY, railW, 8, 4, theme.TileProgressTrackColor);
             canvas.FillRoundedRect(railX, railY, railW * tile.Progress.Value, 8, 4, accent);
         }
-        if (hasMiniChart) {
-            DrawTileMiniChart(canvas, tile, theme, accent, chartX, chartY, chartW, chartH);
+        if (metrics.HasMiniChart) {
+            DrawTileMiniChart(canvas, tile, theme, accent, chartX, metrics.ChartY, chartW, metrics.ChartHeight);
+        }
+    }
+
+    private static ChartColor TileTextColor(VisualCanvasInfoTileTextRole role, VisualCanvasTheme theme) {
+        switch (role) {
+            case VisualCanvasInfoTileTextRole.Label: return theme.TileLabelColor;
+            case VisualCanvasInfoTileTextRole.Detail: return theme.TileDetailColor;
+            default: return theme.TileValueColor;
         }
     }
 

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -211,10 +211,12 @@ public sealed class SvgVisualCanvasRenderer {
         VisualCanvas.ValidateEnum(tile.SurfaceStyle, nameof(tile.SurfaceStyle));
         VisualCanvas.ValidateEnum(tile.IconKind, nameof(tile.IconKind));
         VisualCanvas.ValidateEnum(tile.MiniChartKind, nameof(tile.MiniChartKind));
-        var x = Math.Round(tile.X);
-        var y = Math.Round(tile.Y);
-        var width = Math.Round(tile.Width);
-        var height = Math.Round(tile.Height);
+        VisualCanvas.ValidateEnum(tile.TextFitPolicy, nameof(tile.TextFitPolicy));
+        var metrics = VisualCanvasInfoTileTextLayout.CalculateMetrics(tile);
+        var x = metrics.X;
+        var y = metrics.Y;
+        var width = metrics.Width;
+        var height = metrics.Height;
         var accent = tile.AccentOverride ?? theme.Accent;
         var radius = Math.Min(16, height * 0.18);
         var isRaised = tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Raised;
@@ -232,36 +234,37 @@ public sealed class SvgVisualCanvasRenderer {
         if (isFilled) {
             writer.StartElement("rect").Attribute("x", x + 2.5).Attribute("y", y + 2.5).Attribute("width", Math.Max(1, width - 5)).Attribute("height", Math.Max(1, height - 5)).Attribute("rx", Math.Max(1, radius - 2)).Attribute("fill", "none").Attribute("stroke", theme.TileInnerStroke.ToCss()).EndEmptyElement().Line();
         }
-        var padX = Math.Max(20, Math.Min(28, width * 0.06));
-        var iconBox = Math.Max(44, Math.Min(54, height - 34));
-        var iconX = x + padX;
-        var iconY = y + (height - iconBox) / 2;
+        var padX = metrics.PadX;
+        var iconBox = metrics.IconBox;
+        var iconX = metrics.IconX;
+        var iconY = metrics.IconY;
         var iconFont = Math.Min(25, iconBox * (tile.Icon.Length > 3 ? 0.34 : 0.42));
         writer.StartElement("rect").Attribute("x", iconX).Attribute("y", iconY).Attribute("width", iconBox).Attribute("height", iconBox).Attribute("rx", Math.Min(13, iconBox * 0.25)).Attribute("fill", isFilled ? accent.WithOpacity(isRaised ? 0.25 : 0.18).ToCss() : "none").Attribute("stroke", isRaised ? accent.WithOpacity(0.32).ToCss() : (tile.SurfaceStyle == VisualCanvasInfoTileSurfaceStyle.Outline ? accent.WithOpacity(0.38).ToCss() : "none")).EndEmptyElement().Line();
         RenderTileIcon(writer, tile.IconKind, tile.Icon, iconX, iconY, iconBox, iconFont, accent);
-        var textX = iconX + iconBox + 22;
-        var hasMiniChart = tile.MiniChartKind != VisualCanvasInfoTileMiniChartKind.None && tile.MiniChartValues.Count > 0;
-        var chartW = hasMiniChart ? Math.Min(width * 0.24, Math.Max(82, width * 0.20)) : 0;
-        var chartX = x + width - padX - chartW;
-        var chartY = y + Math.Max(24, height * 0.30);
-        var chartH = Math.Max(28, Math.Min(46, height * 0.42));
-        var hasDetail = tile.Detail.Length > 0;
-        var labelY = y + (hasDetail ? 30 : Math.Max(32, (height - 52) / 2 + 14));
-        var valueY = labelY + 28;
-        var detailY = valueY + 25;
-        var textMax = hasMiniChart ? Math.Max(24, chartX - textX - 16) : Math.Max(24, width - (textX - x) - padX);
-        writer.StartElement("text").Attribute("x", textX).Attribute("y", labelY).Attribute("fill", theme.TileLabelColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 14).Attribute("font-weight", "700").Text(FitText(tile.Label, 14, textMax, true)).EndElement().Line();
-        writer.StartElement("text").Attribute("x", textX).Attribute("y", valueY).Attribute("fill", theme.TileValueColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", height < 92 ? 21 : 22).Attribute("font-weight", "650").Text(FitText(tile.Value, height < 92 ? 21 : 22, textMax, true)).EndElement().Line();
-        if (hasDetail) writer.StartElement("text").Attribute("x", textX).Attribute("y", detailY).Attribute("fill", theme.TileDetailColor.ToCss()).Attribute("font-family", "Segoe UI, Arial, sans-serif").Attribute("font-size", 13).Text(FitText(tile.Detail, 13, textMax, false)).EndElement().Line();
+        var textX = metrics.TextX;
+        var chartW = metrics.ChartWidth;
+        var chartX = metrics.ChartX;
+        foreach (var line in VisualCanvasInfoTileTextLayout.BuildResult(tile, metrics.Y, metrics.Height, metrics.TextX, metrics.TextMax).Lines) {
+            writer.StartElement("text")
+                .Attribute("x", line.X)
+                .Attribute("y", line.Y + line.FontSize)
+                .Attribute("fill", TileTextColor(line.Role, theme).ToCss())
+                .Attribute("font-family", "Segoe UI, Arial, sans-serif")
+                .Attribute("font-size", line.FontSize)
+                .Attribute("font-weight", line.Role == VisualCanvasInfoTileTextRole.Label ? "700" : line.Role == VisualCanvasInfoTileTextRole.Value ? "650" : "500")
+                .Text(line.Text)
+                .EndElement()
+                .Line();
+        }
         if (tile.Progress.HasValue) {
             var railX = textX;
             var railY = y + height - 16;
-            var railW = hasMiniChart ? Math.Max(24, chartX - railX - 16) : Math.Max(24, width - (railX - x) - padX);
+            var railW = metrics.HasMiniChart ? Math.Max(24, chartX - railX - 16) : Math.Max(24, width - (railX - x) - padX);
             writer.StartElement("rect").Attribute("x", railX).Attribute("y", railY).Attribute("width", railW).Attribute("height", 8).Attribute("rx", 4).Attribute("fill", theme.TileProgressTrackColor.ToCss()).EndEmptyElement().Line();
             writer.StartElement("rect").Attribute("x", railX).Attribute("y", railY).Attribute("width", railW * tile.Progress.Value).Attribute("height", 8).Attribute("rx", 4).Attribute("fill", accent.ToCss()).EndEmptyElement().Line();
         }
-        if (hasMiniChart) {
-            RenderTileMiniChart(writer, tile, theme, accent, chartX, chartY, chartW, chartH);
+        if (metrics.HasMiniChart) {
+            RenderTileMiniChart(writer, tile, theme, accent, chartX, metrics.ChartY, chartW, metrics.ChartHeight);
         }
 
         writer.EndElement().Line();
@@ -443,6 +446,14 @@ public sealed class SvgVisualCanvasRenderer {
             case VisualCanvasImageFit.Stretch:
             default:
                 return "none";
+        }
+    }
+
+    private static ChartColor TileTextColor(VisualCanvasInfoTileTextRole role, VisualCanvasTheme theme) {
+        switch (role) {
+            case VisualCanvasInfoTileTextRole.Label: return theme.TileLabelColor;
+            case VisualCanvasInfoTileTextRole.Detail: return theme.TileDetailColor;
+            default: return theme.TileValueColor;
         }
     }
 

--- a/ChartForgeX/VisualCanvas/VisualCanvasInfoTileTextLayout.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasInfoTileTextLayout.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using ChartForgeX.Raster;
+
+namespace ChartForgeX.Composition;
+
+internal enum VisualCanvasInfoTileTextRole {
+    Label,
+    Value,
+    Detail
+}
+
+internal sealed class VisualCanvasInfoTileMetrics {
+    public VisualCanvasInfoTileMetrics(double x, double y, double width, double height, double padX, double iconBox, double iconX, double iconY, double textX, double textMax, bool hasMiniChart, double chartX, double chartY, double chartWidth, double chartHeight) {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+        PadX = padX;
+        IconBox = iconBox;
+        IconX = iconX;
+        IconY = iconY;
+        TextX = textX;
+        TextMax = textMax;
+        HasMiniChart = hasMiniChart;
+        ChartX = chartX;
+        ChartY = chartY;
+        ChartWidth = chartWidth;
+        ChartHeight = chartHeight;
+    }
+
+    public double X { get; }
+    public double Y { get; }
+    public double Width { get; }
+    public double Height { get; }
+    public double PadX { get; }
+    public double IconBox { get; }
+    public double IconX { get; }
+    public double IconY { get; }
+    public double TextX { get; }
+    public double TextMax { get; }
+    public bool HasMiniChart { get; }
+    public double ChartX { get; }
+    public double ChartY { get; }
+    public double ChartWidth { get; }
+    public double ChartHeight { get; }
+}
+
+internal sealed class VisualCanvasInfoTileTextLine {
+    public VisualCanvasInfoTileTextLine(VisualCanvasInfoTileTextRole role, string text, double x, double y, double fontSize, bool emphasized, bool truncated) {
+        Role = role;
+        Text = text;
+        X = x;
+        Y = y;
+        FontSize = fontSize;
+        Emphasized = emphasized;
+        Truncated = truncated;
+    }
+
+    public VisualCanvasInfoTileTextRole Role { get; }
+    public string Text { get; }
+    public double X { get; }
+    public double Y { get; }
+    public double FontSize { get; }
+    public bool Emphasized { get; }
+    public bool Truncated { get; }
+}
+
+internal sealed class VisualCanvasInfoTileTextLayoutResult {
+    public VisualCanvasInfoTileTextLayoutResult(IReadOnlyList<VisualCanvasInfoTileTextLine> lines, bool hasTruncatedText, double textWidth, double textHeight) {
+        Lines = lines;
+        HasTruncatedText = hasTruncatedText;
+        TextWidth = textWidth;
+        TextHeight = textHeight;
+    }
+
+    public IReadOnlyList<VisualCanvasInfoTileTextLine> Lines { get; }
+    public bool HasTruncatedText { get; }
+    public double TextWidth { get; }
+    public double TextHeight { get; }
+}
+
+internal static class VisualCanvasInfoTileTextLayout {
+    public static VisualCanvasInfoTileMetrics CalculateMetrics(VisualCanvasInfoTileLayer tile) {
+        var x = Math.Round(tile.X);
+        var y = Math.Round(tile.Y);
+        var width = Math.Round(tile.Width);
+        var height = Math.Round(tile.Height);
+        var padX = Math.Max(20, Math.Min(28, width * 0.06));
+        var iconBox = Math.Max(44, Math.Min(54, height - 34));
+        var iconX = x + padX;
+        var iconY = y + (height - iconBox) / 2;
+        var textX = iconX + iconBox + 22;
+        var hasMiniChart = tile.MiniChartKind != VisualCanvasInfoTileMiniChartKind.None && tile.MiniChartValues.Count > 0;
+        var chartWidth = hasMiniChart ? Math.Min(width * 0.24, Math.Max(82, width * 0.20)) : 0;
+        var chartX = x + width - padX - chartWidth;
+        var chartY = y + Math.Max(24, height * 0.30);
+        var chartHeight = Math.Max(28, Math.Min(46, height * 0.42));
+        var textMax = hasMiniChart ? Math.Max(24, chartX - textX - 16) : Math.Max(24, width - (textX - x) - padX);
+        return new VisualCanvasInfoTileMetrics(x, y, width, height, padX, iconBox, iconX, iconY, textX, textMax, hasMiniChart, chartX, chartY, chartWidth, chartHeight);
+    }
+
+    public static IReadOnlyList<VisualCanvasInfoTileTextLine> Build(VisualCanvasInfoTileLayer tile, double tileY, double tileHeight, double textX, double maxWidth) =>
+        BuildResult(tile, tileY, tileHeight, textX, maxWidth).Lines;
+
+    public static VisualCanvasInfoTileTextLayoutResult BuildForTile(VisualCanvasInfoTileLayer tile) {
+        var metrics = CalculateMetrics(tile);
+        return BuildResult(tile, metrics.Y, metrics.Height, metrics.TextX, metrics.TextMax);
+    }
+
+    public static VisualCanvasInfoTileTextLayoutResult BuildResult(VisualCanvasInfoTileLayer tile, double tileY, double tileHeight, double textX, double maxWidth) {
+        VisualCanvas.ValidateEnum(tile.TextFitPolicy, nameof(tile.TextFitPolicy));
+        var policy = tile.TextFitPolicy == VisualCanvasTextFitPolicy.Auto ? VisualCanvasTextFitPolicy.WrapThenShrink : tile.TextFitPolicy;
+        var singleLine = policy == VisualCanvasTextFitPolicy.SingleLineEllipsis || policy == VisualCanvasTextFitPolicy.ShrinkToFit;
+        var scale = 1.0;
+        var best = BuildCore(tile, tileY, tileHeight, textX, maxWidth, singleLine, scale);
+        if (policy != VisualCanvasTextFitPolicy.ShrinkToFit && policy != VisualCanvasTextFitPolicy.WrapThenShrink) return best;
+
+        for (var i = 0; i < 8 && best.HasTruncatedText; i++) {
+            scale -= 0.04;
+            if (scale < 0.72) break;
+            var next = BuildCore(tile, tileY, tileHeight, textX, maxWidth, singleLine, scale);
+            best = next;
+            if (!next.HasTruncatedText) break;
+        }
+
+        return best;
+    }
+
+    private static VisualCanvasInfoTileTextLayoutResult BuildCore(VisualCanvasInfoTileLayer tile, double tileY, double tileHeight, double textX, double maxWidth, bool singleLine, double scale) {
+        var labelFont = Math.Max(10, (tileHeight < 72 ? 12.0 : 14.0) * scale);
+        var valueFont = Math.Max(13, (tileHeight < 72 ? 17.0 : tileHeight < 92 ? 21.0 : 22.0) * scale);
+        var detailFont = Math.Max(10, (tileHeight < 72 ? 11.0 : 13.0) * scale);
+        var labelLineHeight = labelFont + 4;
+        var valueLineHeight = valueFont + 4;
+        var detailLineHeight = detailFont + 4;
+        var topPadding = Math.Max(10, Math.Min(18, tileHeight * 0.16));
+        var bottomPadding = tile.Progress.HasValue ? 30.0 : Math.Max(12, Math.Min(18, tileHeight * 0.15));
+        var availableHeight = Math.Max(valueLineHeight, tileHeight - topPadding - bottomPadding);
+        var hasDetail = tile.Detail.Length > 0;
+        var detailLineLimit = singleLine ? (hasDetail ? 1 : 0) : hasDetail ? tileHeight >= 122 ? 2 : 1 : 0;
+        var valueLineLimit = singleLine ? 1 : Math.Max(1, (int)Math.Floor((availableHeight - labelLineHeight - detailLineLimit * detailLineHeight) / valueLineHeight));
+        valueLineLimit = singleLine ? 1 : Math.Min(tileHeight >= 132 ? 3 : 2, valueLineLimit);
+        if (valueLineLimit < 1 && detailLineLimit > 0) {
+            detailLineLimit = 0;
+            valueLineLimit = 1;
+        }
+
+        var labelLines = Wrap(tile.Label, labelFont, maxWidth, true, 1);
+        var valueLines = Wrap(tile.Value, valueFont, maxWidth, true, valueLineLimit);
+        var detailLines = detailLineLimit > 0 ? Wrap(tile.Detail, detailFont, maxWidth, false, detailLineLimit) : WrapResult.Empty;
+        var totalHeight =
+            labelLines.Lines.Count * labelLineHeight +
+            valueLines.Lines.Count * valueLineHeight +
+            detailLines.Lines.Count * detailLineHeight +
+            (valueLines.Lines.Count > 0 ? 3 : 0) +
+            (detailLines.Lines.Count > 0 ? 2 : 0);
+        var y = tileY + Math.Max(topPadding, (tileHeight - bottomPadding - totalHeight) / 2);
+        var lines = new List<VisualCanvasInfoTileTextLine>(labelLines.Lines.Count + valueLines.Lines.Count + detailLines.Lines.Count);
+        foreach (var line in labelLines.Lines) {
+            lines.Add(new VisualCanvasInfoTileTextLine(VisualCanvasInfoTileTextRole.Label, line.Text, textX, y, labelFont, true, line.Truncated));
+            y += labelLineHeight;
+        }
+
+        y += 3;
+        foreach (var line in valueLines.Lines) {
+            lines.Add(new VisualCanvasInfoTileTextLine(VisualCanvasInfoTileTextRole.Value, line.Text, textX, y, valueFont, true, line.Truncated));
+            y += valueLineHeight;
+        }
+
+        if (detailLines.Lines.Count > 0) {
+            y += 2;
+            foreach (var line in detailLines.Lines) {
+                lines.Add(new VisualCanvasInfoTileTextLine(VisualCanvasInfoTileTextRole.Detail, line.Text, textX, y, detailFont, false, line.Truncated));
+                y += detailLineHeight;
+            }
+        }
+
+        var textWidth = 0.0;
+        foreach (var line in lines) {
+            var lineWidth = Measure(line.Text, line.FontSize, line.Emphasized);
+            if (lineWidth > textWidth) textWidth = lineWidth;
+        }
+
+        return new VisualCanvasInfoTileTextLayoutResult(lines, labelLines.Truncated || valueLines.Truncated || detailLines.Truncated, textWidth, totalHeight);
+    }
+
+    private static WrapResult Wrap(string value, double fontSize, double maxWidth, bool emphasized, int maxLines) {
+        if (string.IsNullOrEmpty(value) || maxLines <= 0) return WrapResult.Empty;
+        var words = value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0) return new WrapResult(new[] { new WrappedLine(string.Empty, false) }, false);
+        var lines = new List<WrappedLine>(maxLines);
+        var current = string.Empty;
+        var index = 0;
+        var truncated = false;
+        while (index < words.Length && lines.Count < maxLines) {
+            var word = words[index];
+            var candidate = current.Length == 0 ? word : current + " " + word;
+            if (Measure(candidate, fontSize, emphasized) <= maxWidth) {
+                current = candidate;
+                index++;
+                continue;
+            }
+
+            if (current.Length == 0) {
+                var fitted = FitText(word, fontSize, maxWidth, emphasized, index < words.Length - 1);
+                truncated |= fitted.Truncated || index < words.Length - 1;
+                lines.Add(new WrappedLine(fitted.Text, fitted.Truncated || index < words.Length - 1));
+                index++;
+                continue;
+            }
+
+            if (lines.Count == maxLines - 1) {
+                var remainder = current + " " + string.Join(" ", words, index, words.Length - index);
+                var fitted = FitText(remainder, fontSize, maxWidth, emphasized, true);
+                truncated = true;
+                lines.Add(new WrappedLine(fitted.Text, true));
+                return new WrapResult(lines, truncated);
+            }
+
+            lines.Add(new WrappedLine(current, false));
+            current = string.Empty;
+        }
+
+        if (current.Length > 0 && lines.Count < maxLines) {
+            var fitted = FitText(current, fontSize, maxWidth, emphasized, index < words.Length && Measure(current, fontSize, emphasized) > maxWidth);
+            truncated |= fitted.Truncated || index < words.Length;
+            lines.Add(new WrappedLine(fitted.Text, fitted.Truncated || index < words.Length));
+        } else if (index < words.Length) {
+            truncated = true;
+        }
+
+        return new WrapResult(lines, truncated);
+    }
+
+    private static FitResult FitText(string value, double fontSize, double maxWidth, bool emphasized, bool forceSuffix) {
+        if (string.IsNullOrEmpty(value)) return new FitResult(string.Empty, false);
+        const string suffix = "...";
+        if (!forceSuffix && Measure(value, fontSize, emphasized) <= maxWidth) return new FitResult(value, false);
+        if (Measure(suffix, fontSize, emphasized) > maxWidth) return new FitResult(string.Empty, true);
+        var low = 0;
+        var high = value.Length;
+        while (low < high) {
+            var mid = (low + high + 1) / 2;
+            if (Measure(value.Substring(0, mid).TrimEnd() + suffix, fontSize, emphasized) <= maxWidth) low = mid;
+            else high = mid - 1;
+        }
+
+        return new FitResult(value.Substring(0, low).TrimEnd() + suffix, true);
+    }
+
+    private static double Measure(string value, double fontSize, bool emphasized) =>
+        emphasized ? RgbaCanvas.MeasureTextEmphasizedWidth(value, fontSize, null) : RgbaCanvas.MeasureTextWidth(value, fontSize, null);
+
+    private readonly struct FitResult {
+        public FitResult(string text, bool truncated) {
+            Text = text;
+            Truncated = truncated;
+        }
+
+        public string Text { get; }
+        public bool Truncated { get; }
+    }
+
+    private readonly struct WrappedLine {
+        public WrappedLine(string text, bool truncated) {
+            Text = text;
+            Truncated = truncated;
+        }
+
+        public string Text { get; }
+        public bool Truncated { get; }
+    }
+
+    private sealed class WrapResult {
+        public static readonly WrapResult Empty = new(Array.Empty<WrappedLine>(), false);
+
+        public WrapResult(IReadOnlyList<WrappedLine> lines, bool truncated) {
+            Lines = lines;
+            Truncated = truncated;
+        }
+
+        public IReadOnlyList<WrappedLine> Lines { get; }
+        public bool Truncated { get; }
+    }
+}

--- a/ChartForgeX/VisualCanvas/VisualCanvasInfoTileTextLayout.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasInfoTileTextLayout.cs
@@ -67,15 +67,17 @@ internal sealed class VisualCanvasInfoTileTextLine {
 }
 
 internal sealed class VisualCanvasInfoTileTextLayoutResult {
-    public VisualCanvasInfoTileTextLayoutResult(IReadOnlyList<VisualCanvasInfoTileTextLine> lines, bool hasTruncatedText, double textWidth, double textHeight) {
+    public VisualCanvasInfoTileTextLayoutResult(IReadOnlyList<VisualCanvasInfoTileTextLine> lines, bool hasTruncatedText, bool hasVerticalOverflow, double textWidth, double textHeight) {
         Lines = lines;
         HasTruncatedText = hasTruncatedText;
+        HasVerticalOverflow = hasVerticalOverflow;
         TextWidth = textWidth;
         TextHeight = textHeight;
     }
 
     public IReadOnlyList<VisualCanvasInfoTileTextLine> Lines { get; }
     public bool HasTruncatedText { get; }
+    public bool HasVerticalOverflow { get; }
     public double TextWidth { get; }
     public double TextHeight { get; }
 }
@@ -113,21 +115,29 @@ internal static class VisualCanvasInfoTileTextLayout {
         var policy = tile.TextFitPolicy == VisualCanvasTextFitPolicy.Auto ? VisualCanvasTextFitPolicy.WrapThenShrink : tile.TextFitPolicy;
         var singleLine = policy == VisualCanvasTextFitPolicy.SingleLineEllipsis || policy == VisualCanvasTextFitPolicy.ShrinkToFit;
         var scale = 1.0;
-        var best = BuildCore(tile, tileY, tileHeight, textX, maxWidth, singleLine, scale);
+        var best = BuildCore(tile, tileY, tileHeight, textX, maxWidth, singleLine, scale, false);
         if (policy != VisualCanvasTextFitPolicy.ShrinkToFit && policy != VisualCanvasTextFitPolicy.WrapThenShrink) return best;
 
-        for (var i = 0; i < 8 && best.HasTruncatedText; i++) {
+        for (var i = 0; i < 8 && RequiresFitAdjustment(best); i++) {
             scale -= 0.04;
             if (scale < 0.72) break;
-            var next = BuildCore(tile, tileY, tileHeight, textX, maxWidth, singleLine, scale);
+            var next = BuildCore(tile, tileY, tileHeight, textX, maxWidth, singleLine, scale, false);
             best = next;
-            if (!next.HasTruncatedText) break;
+            if (!RequiresFitAdjustment(next)) break;
+        }
+
+        if (best.HasVerticalOverflow && tile.Detail.Length > 0) {
+            var withoutDetail = BuildCore(tile, tileY, tileHeight, textX, maxWidth, singleLine, scale, true);
+            if (withoutDetail.TextHeight < best.TextHeight || !withoutDetail.HasVerticalOverflow) best = withoutDetail;
         }
 
         return best;
     }
 
-    private static VisualCanvasInfoTileTextLayoutResult BuildCore(VisualCanvasInfoTileLayer tile, double tileY, double tileHeight, double textX, double maxWidth, bool singleLine, double scale) {
+    private static bool RequiresFitAdjustment(VisualCanvasInfoTileTextLayoutResult result) =>
+        result.HasTruncatedText || result.HasVerticalOverflow;
+
+    private static VisualCanvasInfoTileTextLayoutResult BuildCore(VisualCanvasInfoTileLayer tile, double tileY, double tileHeight, double textX, double maxWidth, bool singleLine, double scale, bool omitDetail) {
         var labelFont = Math.Max(10, (tileHeight < 72 ? 12.0 : 14.0) * scale);
         var valueFont = Math.Max(13, (tileHeight < 72 ? 17.0 : tileHeight < 92 ? 21.0 : 22.0) * scale);
         var detailFont = Math.Max(10, (tileHeight < 72 ? 11.0 : 13.0) * scale);
@@ -138,7 +148,7 @@ internal static class VisualCanvasInfoTileTextLayout {
         var bottomPadding = tile.Progress.HasValue ? 30.0 : Math.Max(12, Math.Min(18, tileHeight * 0.15));
         var availableHeight = Math.Max(valueLineHeight, tileHeight - topPadding - bottomPadding);
         var hasDetail = tile.Detail.Length > 0;
-        var detailLineLimit = singleLine ? (hasDetail ? 1 : 0) : hasDetail ? tileHeight >= 122 ? 2 : 1 : 0;
+        var detailLineLimit = omitDetail || !hasDetail ? 0 : singleLine ? 1 : tileHeight >= 122 ? 2 : 1;
         var valueLineLimit = singleLine ? 1 : Math.Max(1, (int)Math.Floor((availableHeight - labelLineHeight - detailLineLimit * detailLineHeight) / valueLineHeight));
         valueLineLimit = singleLine ? 1 : Math.Min(tileHeight >= 132 ? 3 : 2, valueLineLimit);
         if (valueLineLimit < 1 && detailLineLimit > 0) {
@@ -182,11 +192,15 @@ internal static class VisualCanvasInfoTileTextLayout {
             if (lineWidth > textWidth) textWidth = lineWidth;
         }
 
-        return new VisualCanvasInfoTileTextLayoutResult(lines, labelLines.Truncated || valueLines.Truncated || detailLines.Truncated, textWidth, totalHeight);
+        var textBottom = tileY + Math.Max(topPadding, (tileHeight - bottomPadding - totalHeight) / 2) + totalHeight;
+        var hasVerticalOverflow = textBottom > tileY + tileHeight - bottomPadding + 0.5;
+        var detailOmitted = hasDetail && detailLineLimit == 0;
+        return new VisualCanvasInfoTileTextLayoutResult(lines, labelLines.Truncated || valueLines.Truncated || detailLines.Truncated || detailOmitted, hasVerticalOverflow, textWidth, totalHeight);
     }
 
     private static WrapResult Wrap(string value, double fontSize, double maxWidth, bool emphasized, int maxLines) {
         if (string.IsNullOrEmpty(value) || maxLines <= 0) return WrapResult.Empty;
+        if (Measure(value, fontSize, emphasized) <= maxWidth) return new WrapResult(new[] { new WrappedLine(value, false) }, false);
         var words = value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
         if (words.Length == 0) return new WrapResult(new[] { new WrappedLine(string.Empty, false) }, false);
         var lines = new List<WrappedLine>(maxLines);

--- a/ChartForgeX/VisualCanvas/VisualCanvasLayoutDiagnostics.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasLayoutDiagnostics.cs
@@ -121,7 +121,7 @@ internal static class VisualCanvasLayoutAnalyzer {
                 tile.Bounds));
         }
 
-        if (layout.TextHeight > Math.Max(1, metrics.Height - 12)) {
+        if (layout.HasVerticalOverflow || layout.TextHeight > Math.Max(1, metrics.Height - 12)) {
             diagnostics.Add(new VisualCanvasLayoutDiagnostic(
                 VisualCanvasLayoutDiagnosticSeverity.Warning,
                 "InfoTileTextTooTall",

--- a/ChartForgeX/VisualCanvas/VisualCanvasLayoutDiagnostics.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasLayoutDiagnostics.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Composition;
+
+/// <summary>
+/// Severity for visual canvas layout diagnostics.
+/// </summary>
+public enum VisualCanvasLayoutDiagnosticSeverity {
+    /// <summary>The layout is valid, but the report contains useful advisory information.</summary>
+    Info,
+    /// <summary>The layout can render, but may clip, trim, or overlap important content.</summary>
+    Warning,
+    /// <summary>The layout contains invalid state that renderers should not accept.</summary>
+    Error
+}
+
+/// <summary>
+/// A single layout diagnostic produced for a visual canvas layer.
+/// </summary>
+public sealed class VisualCanvasLayoutDiagnostic {
+    internal VisualCanvasLayoutDiagnostic(VisualCanvasLayoutDiagnosticSeverity severity, string code, string message, int layerIndex, string layerType, ChartRect bounds) {
+        Severity = severity;
+        Code = code;
+        Message = message;
+        LayerIndex = layerIndex;
+        LayerType = layerType;
+        Bounds = bounds;
+    }
+
+    /// <summary>Gets the diagnostic severity.</summary>
+    public VisualCanvasLayoutDiagnosticSeverity Severity { get; }
+    /// <summary>Gets the stable diagnostic code.</summary>
+    public string Code { get; }
+    /// <summary>Gets a human-readable diagnostic message.</summary>
+    public string Message { get; }
+    /// <summary>Gets the zero-based layer index.</summary>
+    public int LayerIndex { get; }
+    /// <summary>Gets the layer type name.</summary>
+    public string LayerType { get; }
+    /// <summary>Gets the layer bounds used by the diagnostic.</summary>
+    public ChartRect Bounds { get; }
+}
+
+/// <summary>
+/// Summary of visual canvas layout diagnostics.
+/// </summary>
+public sealed class VisualCanvasLayoutReport {
+    internal VisualCanvasLayoutReport(IReadOnlyList<VisualCanvasLayoutDiagnostic> diagnostics) {
+        Diagnostics = diagnostics;
+        var hasWarnings = false;
+        var hasErrors = false;
+        foreach (var diagnostic in diagnostics) {
+            hasWarnings |= diagnostic.Severity == VisualCanvasLayoutDiagnosticSeverity.Warning;
+            hasErrors |= diagnostic.Severity == VisualCanvasLayoutDiagnosticSeverity.Error;
+        }
+
+        HasWarnings = hasWarnings;
+        HasErrors = hasErrors;
+    }
+
+    /// <summary>Gets diagnostics produced for the canvas.</summary>
+    public IReadOnlyList<VisualCanvasLayoutDiagnostic> Diagnostics { get; }
+    /// <summary>Gets whether the report contains warnings.</summary>
+    public bool HasWarnings { get; }
+    /// <summary>Gets whether the report contains errors.</summary>
+    public bool HasErrors { get; }
+    /// <summary>Gets whether the report contains no warnings or errors.</summary>
+    public bool IsClean => !HasWarnings && !HasErrors;
+}
+
+internal static class VisualCanvasLayoutAnalyzer {
+    public static VisualCanvasLayoutReport Analyze(VisualCanvas canvas) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var diagnostics = new List<VisualCanvasLayoutDiagnostic>();
+        var canvasBounds = new ChartRect(0, 0, canvas.Width, canvas.Height);
+        for (var i = 0; i < canvas.Layers.Count; i++) {
+            var layer = canvas.Layers[i];
+            var bounds = layer.Bounds;
+            if (bounds.X < 0 || bounds.Y < 0 || bounds.Right > canvasBounds.Right || bounds.Bottom > canvasBounds.Bottom) {
+                diagnostics.Add(new VisualCanvasLayoutDiagnostic(
+                    VisualCanvasLayoutDiagnosticSeverity.Warning,
+                    "LayerOutsideCanvas",
+                    "Layer bounds extend beyond the visual canvas and may be clipped.",
+                    i,
+                    layer.GetType().Name,
+                    bounds));
+            }
+
+            if (layer is VisualCanvasInfoTileLayer tile) AnalyzeInfoTile(tile, i, diagnostics);
+        }
+
+        return new VisualCanvasLayoutReport(diagnostics);
+    }
+
+    private static void AnalyzeInfoTile(VisualCanvasInfoTileLayer tile, int layerIndex, List<VisualCanvasLayoutDiagnostic> diagnostics) {
+        VisualCanvas.ValidateEnum(tile.SurfaceStyle, nameof(tile.SurfaceStyle));
+        VisualCanvas.ValidateEnum(tile.IconKind, nameof(tile.IconKind));
+        VisualCanvas.ValidateEnum(tile.MiniChartKind, nameof(tile.MiniChartKind));
+        VisualCanvas.ValidateEnum(tile.TextFitPolicy, nameof(tile.TextFitPolicy));
+        var metrics = VisualCanvasInfoTileTextLayout.CalculateMetrics(tile);
+        if (metrics.TextMax <= 28) {
+            diagnostics.Add(new VisualCanvasLayoutDiagnostic(
+                VisualCanvasLayoutDiagnosticSeverity.Warning,
+                "InfoTileTextAreaTooSmall",
+                "Information tile leaves too little horizontal space for label and value text.",
+                layerIndex,
+                nameof(VisualCanvasInfoTileLayer),
+                tile.Bounds));
+        }
+
+        var layout = VisualCanvasInfoTileTextLayout.BuildResult(tile, metrics.Y, metrics.Height, metrics.TextX, metrics.TextMax);
+        if (layout.HasTruncatedText) {
+            diagnostics.Add(new VisualCanvasLayoutDiagnostic(
+                VisualCanvasLayoutDiagnosticSeverity.Warning,
+                "InfoTileTextTrimmed",
+                "Information tile text was fitted with an ellipsis because the tile cannot contain the full label, value, or detail.",
+                layerIndex,
+                nameof(VisualCanvasInfoTileLayer),
+                tile.Bounds));
+        }
+
+        if (layout.TextHeight > Math.Max(1, metrics.Height - 12)) {
+            diagnostics.Add(new VisualCanvasLayoutDiagnostic(
+                VisualCanvasLayoutDiagnosticSeverity.Warning,
+                "InfoTileTextTooTall",
+                "Information tile text requires more vertical space than the tile makes comfortably available.",
+                layerIndex,
+                nameof(VisualCanvasInfoTileLayer),
+                tile.Bounds));
+        }
+    }
+}

--- a/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
@@ -354,6 +354,9 @@ public sealed class VisualCanvas {
     /// <summary>Resolves anchor-based placement against the full canvas.</summary>
     public ChartRect ResolvePlacement(VisualCanvasPlacement placement, double width, double height) => placement.Resolve(Width, Height, width, height);
 
+    /// <summary>Analyzes canvas layer bounds and built-in text fitting decisions without rendering.</summary>
+    public VisualCanvasLayoutReport AnalyzeLayout() => VisualCanvasLayoutAnalyzer.Analyze(this);
+
     /// <summary>Adds a plain text layer.</summary>
     public VisualCanvas AddText(double x, double y, double width, string text, double fontSize, ChartColor color, VisualCanvasTextAlignment alignment = VisualCanvasTextAlignment.Left, bool emphasized = false) =>
         AddLayer(new VisualCanvasTextLayer(x, y, width, text, fontSize, color) { Alignment = alignment, Emphasized = emphasized });
@@ -412,13 +415,13 @@ public sealed class VisualCanvas {
     }
 
     /// <summary>Adds a reusable information tile.</summary>
-    public VisualCanvas AddInfoTile(double x, double y, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text, VisualCanvasInfoTileMiniChartKind miniChartKind = VisualCanvasInfoTileMiniChartKind.None, IEnumerable<double>? miniChartValues = null, double? miniChartMaximum = null) =>
-        AddLayer(new VisualCanvasInfoTileLayer(x, y, width, height, icon, label, value) { Detail = detail ?? string.Empty, AccentOverride = accent, Progress = progress, SurfaceStyle = surfaceStyle, IconKind = iconKind }.WithMiniChart(miniChartKind, miniChartValues, miniChartMaximum));
+    public VisualCanvas AddInfoTile(double x, double y, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text, VisualCanvasInfoTileMiniChartKind miniChartKind = VisualCanvasInfoTileMiniChartKind.None, IEnumerable<double>? miniChartValues = null, double? miniChartMaximum = null, VisualCanvasTextFitPolicy textFitPolicy = VisualCanvasTextFitPolicy.Auto) =>
+        AddLayer(new VisualCanvasInfoTileLayer(x, y, width, height, icon, label, value) { Detail = detail ?? string.Empty, AccentOverride = accent, Progress = progress, SurfaceStyle = surfaceStyle, IconKind = iconKind, TextFitPolicy = textFitPolicy }.WithMiniChart(miniChartKind, miniChartValues, miniChartMaximum));
 
     /// <summary>Adds a reusable information tile using anchor-based placement.</summary>
-    public VisualCanvas AddInfoTile(VisualCanvasPlacement placement, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text, VisualCanvasInfoTileMiniChartKind miniChartKind = VisualCanvasInfoTileMiniChartKind.None, IEnumerable<double>? miniChartValues = null, double? miniChartMaximum = null) {
+    public VisualCanvas AddInfoTile(VisualCanvasPlacement placement, double width, double height, string icon, string label, string value, string? detail = null, ChartColor? accent = null, double? progress = null, VisualCanvasInfoTileSurfaceStyle surfaceStyle = VisualCanvasInfoTileSurfaceStyle.Glass, VisualCanvasInfoTileIconKind iconKind = VisualCanvasInfoTileIconKind.Text, VisualCanvasInfoTileMiniChartKind miniChartKind = VisualCanvasInfoTileMiniChartKind.None, IEnumerable<double>? miniChartValues = null, double? miniChartMaximum = null, VisualCanvasTextFitPolicy textFitPolicy = VisualCanvasTextFitPolicy.Auto) {
         var bounds = ResolvePlacement(placement, width, height);
-        return AddInfoTile(bounds.X, bounds.Y, bounds.Width, bounds.Height, icon, label, value, detail, accent, progress, surfaceStyle, iconKind, miniChartKind, miniChartValues, miniChartMaximum);
+        return AddInfoTile(bounds.X, bounds.Y, bounds.Width, bounds.Height, icon, label, value, detail, accent, progress, surfaceStyle, iconKind, miniChartKind, miniChartValues, miniChartMaximum, textFitPolicy);
     }
 
     /// <summary>Adds a central icon or logo badge.</summary>
@@ -640,6 +643,8 @@ public sealed class VisualCanvasInfoTileLayer : VisualCanvasLayer {
     public VisualCanvasInfoTileIconKind IconKind { get; set; }
     /// <summary>Gets or sets the compact chart kind rendered inside the tile.</summary>
     public VisualCanvasInfoTileMiniChartKind MiniChartKind { get; set; }
+    /// <summary>Gets or sets how label, value, and detail text should be fitted inside this tile.</summary>
+    public VisualCanvasTextFitPolicy TextFitPolicy { get; set; }
     /// <summary>Gets compact chart values rendered inside the tile.</summary>
     public IReadOnlyList<double> MiniChartValues => _miniChartValues;
     /// <summary>Gets or sets the optional compact chart maximum. When empty, the values define the scale.</summary>
@@ -673,6 +678,13 @@ public sealed class VisualCanvasInfoTileLayer : VisualCanvasLayer {
 
         MiniChartKind = _miniChartValues.Count == 0 ? VisualCanvasInfoTileMiniChartKind.None : kind;
         MiniChartMaximum = maximum;
+        return this;
+    }
+
+    /// <summary>Sets the text fit policy used by renderers for this information tile.</summary>
+    public VisualCanvasInfoTileLayer WithTextFitPolicy(VisualCanvasTextFitPolicy policy) {
+        VisualCanvas.ValidateEnum(policy, nameof(policy));
+        TextFitPolicy = policy;
         return this;
     }
 }

--- a/ChartForgeX/VisualCanvas/VisualCanvasTextFitPolicy.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasTextFitPolicy.cs
@@ -1,0 +1,17 @@
+namespace ChartForgeX.Composition;
+
+/// <summary>
+/// Controls how information tile text is fitted when the tile is narrow or short.
+/// </summary>
+public enum VisualCanvasTextFitPolicy {
+    /// <summary>Use the balanced default: wrap when possible and shrink slightly before truncating.</summary>
+    Auto,
+    /// <summary>Keep each tile text role on one line and trim with an ellipsis when needed.</summary>
+    SingleLineEllipsis,
+    /// <summary>Wrap text across the available tile lines and trim only the final overflowing line.</summary>
+    Wrap,
+    /// <summary>Prefer one-line text and reduce font sizes before trimming with an ellipsis.</summary>
+    ShrinkToFit,
+    /// <summary>Wrap text first, then reduce font sizes if the tile still cannot contain the text.</summary>
+    WrapThenShrink
+}


### PR DESCRIPTION
## Summary
- add reusable text-fit policies for visual canvas info tiles
- share info-tile metrics/layout between SVG and PNG renderers
- add `VisualCanvas.AnalyzeLayout()` diagnostics for clipped layers, trimmed tile text, and reserved progress-rail overflow
- preserve exact spacing for fitted one-line tile text and report intentionally omitted detail as trimmed
- cover resized, constrained, spaced, progress-rail, and invalid policy cases in smoke tests

## Validation
- `dotnet test .\ChartForgeX.sln -c Release --no-restore`