### PR TITLE
Parse host-discovered visual fences directly

### DIFF
--- a/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
+++ b/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Interactivity.Html</PackageId>
-    <Version>1.0.0</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Self-contained HTML, SVG, and graph explorer interaction adapter for ChartForgeX charts and graph scenes.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
+++ b/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Interactivity</PackageId>
-    <Version>1.0.0</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Host-neutral interaction contracts for ChartForgeX chart renderers and adapters.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Markup.Mermaid/ChartForgeX.Markup.Mermaid.csproj
+++ b/ChartForgeX.Markup.Mermaid/ChartForgeX.Markup.Mermaid.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Markup.Mermaid</PackageId>
-    <Version>1.0.0</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Mermaid fenced-block adapter for ChartForgeX markup visual artifact pipelines.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Markup.Mermaid/MermaidVisualMarkupParser.cs
+++ b/ChartForgeX.Markup.Mermaid/MermaidVisualMarkupParser.cs
@@ -36,6 +36,16 @@ public sealed class MermaidVisualMarkupParser {
     }
 
     /// <summary>
+    /// Parses a visual scan result into ChartForgeX visual artifacts, including Mermaid, while preserving scanner diagnostics.
+    /// </summary>
+    /// <param name="scan">A scan result produced by ChartForgeX or a host-discovered fence projection.</param>
+    /// <returns>The visual markup parse result.</returns>
+    public VisualMarkupParseResult Parse(VisualMarkupScanResult scan) {
+        if (scan == null) throw new ArgumentNullException(nameof(scan));
+        return _parser.Parse(scan);
+    }
+
+    /// <summary>
     /// Parses visual blocks that were already discovered by another Markdown parser into ChartForgeX visual artifacts.
     /// </summary>
     /// <param name="blocks">Pre-scanned visual blocks, for example blocks discovered by a host Markdown pipeline.</param>

--- a/ChartForgeX.Markup/ChartForgeX.Markup.csproj
+++ b/ChartForgeX.Markup/ChartForgeX.Markup.csproj
@@ -17,9 +17,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Markup</PackageId>
-    <Version>1.0.0</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Markdown-friendly ChartForgeX markup parser and code emitter for charts and topology diagrams.</Description>
+    <PackageReleaseNotes>Adds direct validation and projection for visual fences discovered by another Markdown parser.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>charts;markdown;markup;svg;png;html;topology;reports;dashboard;zero-dependency;aot;nativeaot;trimming</PackageTags>

--- a/ChartForgeX.Markup/MarkupTopologyParser.cs
+++ b/ChartForgeX.Markup/MarkupTopologyParser.cs
@@ -188,8 +188,8 @@ public sealed class MarkupTopologyParser {
                 Subtitle = Optional(row, "subtitle"),
                 Color = Optional(row, "color"),
                 Icon = Optional(row, "icon"),
-                Width = Number(row, "width", 260),
-                Height = Number(row, "height", 160)
+                Width = NonNegativeNumber(row, "width", 260),
+                Height = NonNegativeNumber(row, "height", 160)
             });
             if (section == "nodes") document.Nodes.Add(new MarkupTopologyNode {
                 Id = Required(row, "id"),
@@ -203,8 +203,8 @@ public sealed class MarkupTopologyParser {
                 Badge = Optional(row, "badge"),
                 Color = Optional(row, "color"),
                 Display = row.TryGetValue("display", out var display) && !string.IsNullOrWhiteSpace(display) ? ParseEnum<TopologyNodeDisplayMode>(display) : null,
-                Width = Number(row, "width", 120),
-                Height = Number(row, "height", 64)
+                Width = PositiveNumber(row, "width", 120),
+                Height = PositiveNumber(row, "height", 64)
             });
             if (section == "edges") AddEdge(document, Value(row, "id", string.Empty), Required(row, "from"), Required(row, "to"), Optional(row, "label"), row);
         } catch (Exception ex) when (ex is ArgumentException || ex is FormatException || ex is InvalidOperationException) {
@@ -239,8 +239,8 @@ public sealed class MarkupTopologyParser {
             Subtitle = Optional(attributes, "subtitle"),
             Color = Optional(attributes, "color"),
             Icon = Optional(attributes, "icon"),
-            Width = Number(attributes, "width", 260),
-            Height = Number(attributes, "height", 160)
+            Width = NonNegativeNumber(attributes, "width", 260),
+            Height = NonNegativeNumber(attributes, "height", 160)
         });
     }
 
@@ -259,8 +259,8 @@ public sealed class MarkupTopologyParser {
             Badge = Optional(attributes, "badge"),
             Color = Optional(attributes, "color"),
             Display = attributes.TryGetValue("display", out var display) ? ParseEnum<TopologyNodeDisplayMode>(display) : null,
-            Width = Number(attributes, "width", 120),
-            Height = Number(attributes, "height", 64)
+            Width = PositiveNumber(attributes, "width", 120),
+            Height = PositiveNumber(attributes, "height", 64)
         });
     }
 
@@ -529,12 +529,14 @@ public sealed class MarkupTopologyParser {
     private static string? Optional(Dictionary<string, string> row, string key) => row.TryGetValue(NormalizeKey(key), out var value) && !string.IsNullOrWhiteSpace(value) ? value : null;
     private static string Value(Dictionary<string, string> row, string key, string fallback) => row.TryGetValue(NormalizeKey(key), out var value) && !string.IsNullOrWhiteSpace(value) ? value : fallback;
     private static string Required(Dictionary<string, string> row, string key) => Optional(row, key) ?? throw new ArgumentException("Missing required '" + key + "' column.");
-    private static double Number(Dictionary<string, string> row, string key, double fallback) {
+    private static double PositiveNumber(Dictionary<string, string> row, string key, double fallback) => Number(row, key, fallback, allowZero: false);
+    private static double NonNegativeNumber(Dictionary<string, string> row, string key, double fallback) => Number(row, key, fallback, allowZero: true);
+    private static double Number(Dictionary<string, string> row, string key, double fallback, bool allowZero) {
         var number = row.TryGetValue(NormalizeKey(key), out var value) && !string.IsNullOrWhiteSpace(value)
             ? double.Parse(value, CultureInfo.InvariantCulture)
             : fallback;
-        if (number <= 0 || double.IsNaN(number) || double.IsInfinity(number)) {
-            throw new ArgumentException(key + " must be a positive finite number.");
+        if (double.IsNaN(number) || double.IsInfinity(number) || (allowZero ? number < 0 : number <= 0)) {
+            throw new ArgumentException(key + (allowZero ? " must be a non-negative finite number." : " must be a positive finite number."));
         }
 
         return number;

--- a/ChartForgeX.Markup/MarkupTopologyParser.cs
+++ b/ChartForgeX.Markup/MarkupTopologyParser.cs
@@ -529,7 +529,16 @@ public sealed class MarkupTopologyParser {
     private static string? Optional(Dictionary<string, string> row, string key) => row.TryGetValue(NormalizeKey(key), out var value) && !string.IsNullOrWhiteSpace(value) ? value : null;
     private static string Value(Dictionary<string, string> row, string key, string fallback) => row.TryGetValue(NormalizeKey(key), out var value) && !string.IsNullOrWhiteSpace(value) ? value : fallback;
     private static string Required(Dictionary<string, string> row, string key) => Optional(row, key) ?? throw new ArgumentException("Missing required '" + key + "' column.");
-    private static double Number(Dictionary<string, string> row, string key, double fallback) => row.TryGetValue(NormalizeKey(key), out var value) && !string.IsNullOrWhiteSpace(value) ? double.Parse(value, CultureInfo.InvariantCulture) : fallback;
+    private static double Number(Dictionary<string, string> row, string key, double fallback) {
+        var number = row.TryGetValue(NormalizeKey(key), out var value) && !string.IsNullOrWhiteSpace(value)
+            ? double.Parse(value, CultureInfo.InvariantCulture)
+            : fallback;
+        if (number <= 0 || double.IsNaN(number) || double.IsInfinity(number)) {
+            throw new ArgumentException(key + " must be a positive finite number.");
+        }
+
+        return number;
+    }
     private static void Add<TDocument>(MarkupParseResult<TDocument> result, int line, MarkupDiagnosticSeverity severity, string message) where TDocument : class => result.Diagnostics.Add(new MarkupDiagnostic { Line = line, Severity = severity, Message = message });
 
     private static List<string> SplitTableCells(string line) {

--- a/ChartForgeX.Markup/VisualMarkupParser.cs
+++ b/ChartForgeX.Markup/VisualMarkupParser.cs
@@ -40,7 +40,16 @@ public sealed class VisualMarkupParser {
     /// <returns>The visual markup parse result.</returns>
     public VisualMarkupParseResult Parse(string text) {
         if (text == null) throw new ArgumentNullException(nameof(text));
-        var scan = VisualMarkupScanner.Scan(text);
+        return Parse(VisualMarkupScanner.Scan(text));
+    }
+
+    /// <summary>
+    /// Parses a visual scan result into typed visual artifacts while preserving scanner diagnostics.
+    /// </summary>
+    /// <param name="scan">A scan result produced by ChartForgeX or a host-discovered fence projection.</param>
+    /// <returns>The visual markup parse result.</returns>
+    public VisualMarkupParseResult Parse(VisualMarkupScanResult scan) {
+        if (scan == null) throw new ArgumentNullException(nameof(scan));
         var result = new VisualMarkupParseResult();
         foreach (var diagnostic in scan.Diagnostics) result.Diagnostics.Add(diagnostic);
         ParseBlocks(result, scan.Blocks);

--- a/ChartForgeX.Markup/VisualMarkupScanner.cs
+++ b/ChartForgeX.Markup/VisualMarkupScanner.cs
@@ -70,6 +70,42 @@ public static class VisualMarkupScanner {
     /// <returns>The supported visual blocks.</returns>
     public static List<VisualMarkupBlock> ExtractBlocks(string text) => Scan(text).Blocks;
 
+    /// <summary>
+    /// Validates and projects a visual fence that was already discovered by another Markdown parser.
+    /// </summary>
+    /// <param name="fenceInfo">The full fence info string after the opening marker.</param>
+    /// <param name="payload">The fence payload.</param>
+    /// <param name="fenceLine">The one-based source line containing the opening fence.</param>
+    /// <param name="payloadStartLine">The one-based source line where the payload starts.</param>
+    /// <param name="payloadEndLine">The one-based source line where the payload ends.</param>
+    /// <returns>A scan result containing the projected block or validation diagnostics.</returns>
+    public static VisualMarkupScanResult ParseFenceBlock(
+        string fenceInfo,
+        string payload,
+        int fenceLine,
+        int payloadStartLine,
+        int payloadEndLine) {
+        if (fenceInfo == null) throw new ArgumentNullException(nameof(fenceInfo));
+        if (payload == null) throw new ArgumentNullException(nameof(payload));
+
+        var normalizedFenceLine = Math.Max(1, fenceLine);
+        var normalizedStartLine = Math.Max(1, payloadStartLine);
+        var normalizedEndLine = Math.Max(normalizedStartLine, payloadEndLine);
+        var result = new VisualMarkupScanResult();
+        var descriptor = ResolveFence(result, fenceInfo, normalizedFenceLine);
+        if (descriptor.HasValue) {
+            result.Blocks.Add(CreateBlock(
+                descriptor.Value,
+                fenceInfo,
+                payload,
+                normalizedFenceLine,
+                normalizedStartLine,
+                normalizedEndLine));
+        }
+
+        return result;
+    }
+
     internal static bool TryResolveFence(string info, out VisualMarkupKind kind, out string fenceName) {
         var descriptor = ResolveFence(null, info, 1);
         if (descriptor.HasValue) {
@@ -84,12 +120,22 @@ public static class VisualMarkupScanner {
     }
 
     private static VisualMarkupBlock CreateBlock(VisualMarkupFenceDescriptor descriptor, string fenceInfo, List<string> payload, int fenceLine, int payloadStartLine, int payloadEndLine) {
+        return CreateBlock(
+            descriptor,
+            fenceInfo,
+            string.Join("\n", payload),
+            fenceLine,
+            payloadStartLine,
+            payloadEndLine);
+    }
+
+    private static VisualMarkupBlock CreateBlock(VisualMarkupFenceDescriptor descriptor, string fenceInfo, string payload, int fenceLine, int payloadStartLine, int payloadEndLine) {
         return new VisualMarkupBlock(
             descriptor.Kind,
             descriptor.Name,
             fenceInfo.Trim(),
             descriptor.SchemaVersion,
-            string.Join("\n", payload),
+            payload,
             fenceLine,
             payloadStartLine,
             payloadEndLine < payloadStartLine ? payloadStartLine : payloadEndLine,

--- a/ChartForgeX.Mermaid/ChartForgeX.Mermaid.csproj
+++ b/ChartForgeX.Mermaid/ChartForgeX.Mermaid.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Mermaid</PackageId>
-    <Version>1.0.0</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Native Mermaid compatibility parsing foundations for ChartForgeX visual artifact pipelines.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Tests/SmokeTests/BuildQualityTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/BuildQualityTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Xml.Linq;
 
 namespace ChartForgeX.Tests;
 
@@ -107,8 +108,17 @@ internal static partial class SmokeTests {
             Assert(projectFile.Contains("<Version>$(ChartForgeXProductVersion)</Version>", StringComparison.Ordinal), "Package project should consume the shared ChartForgeX product version: " + packageProject + ".");
         }
 
-        var directoryBuildProps = File.ReadAllText(Path.Combine(FindRepositoryRoot(), "Directory.Build.props"));
-        Assert(directoryBuildProps.Contains("<ChartForgeXProductVersion>1.0.0</ChartForgeXProductVersion>", StringComparison.Ordinal), "Directory.Build.props should own the ChartForgeX product version.");
+        var directoryBuildPropsPath = Path.Combine(FindRepositoryRoot(), "Directory.Build.props");
+        var directoryBuildProps = File.ReadAllText(directoryBuildPropsPath);
+        var productVersionText = XDocument.Load(directoryBuildPropsPath)
+            .Descendants("ChartForgeXProductVersion")
+            .Select(static element => element.Value.Trim())
+            .FirstOrDefault();
+        Assert(
+            Version.TryParse(productVersionText, out var productVersion)
+            && productVersion.Build >= 0
+            && productVersion.Revision < 0,
+            "Directory.Build.props should own a three-part ChartForgeX product version.");
         Assert(directoryBuildProps.Contains("<AssemblyVersion>$(ChartForgeXProductVersion).0</AssemblyVersion>", StringComparison.Ordinal), "ChartForgeX assembly identity should be isolated from host build version properties.");
 
         var qualityWorkflow = File.ReadAllText(Path.Combine(FindRepositoryRoot(), ".github", "workflows", "quality.yml"));

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -315,6 +315,7 @@ internal static partial class SmokeTests {
         ("Topology normalizes overlapping manual content", TopologyNormalizesOverlappingManualContent),
         ("Topology fits manual content into viewport", TopologyFitsManualContentIntoViewport),
         ("Topology fits rendered tile adornments into viewport", TopologyFitsRenderedTileAdornmentsIntoViewport),
+        ("Topology auto-sized groups enclose explicit member bounds", TopologyAutoSizedGroupsEncloseExplicitMemberBounds),
         ("Topology can fit dense content into fixed viewport", TopologyCanFitDenseContentIntoFixedViewport),
         ("Topology reserves group header space", TopologyReservesGroupHeaderSpace),
         ("Topology renders deterministic layouts", TopologyRendersDeterministicLayouts),

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -474,6 +474,7 @@ internal static partial class SmokeTests {
         ("Markup topology rejects mismatched section commands", MarkupTopologyRejectsMismatchedSectionCommands),
         ("Markup topology handles editing-friendly Markdown fences", MarkupTopologyHandlesEditingFriendlyMarkdownFences),
         ("Visual markup scanner extracts supported visual fences", VisualMarkupScannerExtractsSupportedVisualFences),
+        ("Visual markup scanner parses host-discovered fence blocks", VisualMarkupScannerParsesHostDiscoveredFenceBlocks),
         ("Visual markup scanner reports unsupported ChartForgeX fences", VisualMarkupScannerReportsUnsupportedChartForgeXFences),
         ("Visual markup scanner requires ChartForgeX schema version", VisualMarkupScannerRequiresChartForgeXSchemaVersion),
         ("Visual markup scanner keeps topology compatibility", VisualMarkupScannerKeepsTopologyCompatibility),

--- a/ChartForgeX.Tests/SmokeTests/TopologyAutoGroupTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/TopologyAutoGroupTests.cs
@@ -1,0 +1,24 @@
+using System;
+using ChartForgeX.Topology;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void TopologyAutoSizedGroupsEncloseExplicitMemberBounds() {
+        var chart = TopologyChart.Create()
+            .WithId("auto-sized-explicit-origin")
+            .WithViewport(520, 360, 24)
+            .WithLegend(null)
+            .WithLayout(TopologyLayoutMode.Manual)
+            .AddGroup("region", "Region", 300, 200, 0, 0, TopologyHealthStatus.Healthy)
+            .AddNode("site", "Site", 100, 80, TopologyNodeKind.Branch, TopologyHealthStatus.Healthy, "region", width: 120, height: 64);
+
+        var prepared = TopologyLayoutEngine.Prepare(chart, options: new TopologyRenderOptions { IncludeLegend = false });
+        var group = prepared.Groups[0];
+        var node = prepared.Nodes[0];
+        Assert(group.X <= node.X && group.Y <= node.Y, "Auto-sized group origins should move far enough to enclose member nodes.");
+        Assert(group.X + group.Width >= node.X + node.Width && group.Y + group.Height >= node.Y + node.Height, "Auto-sized group dimensions should enclose member node bounds.");
+        Assert(chart.ToSvg(new TopologyRenderOptions { IncludeLegend = false }).Contains("data-group-id=\"region\"", StringComparison.Ordinal), "Auto-sized explicit-origin groups should render as SVG.");
+        Assert(chart.ToPng(new TopologyRenderOptions { IncludeLegend = false }).Length > 64, "Auto-sized explicit-origin groups should render as PNG.");
+    }
+}

--- a/ChartForgeX.Tests/SmokeTests/VisualMarkupFenceBlockTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualMarkupFenceBlockTests.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using ChartForgeX.Markup;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void VisualMarkupScannerParsesHostDiscoveredFenceBlocks() {
+        var result = VisualMarkupScanner.ParseFenceBlock(
+            "chartforgex table v1 {#users .compact mode=\"native\"}",
+            "| Name | State |\n| --- | --- |\n| Ada | Enabled |",
+            fenceLine: 20,
+            payloadStartLine: 21,
+            payloadEndLine: 23);
+
+        Assert(result.Diagnostics.Count == 0, "A supported host-discovered fence should not produce diagnostics.");
+        var block = result.Blocks.Single();
+        Assert(block.Kind == VisualMarkupKind.Table, "The direct host path should use the same visual-kind contract as Markdown scanning.");
+        Assert(block.FenceLine == 20 && block.StartLine == 21 && block.EndLine == 23, "The direct host path should preserve source lines.");
+        Assert(block.Attributes["id"] == "users" && block.Attributes["class"] == "compact" && block.Attributes["mode"] == "native", "The direct host path should use the shared fence attribute parser.");
+
+        var invalid = VisualMarkupScanner.ParseFenceBlock(
+            "chartforgex table",
+            "| Name |",
+            fenceLine: 40,
+            payloadStartLine: 41,
+            payloadEndLine: 41);
+        Assert(invalid.Blocks.Count == 0, "An unversioned direct fence should not become a visual block.");
+        Assert(invalid.Diagnostics.Count == 1 && invalid.Diagnostics[0].Line == 40, "The direct host path should return shared line-aware validation diagnostics.");
+    }
+}

--- a/ChartForgeX.Tests/SmokeTests/VisualMarkupFenceBlockTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualMarkupFenceBlockTests.cs
@@ -26,5 +26,9 @@ internal static partial class SmokeTests {
             payloadEndLine: 41);
         Assert(invalid.Blocks.Count == 0, "An unversioned direct fence should not become a visual block.");
         Assert(invalid.Diagnostics.Count == 1 && invalid.Diagnostics[0].Line == 40, "The direct host path should return shared line-aware validation diagnostics.");
+
+        var parsedInvalid = new VisualMarkupParser().Parse(invalid);
+        Assert(parsedInvalid.Artifacts.Count == 0, "An invalid host-discovered fence should not produce an artifact.");
+        Assert(parsedInvalid.Diagnostics.Count == 1 && parsedInvalid.Diagnostics[0].Line == 40, "The scan-result parser path should preserve host fence diagnostics.");
     }
 }

--- a/ChartForgeX.Tests/SmokeTests/VisualMarkupFenceBlockTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualMarkupFenceBlockTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using ChartForgeX.Markup;
+using ChartForgeX.VisualArtifacts;
 
 namespace ChartForgeX.Tests;
 
@@ -31,14 +32,26 @@ internal static partial class SmokeTests {
         Assert(parsedInvalid.Artifacts.Count == 0, "An invalid host-discovered fence should not produce an artifact.");
         Assert(parsedInvalid.Diagnostics.Count == 1 && parsedInvalid.Diagnostics[0].Line == 40, "The scan-result parser path should preserve host fence diagnostics.");
 
-        var invalidDimensions = VisualMarkupScanner.ParseFenceBlock(
+        var autoSizedGroup = VisualMarkupScanner.ParseFenceBlock(
             "chartforgex topology v1",
             "group D1 \"Primary\" width:0\nnode dc1 \"DC1\" group:D1",
             fenceLine: 50,
             payloadStartLine: 51,
             payloadEndLine: 52);
-        var parsedDimensions = new VisualMarkupParser().Parse(invalidDimensions);
-        Assert(parsedDimensions.Artifacts.Count == 0, "A topology with invalid dimensions should not escape as an artifact that fails during rendering.");
-        Assert(parsedDimensions.Diagnostics.Any(diagnostic => diagnostic.Line == 51 && diagnostic.Message.Contains("width must be a positive finite number", System.StringComparison.Ordinal)), "Invalid topology dimensions should be rejected with a line-aware parse diagnostic.");
+        var parsedAutoSizedGroup = new VisualMarkupParser().Parse(autoSizedGroup);
+        Assert(parsedAutoSizedGroup.Diagnostics.Count == 0, "Zero group dimensions should preserve the shared auto-size contract.");
+        var autoSizedArtifact = parsedAutoSizedGroup.Artifacts.Single();
+        Assert(autoSizedArtifact.ToSvg().Contains("data-group-id=\"D1\"", System.StringComparison.Ordinal), "An auto-sized single-node group should render through the shared topology layout engine.");
+        Assert(autoSizedArtifact.ToPng().Length > 64, "An auto-sized single-node group should render through the shared PNG boundary.");
+
+        var invalidNodeDimensions = VisualMarkupScanner.ParseFenceBlock(
+            "chartforgex topology v1",
+            "node dc1 \"DC1\" width:0",
+            fenceLine: 60,
+            payloadStartLine: 61,
+            payloadEndLine: 61);
+        var parsedInvalidNode = new VisualMarkupParser().Parse(invalidNodeDimensions);
+        Assert(parsedInvalidNode.Artifacts.Count == 0, "A node with invalid dimensions should not escape as an artifact that fails during rendering.");
+        Assert(parsedInvalidNode.Diagnostics.Any(diagnostic => diagnostic.Line == 61 && diagnostic.Message.Contains("width must be a positive finite number", System.StringComparison.Ordinal)), "Invalid node dimensions should be rejected with a line-aware parse diagnostic.");
     }
 }

--- a/ChartForgeX.Tests/SmokeTests/VisualMarkupFenceBlockTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/VisualMarkupFenceBlockTests.cs
@@ -30,5 +30,15 @@ internal static partial class SmokeTests {
         var parsedInvalid = new VisualMarkupParser().Parse(invalid);
         Assert(parsedInvalid.Artifacts.Count == 0, "An invalid host-discovered fence should not produce an artifact.");
         Assert(parsedInvalid.Diagnostics.Count == 1 && parsedInvalid.Diagnostics[0].Line == 40, "The scan-result parser path should preserve host fence diagnostics.");
+
+        var invalidDimensions = VisualMarkupScanner.ParseFenceBlock(
+            "chartforgex topology v1",
+            "group D1 \"Primary\" width:0\nnode dc1 \"DC1\" group:D1",
+            fenceLine: 50,
+            payloadStartLine: 51,
+            payloadEndLine: 52);
+        var parsedDimensions = new VisualMarkupParser().Parse(invalidDimensions);
+        Assert(parsedDimensions.Artifacts.Count == 0, "A topology with invalid dimensions should not escape as an artifact that fails during rendering.");
+        Assert(parsedDimensions.Diagnostics.Any(diagnostic => diagnostic.Line == 51 && diagnostic.Message.Contains("width must be a positive finite number", System.StringComparison.Ordinal)), "Invalid topology dimensions should be rejected with a line-aware parse diagnostic.");
     }
 }

--- a/ChartForgeX/ChartForgeX.csproj
+++ b/ChartForgeX/ChartForgeX.csproj
@@ -18,7 +18,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX</PackageId>
-    <Version>1.0.0</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Dependency-free SVG, HTML, PNG, GIF, JPEG, BMP, PPM, and TIFF rendering and image composition for .NET charts, visual blocks, report tables, metric cards, wallpapers, and topology diagrams.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX/Topology/TopologyLayoutNormalizer.cs
+++ b/ChartForgeX/Topology/TopologyLayoutNormalizer.cs
@@ -13,6 +13,8 @@ internal static class TopologyLayoutNormalizer {
     private const double GroupHeaderBottomGap = 12;
     private const double RowTolerance = 36;
     private const double MinimumNodeWidth = 108;
+    private const double MinimumAutoGroupWidth = 190;
+    private const double MinimumAutoGroupHeight = 170;
 
     public static void Normalize(TopologyChart chart, TopologyRenderOptions? options = null) {
         options ??= new TopologyRenderOptions();
@@ -94,10 +96,25 @@ internal static class TopologyLayoutNormalizer {
             .GroupBy(group => group.Id, StringComparer.Ordinal)
             .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
 
-        foreach (var nodeSet in chart.Nodes.Where(node => !string.IsNullOrWhiteSpace(node.GroupId)).GroupBy(node => node.GroupId!, StringComparer.Ordinal)) {
-            if (!groups.TryGetValue(nodeSet.Key, out var group)) continue;
-            var requiredBottom = nodeSet.Max(node => node.Y + node.Height) + GroupPadding;
-            if (requiredBottom > group.Y + group.Height) group.Height = requiredBottom - group.Y;
+        var nodesByGroup = chart.Nodes
+            .Where(node => !string.IsNullOrWhiteSpace(node.GroupId))
+            .GroupBy(node => node.GroupId!, StringComparer.Ordinal)
+            .ToDictionary(nodeSet => nodeSet.Key, nodeSet => nodeSet.ToList(), StringComparer.Ordinal);
+
+        foreach (var group in groups.Values) {
+            if (!nodesByGroup.TryGetValue(group.Id, out var nodes) || nodes.Count == 0) {
+                if (group.Width <= 0) group.Width = MinimumAutoGroupWidth;
+                if (group.Height <= 0) group.Height = MinimumAutoGroupHeight;
+                continue;
+            }
+
+            var requiredRight = nodes.Max(node => node.X + node.Width) + GroupPadding;
+            var requiredBottom = nodes.Max(node => node.Y + node.Height) + GroupPadding;
+            var requiredWidth = requiredRight - group.X;
+            var requiredHeight = requiredBottom - group.Y;
+            if (group.Width <= 0) group.Width = Math.Max(MinimumAutoGroupWidth, requiredWidth);
+            if (group.Height <= 0) group.Height = Math.Max(MinimumAutoGroupHeight, requiredHeight);
+            else if (requiredBottom > group.Y + group.Height) group.Height = requiredHeight;
         }
     }
 

--- a/ChartForgeX/Topology/TopologyLayoutNormalizer.cs
+++ b/ChartForgeX/Topology/TopologyLayoutNormalizer.cs
@@ -18,6 +18,7 @@ internal static class TopologyLayoutNormalizer {
 
     public static void Normalize(TopologyChart chart, TopologyRenderOptions? options = null) {
         options ??= new TopologyRenderOptions();
+        ExpandGroupsForNodes(chart);
         ResolveGroupHeaderOverlaps(chart, options);
         ResolveNodeOverlaps(chart);
         ExpandGroupsForNodes(chart);
@@ -110,11 +111,19 @@ internal static class TopologyLayoutNormalizer {
 
             var requiredRight = nodes.Max(node => node.X + node.Width) + GroupPadding;
             var requiredBottom = nodes.Max(node => node.Y + node.Height) + GroupPadding;
-            var requiredWidth = requiredRight - group.X;
-            var requiredHeight = requiredBottom - group.Y;
-            if (group.Width <= 0) group.Width = Math.Max(MinimumAutoGroupWidth, requiredWidth);
-            if (group.Height <= 0) group.Height = Math.Max(MinimumAutoGroupHeight, requiredHeight);
-            else if (requiredBottom > group.Y + group.Height) group.Height = requiredHeight;
+            if (group.Width <= 0) {
+                var requiredLeft = nodes.Min(node => node.X) - GroupPadding;
+                if (requiredLeft < group.X) group.X = requiredLeft;
+                group.Width = Math.Max(MinimumAutoGroupWidth, requiredRight - group.X);
+            }
+
+            if (group.Height <= 0) {
+                var requiredTop = nodes.Min(node => node.Y) - GroupPadding;
+                if (requiredTop < group.Y) group.Y = requiredTop;
+                group.Height = Math.Max(MinimumAutoGroupHeight, requiredBottom - group.Y);
+            } else if (requiredBottom > group.Y + group.Height) {
+                group.Height = requiredBottom - group.Y;
+            }
         }
     }
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <ChartForgeXProductVersion>1.0.0</ChartForgeXProductVersion>
+    <ChartForgeXProductVersion>1.0.1</ChartForgeXProductVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ChartForgeX' Or '$(MSBuildProjectName)' == 'ChartForgeX.Interactivity' Or '$(MSBuildProjectName)' == 'ChartForgeX.Interactivity.Html' Or '$(MSBuildProjectName)' == 'ChartForgeX.Markup' Or '$(MSBuildProjectName)' == 'ChartForgeX.Mermaid' Or '$(MSBuildProjectName)' == 'ChartForgeX.Markup.Mermaid'">

--- a/docs/markup-v1-reference.md
+++ b/docs/markup-v1-reference.md
@@ -164,6 +164,6 @@ These capabilities describe what a production host or adapter may expose. They d
 
 ## API Surface
 
-Use `VisualMarkupParser.Parse(markdown)` when ChartForgeX should scan Markdown itself. Use `VisualMarkupScanner.Scan(markdown)` or `VisualMarkupParser.ParseBlocks(blocks)` when another Markdown host owns fence discovery.
+Use `VisualMarkupParser.Parse(markdown)` when ChartForgeX should scan Markdown itself. When another Markdown host owns fence discovery, use `VisualMarkupScanner.ParseFenceBlock(...)` to validate and project its fence metadata, then pass the returned blocks to `VisualMarkupParser.ParseBlocks(blocks)`.
 
 `VisualArtifact` exposes `ToSvg()`, `ToHtmlPage()`, `ToPng()`, `SaveSvg()`, `SaveHtml()`, and `SavePng()` for supported static models. The artifact envelope preserves the artifact kind, source language, title, subtitle, natural size, export formats, regions, legend entries, and metadata.

--- a/docs/markup-v1-reference.md
+++ b/docs/markup-v1-reference.md
@@ -164,6 +164,6 @@ These capabilities describe what a production host or adapter may expose. They d
 
 ## API Surface
 
-Use `VisualMarkupParser.Parse(markdown)` when ChartForgeX should scan Markdown itself. When another Markdown host owns fence discovery, use `VisualMarkupScanner.ParseFenceBlock(...)` to validate and project its fence metadata, then pass the returned blocks to `VisualMarkupParser.ParseBlocks(blocks)`.
+Use `VisualMarkupParser.Parse(markdown)` when ChartForgeX should scan Markdown itself. When another Markdown host owns fence discovery, use `VisualMarkupScanner.ParseFenceBlock(...)` to validate and project its fence metadata, then pass the complete scan result to `VisualMarkupParser.Parse(scan)` so validation diagnostics cannot be discarded. `ParseBlocks(blocks)` is available for hosts that already own and have handled scanner diagnostics.
 
 `VisualArtifact` exposes `ToSvg()`, `ToHtmlPage()`, `ToPng()`, `SaveSvg()`, `SaveHtml()`, and `SavePng()` for supported static models. The artifact envelope preserves the artifact kind, source language, title, subtitle, natural size, export formats, regions, legend entries, and metadata.

--- a/docs/markup.md
+++ b/docs/markup.md
@@ -20,7 +20,7 @@ The generic `ChartForgeX.Markup` package recognizes:
 
 Unsupported or unversioned `chartforgex` family fences produce diagnostics instead of being silently ignored. The parser also accepts custom block parsers through `IVisualMarkupBlockParser`, so optional packages can add real behavior without making the core markup package depend on them.
 
-Standalone tools can call `VisualMarkupParser.Parse(markdown)` and let ChartForgeX scan Markdown itself. Hosts that already parse Markdown, such as OfficeIMO-backed IX pipelines, should project each discovered fence with `VisualMarkupScanner.ParseFenceBlock(...)` and pass the returned typed blocks through `VisualMarkupParser.ParseBlocks(blocks)`. That keeps one Markdown source of truth while preserving ChartForgeX's fence validation, attributes, line-aware diagnostics, artifact conversion, and static rendering.
+Standalone tools can call `VisualMarkupParser.Parse(markdown)` and let ChartForgeX scan Markdown itself. Hosts that already parse Markdown, such as OfficeIMO-backed IX pipelines, should project each discovered fence with `VisualMarkupScanner.ParseFenceBlock(...)` and pass the complete scan result through `VisualMarkupParser.Parse(scan)`. That keeps one Markdown source of truth while preserving ChartForgeX's fence validation, attributes, line-aware diagnostics, artifact conversion, and static rendering. Use `ParseBlocks(blocks)` only when the host already owns and has handled scanner diagnostics.
 
 The host integration shape is:
 
@@ -34,7 +34,7 @@ var fence = VisualMarkupScanner.ParseFenceBlock(
     payloadStartLine: 25,
     payloadEndLine: 27);
 
-var result = new VisualMarkupParser().ParseBlocks(fence.Blocks);
+var result = new VisualMarkupParser().Parse(fence);
 ```
 
 OfficeIMO or another Markdown-native host owns Markdown parsing, fence discovery, and any document-native metadata. ChartForgeX owns visual payload parsing, diagnostics, reusable models, and deterministic static previews.

--- a/docs/markup.md
+++ b/docs/markup.md
@@ -20,30 +20,21 @@ The generic `ChartForgeX.Markup` package recognizes:
 
 Unsupported or unversioned `chartforgex` family fences produce diagnostics instead of being silently ignored. The parser also accepts custom block parsers through `IVisualMarkupBlockParser`, so optional packages can add real behavior without making the core markup package depend on them.
 
-Standalone tools can call `VisualMarkupParser.Parse(markdown)` and let ChartForgeX scan Markdown itself. Hosts that already parse Markdown, such as OfficeIMO-backed IX pipelines, should pass their discovered visual fences through `VisualMarkupParser.ParseBlocks(blocks)` instead. That keeps one Markdown source of truth while preserving ChartForgeX's line-aware diagnostics, artifact conversion, and static rendering.
+Standalone tools can call `VisualMarkupParser.Parse(markdown)` and let ChartForgeX scan Markdown itself. Hosts that already parse Markdown, such as OfficeIMO-backed IX pipelines, should project each discovered fence with `VisualMarkupScanner.ParseFenceBlock(...)` and pass the returned typed blocks through `VisualMarkupParser.ParseBlocks(blocks)`. That keeps one Markdown source of truth while preserving ChartForgeX's fence validation, attributes, line-aware diagnostics, artifact conversion, and static rendering.
 
 The host integration shape is:
 
 ```csharp
 using ChartForgeX.Markup;
 
-var blocks = new[] {
-    new VisualMarkupBlock(
-        VisualMarkupKind.Chart,
-        "chartforgex chart",
-        "chartforgex chart v1 {#trend title=\"Trend\"}",
-        schemaVersion: 1,
-        "type line\nlabels Jan Feb Mar\nvalues 12 18 16",
-        fenceLine: 24,
-        startLine: 25,
-        endLine: 27,
-        attributes: new Dictionary<string, string> {
-            ["id"] = "trend",
-            ["title"] = "Trend"
-        })
-};
+var fence = VisualMarkupScanner.ParseFenceBlock(
+    "chartforgex chart v1 {#trend title=\"Trend\"}",
+    "type line\nlabels Jan Feb Mar\nvalues 12 18 16",
+    fenceLine: 24,
+    payloadStartLine: 25,
+    payloadEndLine: 27);
 
-var result = new VisualMarkupParser().ParseBlocks(blocks);
+var result = new VisualMarkupParser().ParseBlocks(fence.Blocks);
 ```
 
 OfficeIMO or another Markdown-native host owns Markdown parsing, fence discovery, and any document-native metadata. ChartForgeX owns visual payload parsing, diagnostics, reusable models, and deterministic static previews.


### PR DESCRIPTION
## Summary

- add `VisualMarkupScanner.ParseFenceBlock(...)` for hosts that already own Markdown fence discovery
- reuse the canonical ChartForgeX kind, schema, attribute, diagnostic, and source-line logic without reconstructing Markdown
- make `Directory.Build.props` the single version owner for all six packages and prepare version 1.0.1
- update host-integration documentation and release guards

## Validation

- `dotnet test ChartForgeX.sln -c Release --no-restore` (736 passed)
- `./Build.ps1 -Configuration Release` (build, tests, Mermaid fixtures, Native AOT, and six 1.0.1 NuGet/symbol packages)
- IntelligenceX native rendering consumer: 55 focused tests passed against the locally packed 1.0.1 artifacts
