### PR TITLE
Add hero badge logo support

### DIFF
--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -51,6 +51,13 @@ internal static partial class SmokeTests {
         Assert(brandedBadgeSvg.Contains("preserveAspectRatio=\"xMidYMid meet\"", StringComparison.Ordinal), "VisualCanvas hero badge logos should default to contain fit for SVG output.");
         var brandedBadgePng = RasterImageDecoder.Decode(brandedBadgeCanvas.ToPng());
         Assert(CountPixels(brandedBadgePng, (r, g, b, a) => a > 240 && r > 220 && g < 80 && b < 80) > 500, "VisualCanvas hero badges should render configured logo pixels in PNG output.");
+        var rgbaOnlyBadgeSvg = VisualCanvas.Create(180, 120)
+            .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+            .AddHeroBadge(20, 20, 60, 50, string.Empty, null, null, imageRgba: badgeLogoPixels, imageSourceWidth: 2, imageSourceHeight: 2, imageFit: VisualCanvasImageFit.Tile)
+            .AddHeroBadge(100, 20, 60, 50, string.Empty, null, null, imageRgba: badgeLogoPixels, imageSourceWidth: 2, imageSourceHeight: 2, imageFit: VisualCanvasImageFit.Center)
+            .ToSvg("visual-canvas-rgba-only-badges");
+        Assert(rgbaOnlyBadgeSvg.Contains("data:image/png;base64", StringComparison.Ordinal), "VisualCanvas hero badge SVG output should synthesize image hrefs for RGBA-only logo pixels.");
+        Assert(rgbaOnlyBadgeSvg.Contains("-hero-badge-image-0", StringComparison.Ordinal) && rgbaOnlyBadgeSvg.Contains("-hero-badge-image-1", StringComparison.Ordinal), "Multiple hero badge images should use unique SVG image IDs.");
 
         var resizedTileCanvas = VisualCanvas.Create(620, 220)
             .WithBackdrop(VisualCanvasBackdropStyle.Transparent)

--- a/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualCanvasTests.cs
@@ -39,6 +39,19 @@ internal static partial class SmokeTests {
         Assert(svg.Contains("Power", StringComparison.Ordinal) && svg.Contains("BGInfo", StringComparison.Ordinal), "VisualCanvas hero title should preserve colored title runs.");
         Assert(canvas.ToPng().Length > 64, "VisualCanvas should render PNG output.");
 
+        var badgeLogoPixels = new byte[] {
+            255, 32, 32, 255, 255, 32, 32, 255,
+            255, 32, 32, 255, 255, 32, 32, 255
+        };
+        var brandedBadgeCanvas = VisualCanvas.Create(180, 120)
+            .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
+            .AddHeroBadge(40, 20, 100, 70, "LG", ChartColor.FromHex("#22A7FF"), "data:image/png;base64,AA==", badgeLogoPixels, 2, 2, VisualCanvasImageFit.Contain, imagePadding: 12);
+        var brandedBadgeSvg = brandedBadgeCanvas.ToSvg("visual-canvas-branded-badge");
+        Assert(brandedBadgeSvg.Contains("data:image/png;base64", StringComparison.Ordinal), "VisualCanvas hero badges should embed configured logo images in SVG output.");
+        Assert(brandedBadgeSvg.Contains("preserveAspectRatio=\"xMidYMid meet\"", StringComparison.Ordinal), "VisualCanvas hero badge logos should default to contain fit for SVG output.");
+        var brandedBadgePng = RasterImageDecoder.Decode(brandedBadgeCanvas.ToPng());
+        Assert(CountPixels(brandedBadgePng, (r, g, b, a) => a > 240 && r > 220 && g < 80 && b < 80) > 500, "VisualCanvas hero badges should render configured logo pixels in PNG output.");
+
         var resizedTileCanvas = VisualCanvas.Create(620, 220)
             .WithBackdrop(VisualCanvasBackdropStyle.Transparent)
             .AddInfoTile(24, 24, 520, 150, "OS", "OPERATING SYSTEM", "Windows 11 Enterprise Intune compliance", "cross-site policy drift", surfaceStyle: VisualCanvasInfoTileSurfaceStyle.Raised, iconKind: VisualCanvasInfoTileIconKind.OperatingSystem);
@@ -261,6 +274,15 @@ internal static partial class SmokeTests {
     }
 
     private static bool IsClose(double actual, double expected) => Math.Abs(actual - expected) < 0.001;
+
+    private static int CountPixels(RgbaImage image, Func<byte, byte, byte, byte, bool> predicate) {
+        var count = 0;
+        for (var i = 0; i < image.Pixels.Length; i += 4) {
+            if (predicate(image.Pixels[i], image.Pixels[i + 1], image.Pixels[i + 2], image.Pixels[i + 3])) count++;
+        }
+
+        return count;
+    }
 
     private static byte[] WithExifOrientation(byte[] jpeg, ushort orientation) {
         var segment = new byte[] {

--- a/ChartForgeX/ChartExtensions.cs
+++ b/ChartForgeX/ChartExtensions.cs
@@ -530,6 +530,25 @@ public static partial class ChartExtensions {
     }
 
     /// <summary>
+    /// Decodes an image file and adds it as the content of a hero badge.
+    /// </summary>
+    public static VisualCanvas AddHeroBadgeImageFile(this VisualCanvas canvas, double x, double y, double width, double height, string path, string symbol = "", ChartColor? accent = null, VisualCanvasImageFit fit = VisualCanvasImageFit.Contain, double padding = 10, double opacity = 1) {
+        if (path == null) throw new ArgumentNullException(nameof(path));
+        var data = File.ReadAllBytes(path);
+        var image = RasterImageDecoder.Decode(data);
+        return canvas.AddHeroBadge(x, y, width, height, symbol, accent, EmbeddedRasterDataUri(data, image, path), image.Pixels, image.Width, image.Height, fit, padding, opacity);
+    }
+
+    /// <summary>
+    /// Decodes an image file and adds it as the content of a hero badge using anchor-based placement.
+    /// </summary>
+    public static VisualCanvas AddHeroBadgeImageFile(this VisualCanvas canvas, VisualCanvasPlacement placement, double width, double height, string path, string symbol = "", ChartColor? accent = null, VisualCanvasImageFit fit = VisualCanvasImageFit.Contain, double padding = 10, double opacity = 1) {
+        if (canvas == null) throw new ArgumentNullException(nameof(canvas));
+        var bounds = canvas.ResolvePlacement(placement, width, height);
+        return canvas.AddHeroBadgeImageFile(bounds.X, bounds.Y, bounds.Width, bounds.Height, path, symbol, accent, fit, padding, opacity);
+    }
+
+    /// <summary>
     /// Adds a rendered chart layer to a visual canvas.
     /// </summary>
     public static VisualCanvas AddChart(this VisualCanvas canvas, double x, double y, double width, double height, Chart chart, VisualCanvasImageFit fit = VisualCanvasImageFit.Stretch, double opacity = 1) {

--- a/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/PngVisualCanvasRenderer.cs
@@ -334,11 +334,26 @@ public sealed class PngVisualCanvasRenderer {
     }
 
     private static void DrawHeroBadge(RgbaCanvas canvas, VisualCanvasHeroBadgeLayer badge, VisualCanvasTheme theme) {
+        VisualCanvas.ValidateEnum(badge.ImageFit, nameof(badge.ImageFit));
         var radius = Math.Min(22, badge.Height * 0.20);
         canvas.FillRoundedRect(badge.X - 6, badge.Y - 6, badge.Width + 12, badge.Height + 12, radius + 4, theme.HeroBadgeGlowColor);
         canvas.FillRoundedRectVerticalGradient(badge.X, badge.Y, badge.Width, badge.Height, radius, theme.HeroBadgeTop, theme.HeroBadgeBottom);
         var accent = badge.AccentOverride ?? theme.SecondaryAccent;
         canvas.StrokeRoundedRect(badge.X, badge.Y, badge.Width, badge.Height, radius, accent, 2.4);
+        if (badge.ImageRgba != null && badge.ImageSourceWidth > 0 && badge.ImageSourceHeight > 0) {
+            var padding = Math.Max(0, Math.Min(Math.Min(badge.ImagePadding, badge.Width / 2 - 1), badge.Height / 2 - 1));
+            var image = new VisualCanvasImageLayer(badge.X + padding, badge.Y + padding, Math.Max(1, badge.Width - padding * 2), Math.Max(1, badge.Height - padding * 2)) {
+                Rgba = badge.ImageRgba,
+                SourceWidth = badge.ImageSourceWidth,
+                SourceHeight = badge.ImageSourceHeight,
+                Fit = badge.ImageFit,
+                Opacity = badge.ImageOpacity
+            };
+            var rgba = image.Opacity >= 0.999 ? image.Rgba : ApplyOpacity(image.Rgba, image.Opacity);
+            DrawFittedImage(canvas, image, rgba);
+            return;
+        }
+
         var fontSize = Math.Max(24, badge.Height * 0.42);
         DrawText(canvas, badge.X, badge.Y + badge.Height / 2 - fontSize * 0.40, badge.Width, badge.Symbol, fontSize, theme.HeroBadgeTextColor, VisualCanvasTextAlignment.Center, true);
     }

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.Text;
 using System.Threading;
+using ChartForgeX.Core;
 using ChartForgeX.Primitives;
 using ChartForgeX.Raster;
 using ChartForgeX.Svg;
@@ -86,7 +87,7 @@ public sealed class SvgVisualCanvasRenderer {
         } else if (layer is VisualCanvasInfoTileLayer tile) {
             RenderInfoTile(writer, tile, id, theme);
         } else if (layer is VisualCanvasHeroBadgeLayer badge) {
-            RenderHeroBadge(writer, badge, id, theme);
+            RenderHeroBadge(writer, badge, id, theme, layerIndex);
         } else if (layer is VisualCanvasImageLayer image) {
             RenderImage(writer, image, id, layerIndex, theme);
         } else if (layer is VisualCanvasFeatureStripLayer strip) {
@@ -388,27 +389,35 @@ public sealed class SvgVisualCanvasRenderer {
         writer.EndElement().Line();
     }
 
-    private static void RenderHeroBadge(SvgMarkupWriter writer, VisualCanvasHeroBadgeLayer badge, string id, VisualCanvasTheme theme) {
+    private static void RenderHeroBadge(SvgMarkupWriter writer, VisualCanvasHeroBadgeLayer badge, string id, VisualCanvasTheme theme, int layerIndex) {
         VisualCanvas.ValidateEnum(badge.ImageFit, nameof(badge.ImageFit));
         var accent = badge.AccentOverride ?? theme.SecondaryAccent;
         writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-hero-badge").EndStartElement().Line();
         writer.StartElement("rect").Attribute("x", badge.X).Attribute("y", badge.Y).Attribute("width", badge.Width).Attribute("height", badge.Height).Attribute("rx", Math.Min(22, badge.Height * 0.20)).Attribute("fill", "url(#" + id + "-hero-badge)").Attribute("stroke", accent.ToCss()).Attribute("stroke-width", 2.4).Attribute("filter", "url(#" + id + "-soft-glow)").EndEmptyElement().Line();
-        if (badge.ImageHref.Length > 0) {
+        var href = ResolveBadgeImageHref(badge);
+        if (href.Length > 0) {
             var padding = Math.Max(0, Math.Min(Math.Min(badge.ImagePadding, badge.Width / 2 - 1), badge.Height / 2 - 1));
             var image = new VisualCanvasImageLayer(badge.X + padding, badge.Y + padding, Math.Max(1, badge.Width - padding * 2), Math.Max(1, badge.Height - padding * 2)) {
-                Href = badge.ImageHref,
+                Href = href,
                 SourceWidth = badge.ImageSourceWidth,
                 SourceHeight = badge.ImageSourceHeight,
                 Fit = badge.ImageFit,
                 Opacity = badge.ImageOpacity
             };
-            RenderImage(writer, image, id + "-hero-badge", 0, theme);
+            RenderImage(writer, image, id + "-hero-badge", layerIndex, theme);
             writer.EndElement().Line();
             return;
         }
 
         writer.StartElement("text").Attribute("x", badge.X + badge.Width / 2).Attribute("y", badge.Y + badge.Height / 2 + badge.Height * 0.17).Attribute("text-anchor", "middle").Attribute("fill", theme.HeroBadgeTextColor.ToCss()).Attribute("font-family", "Cascadia Mono, Consolas, monospace").Attribute("font-size", Math.Max(24, badge.Height * 0.42)).Attribute("font-weight", "850").Text(badge.Symbol).EndElement().Line();
         writer.EndElement().Line();
+    }
+
+    private static string ResolveBadgeImageHref(VisualCanvasHeroBadgeLayer badge) {
+        if (badge.ImageHref.Length > 0) return badge.ImageHref;
+        if (badge.ImageRgba == null || badge.ImageSourceWidth <= 0 || badge.ImageSourceHeight <= 0) return string.Empty;
+        var png = RasterImageEncoder.Encode(new RgbaImage(badge.ImageSourceWidth, badge.ImageSourceHeight, badge.ImageRgba), RasterImageFormat.Png);
+        return "data:image/png;base64," + Convert.ToBase64String(png);
     }
 
     private static void RenderImage(SvgMarkupWriter writer, VisualCanvasImageLayer image, string id, int layerIndex, VisualCanvasTheme theme) {

--- a/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
+++ b/ChartForgeX/VisualCanvas/SvgVisualCanvasRenderer.cs
@@ -389,9 +389,24 @@ public sealed class SvgVisualCanvasRenderer {
     }
 
     private static void RenderHeroBadge(SvgMarkupWriter writer, VisualCanvasHeroBadgeLayer badge, string id, VisualCanvasTheme theme) {
+        VisualCanvas.ValidateEnum(badge.ImageFit, nameof(badge.ImageFit));
         var accent = badge.AccentOverride ?? theme.SecondaryAccent;
         writer.StartElement("g").Attribute("data-cfx-role", "visual-canvas-hero-badge").EndStartElement().Line();
         writer.StartElement("rect").Attribute("x", badge.X).Attribute("y", badge.Y).Attribute("width", badge.Width).Attribute("height", badge.Height).Attribute("rx", Math.Min(22, badge.Height * 0.20)).Attribute("fill", "url(#" + id + "-hero-badge)").Attribute("stroke", accent.ToCss()).Attribute("stroke-width", 2.4).Attribute("filter", "url(#" + id + "-soft-glow)").EndEmptyElement().Line();
+        if (badge.ImageHref.Length > 0) {
+            var padding = Math.Max(0, Math.Min(Math.Min(badge.ImagePadding, badge.Width / 2 - 1), badge.Height / 2 - 1));
+            var image = new VisualCanvasImageLayer(badge.X + padding, badge.Y + padding, Math.Max(1, badge.Width - padding * 2), Math.Max(1, badge.Height - padding * 2)) {
+                Href = badge.ImageHref,
+                SourceWidth = badge.ImageSourceWidth,
+                SourceHeight = badge.ImageSourceHeight,
+                Fit = badge.ImageFit,
+                Opacity = badge.ImageOpacity
+            };
+            RenderImage(writer, image, id + "-hero-badge", 0, theme);
+            writer.EndElement().Line();
+            return;
+        }
+
         writer.StartElement("text").Attribute("x", badge.X + badge.Width / 2).Attribute("y", badge.Y + badge.Height / 2 + badge.Height * 0.17).Attribute("text-anchor", "middle").Attribute("fill", theme.HeroBadgeTextColor.ToCss()).Attribute("font-family", "Cascadia Mono, Consolas, monospace").Attribute("font-size", Math.Max(24, badge.Height * 0.42)).Attribute("font-weight", "850").Text(badge.Symbol).EndElement().Line();
         writer.EndElement().Line();
     }

--- a/ChartForgeX/VisualCanvas/VisualCanvasHeroBadgeLayer.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasHeroBadgeLayer.cs
@@ -1,0 +1,57 @@
+using System;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Composition;
+
+/// <summary>Central logo or icon badge layer.</summary>
+public sealed class VisualCanvasHeroBadgeLayer : VisualCanvasLayer {
+    private string _symbol;
+    private string _imageHref = string.Empty;
+    private double _imagePadding = 10;
+    private double _imageOpacity = 1;
+
+    /// <summary>Initializes a hero badge layer.</summary>
+    /// <param name="x">The badge X coordinate.</param>
+    /// <param name="y">The badge Y coordinate.</param>
+    /// <param name="width">The badge width.</param>
+    /// <param name="height">The badge height.</param>
+    /// <param name="symbol">The badge symbol.</param>
+    public VisualCanvasHeroBadgeLayer(double x, double y, double width, double height, string symbol) : base(x, y, width, height) {
+        _symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
+    }
+
+    /// <summary>Gets or sets the badge symbol.</summary>
+    public string Symbol { get => _symbol; set => _symbol = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets the badge accent color.</summary>
+    public ChartColor Accent { get => AccentOverride ?? ChartColor.FromHex("#22A7FF"); set => AccentOverride = value; }
+    /// <summary>Gets or sets an explicit badge accent color. When empty, renderers use the current theme secondary accent.</summary>
+    public ChartColor? AccentOverride { get; set; }
+    /// <summary>Gets or sets an SVG-compatible image reference for the badge logo.</summary>
+    public string ImageHref { get => _imageHref; set => _imageHref = value ?? throw new ArgumentNullException(nameof(value)); }
+    /// <summary>Gets or sets optional source RGBA pixels for PNG output.</summary>
+    public byte[]? ImageRgba { get; set; }
+    /// <summary>Gets or sets the source bitmap width for PNG output.</summary>
+    public int ImageSourceWidth { get; set; }
+    /// <summary>Gets or sets the source bitmap height for PNG output.</summary>
+    public int ImageSourceHeight { get; set; }
+    /// <summary>Gets or sets how the badge image is placed inside the badge.</summary>
+    public VisualCanvasImageFit ImageFit { get; set; } = VisualCanvasImageFit.Contain;
+    /// <summary>Gets or sets padding between the badge shell and image content.</summary>
+    public double ImagePadding {
+        get => _imagePadding;
+        set {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value < 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Hero badge image padding must be finite and greater than or equal to zero.");
+            _imagePadding = value;
+        }
+    }
+    /// <summary>Gets or sets badge image opacity from zero to one.</summary>
+    public double ImageOpacity {
+        get => _imageOpacity;
+        set {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value < 0 || value > 1) throw new ArgumentOutOfRangeException(nameof(value), value, "Hero badge image opacity must be between zero and one.");
+            _imageOpacity = value;
+        }
+    }
+    /// <summary>Gets whether the badge has image content for at least one renderer.</summary>
+    public bool HasImage => ImageHref.Length > 0 || ImageRgba != null;
+}

--- a/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
@@ -425,7 +425,11 @@ public sealed class VisualCanvas {
     }
 
     /// <summary>Adds a central icon or logo badge.</summary>
-    public VisualCanvas AddHeroBadge(double x, double y, double width, double height, string symbol, ChartColor? accent = null, string? imageHref = null, byte[]? imageRgba = null, int imageSourceWidth = 0, int imageSourceHeight = 0, VisualCanvasImageFit imageFit = VisualCanvasImageFit.Contain, double imagePadding = 10, double imageOpacity = 1) {
+    public VisualCanvas AddHeroBadge(double x, double y, double width, double height, string symbol, ChartColor? accent = null) =>
+        AddHeroBadge(x, y, width, height, symbol, accent, null, null, 0, 0, VisualCanvasImageFit.Contain, 10, 1);
+
+    /// <summary>Adds a central icon or logo badge with optional image content.</summary>
+    public VisualCanvas AddHeroBadge(double x, double y, double width, double height, string symbol, ChartColor? accent, string? imageHref, byte[]? imageRgba = null, int imageSourceWidth = 0, int imageSourceHeight = 0, VisualCanvasImageFit imageFit = VisualCanvasImageFit.Contain, double imagePadding = 10, double imageOpacity = 1) {
         ValidateEnum(imageFit, nameof(imageFit));
         if (imageRgba != null && (imageSourceWidth <= 0 || imageSourceHeight <= 0)) throw new ArgumentOutOfRangeException(nameof(imageSourceWidth), "Hero badge image layers require positive imageSourceWidth and imageSourceHeight.");
         return AddLayer(new VisualCanvasHeroBadgeLayer(x, y, width, height, symbol) {
@@ -441,7 +445,13 @@ public sealed class VisualCanvas {
     }
 
     /// <summary>Adds a central icon or logo badge using anchor-based placement.</summary>
-    public VisualCanvas AddHeroBadge(VisualCanvasPlacement placement, double width, double height, string symbol, ChartColor? accent = null, string? imageHref = null, byte[]? imageRgba = null, int imageSourceWidth = 0, int imageSourceHeight = 0, VisualCanvasImageFit imageFit = VisualCanvasImageFit.Contain, double imagePadding = 10, double imageOpacity = 1) {
+    public VisualCanvas AddHeroBadge(VisualCanvasPlacement placement, double width, double height, string symbol, ChartColor? accent = null) {
+        var bounds = ResolvePlacement(placement, width, height);
+        return AddHeroBadge(bounds.X, bounds.Y, bounds.Width, bounds.Height, symbol, accent);
+    }
+
+    /// <summary>Adds a central icon or logo badge with optional image content using anchor-based placement.</summary>
+    public VisualCanvas AddHeroBadge(VisualCanvasPlacement placement, double width, double height, string symbol, ChartColor? accent, string? imageHref, byte[]? imageRgba = null, int imageSourceWidth = 0, int imageSourceHeight = 0, VisualCanvasImageFit imageFit = VisualCanvasImageFit.Contain, double imagePadding = 10, double imageOpacity = 1) {
         var bounds = ResolvePlacement(placement, width, height);
         return AddHeroBadge(bounds.X, bounds.Y, bounds.Width, bounds.Height, symbol, accent, imageHref, imageRgba, imageSourceWidth, imageSourceHeight, imageFit, imagePadding, imageOpacity);
     }

--- a/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
+++ b/ChartForgeX/VisualCanvas/VisualCanvasModels.cs
@@ -425,13 +425,25 @@ public sealed class VisualCanvas {
     }
 
     /// <summary>Adds a central icon or logo badge.</summary>
-    public VisualCanvas AddHeroBadge(double x, double y, double width, double height, string symbol, ChartColor? accent = null) =>
-        AddLayer(new VisualCanvasHeroBadgeLayer(x, y, width, height, symbol) { AccentOverride = accent });
+    public VisualCanvas AddHeroBadge(double x, double y, double width, double height, string symbol, ChartColor? accent = null, string? imageHref = null, byte[]? imageRgba = null, int imageSourceWidth = 0, int imageSourceHeight = 0, VisualCanvasImageFit imageFit = VisualCanvasImageFit.Contain, double imagePadding = 10, double imageOpacity = 1) {
+        ValidateEnum(imageFit, nameof(imageFit));
+        if (imageRgba != null && (imageSourceWidth <= 0 || imageSourceHeight <= 0)) throw new ArgumentOutOfRangeException(nameof(imageSourceWidth), "Hero badge image layers require positive imageSourceWidth and imageSourceHeight.");
+        return AddLayer(new VisualCanvasHeroBadgeLayer(x, y, width, height, symbol) {
+            AccentOverride = accent,
+            ImageHref = imageHref ?? string.Empty,
+            ImageRgba = imageRgba,
+            ImageSourceWidth = imageSourceWidth,
+            ImageSourceHeight = imageSourceHeight,
+            ImageFit = imageFit,
+            ImagePadding = imagePadding,
+            ImageOpacity = imageOpacity
+        });
+    }
 
     /// <summary>Adds a central icon or logo badge using anchor-based placement.</summary>
-    public VisualCanvas AddHeroBadge(VisualCanvasPlacement placement, double width, double height, string symbol, ChartColor? accent = null) {
+    public VisualCanvas AddHeroBadge(VisualCanvasPlacement placement, double width, double height, string symbol, ChartColor? accent = null, string? imageHref = null, byte[]? imageRgba = null, int imageSourceWidth = 0, int imageSourceHeight = 0, VisualCanvasImageFit imageFit = VisualCanvasImageFit.Contain, double imagePadding = 10, double imageOpacity = 1) {
         var bounds = ResolvePlacement(placement, width, height);
-        return AddHeroBadge(bounds.X, bounds.Y, bounds.Width, bounds.Height, symbol, accent);
+        return AddHeroBadge(bounds.X, bounds.Y, bounds.Width, bounds.Height, symbol, accent, imageHref, imageRgba, imageSourceWidth, imageSourceHeight, imageFit, imagePadding, imageOpacity);
     }
 
     /// <summary>Adds an image layer. SVG output uses <paramref name="href"/>; PNG output uses <paramref name="rgba"/> when supplied.</summary>
@@ -687,28 +699,6 @@ public sealed class VisualCanvasInfoTileLayer : VisualCanvasLayer {
         TextFitPolicy = policy;
         return this;
     }
-}
-
-/// <summary>Central logo or icon badge layer.</summary>
-public sealed class VisualCanvasHeroBadgeLayer : VisualCanvasLayer {
-    private string _symbol;
-
-    /// <summary>Initializes a hero badge layer.</summary>
-    /// <param name="x">The badge X coordinate.</param>
-    /// <param name="y">The badge Y coordinate.</param>
-    /// <param name="width">The badge width.</param>
-    /// <param name="height">The badge height.</param>
-    /// <param name="symbol">The badge symbol.</param>
-    public VisualCanvasHeroBadgeLayer(double x, double y, double width, double height, string symbol) : base(x, y, width, height) {
-        _symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
-    }
-
-    /// <summary>Gets or sets the badge symbol.</summary>
-    public string Symbol { get => _symbol; set => _symbol = value ?? throw new ArgumentNullException(nameof(value)); }
-    /// <summary>Gets or sets the badge accent color.</summary>
-    public ChartColor Accent { get => AccentOverride ?? ChartColor.FromHex("#22A7FF"); set => AccentOverride = value; }
-    /// <summary>Gets or sets an explicit badge accent color. When empty, renderers use the current theme secondary accent.</summary>
-    public ChartColor? AccentOverride { get; set; }
 }
 
 /// <summary>Image layer for host-provided bitmap or SVG-compatible image references.</summary>

--- a/docs/visual-canvas.md
+++ b/docs/visual-canvas.md
@@ -113,7 +113,19 @@ var canvas = background
 canvas.SavePng("wallpaper-with-info.png");
 ```
 
-`AddImageFile(...)` and `AddImageBytes(...)` are available when an image should be placed into an existing canvas region. The dependency-free decoder supports baseline/progressive JPEG, PNG, BMP, PPM, and uncompressed RGB TIFF. Hosts that need unsupported image variants can decode them before handing RGBA pixels to `AddRasterImage(...)`.
+`AddImageFile(...)`, `AddImageBytes(...)`, and `AddHeroBadgeImageFile(...)` are available when an image should be placed into an existing canvas region or inside the central hero badge. The dependency-free decoder supports baseline/progressive JPEG, PNG, BMP, PPM, and uncompressed RGB TIFF. Hosts that need unsupported image variants can decode them before handing RGBA pixels to `AddRasterImage(...)` or `AddHeroBadge(...)`.
+
+```csharp
+var brandedCanvas = VisualCanvas.CreateSocialPreview()
+    .AddHeroBadgeImageFile(
+        538,
+        157,
+        124,
+        88,
+        "logo.png",
+        fit: VisualCanvasImageFit.Contain,
+        padding: 12);
+```
 
 For lower-level wallpaper and report generation where the host wants to work directly with RGBA pixels, use `ImageComposition`. It keeps the same anchor and fit model as `VisualCanvas`, but focuses on image-engine operations: load or create a background, alpha-blend overlays, draw rectangle outlines, draw text, place ChartForgeX layers, and save by extension without `System.Drawing`.
 


### PR DESCRIPTION
## Summary
- add image-capable hero badges to VisualCanvas for SVG and PNG output
- add `AddHeroBadgeImageFile(...)` convenience overloads with fit, padding, and opacity controls
- keep existing hero badge overloads binary-compatible while adding image-capable overloads
- document logo badge usage and cover SVG/PNG rendering with smoke tests, including RGBA-only SVG parity and unique SVG clip/pattern IDs

## Usage
```csharp
VisualCanvas.CreateSocialPreview()
    .AddHeroBadgeImageFile(538, 157, 124, 88, "logo.png", fit: VisualCanvasImageFit.Contain, padding: 12);
```

## Validation
- `dotnet test ChartForgeX.Tests\ChartForgeX.Tests.csproj --configuration Release`

## Related
EvotecIT/PowerBGInfo#55 uses this same logo-in-badge experience in PowerBGInfo. The PowerBGInfo PR is package-build compatible on its own, while this PR makes the capability reusable for other ChartForgeX canvas consumers.