### PR TITLE
Restore central ChartForgeX package versioning

### DIFF
--- a/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
+++ b/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Interactivity.Html</PackageId>
-    <Version>1.0.1</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Self-contained HTML, SVG, and graph explorer interaction adapter for ChartForgeX charts and graph scenes.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
+++ b/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Interactivity</PackageId>
-    <Version>1.0.1</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Host-neutral interaction contracts for ChartForgeX chart renderers and adapters.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Markup.Mermaid/ChartForgeX.Markup.Mermaid.csproj
+++ b/ChartForgeX.Markup.Mermaid/ChartForgeX.Markup.Mermaid.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Markup.Mermaid</PackageId>
-    <Version>1.0.1</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Mermaid fenced-block adapter for ChartForgeX markup visual artifact pipelines.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Markup/ChartForgeX.Markup.csproj
+++ b/ChartForgeX.Markup/ChartForgeX.Markup.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Markup</PackageId>
-    <Version>1.0.1</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Markdown-friendly ChartForgeX markup parser and code emitter for charts and topology diagrams.</Description>
     <PackageReleaseNotes>Adds direct validation and projection for visual fences discovered by another Markdown parser.</PackageReleaseNotes>

--- a/ChartForgeX.Mermaid/ChartForgeX.Mermaid.csproj
+++ b/ChartForgeX.Mermaid/ChartForgeX.Mermaid.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Mermaid</PackageId>
-    <Version>1.0.1</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Native Mermaid compatibility parsing foundations for ChartForgeX visual artifact pipelines.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX/ChartForgeX.csproj
+++ b/ChartForgeX/ChartForgeX.csproj
@@ -18,7 +18,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX</PackageId>
-    <Version>1.0.1</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Dependency-free SVG, HTML, PNG, GIF, JPEG, BMP, PPM, and TIFF rendering and image composition for .NET charts, visual blocks, report tables, metric cards, wallpapers, and topology diagrams.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- restore `ChartForgeXProductVersion` as the single package-version owner for all six published ChartForgeX projects
- remove literal `1.0.1` values written by the previous release tooling
- keep package, assembly, file, and informational versions aligned through `Directory.Build.props`

## Why
The 1.0.1 release succeeded, but the older publisher rewrote each project file independently. PowerForge now understands imported central MSBuild versions, so future releases no longer need six duplicate version values.

## Validation
- evaluated `Version`, `PackageVersion`, and `AssemblyVersion` for all six package projects: `1.0.1`, `1.0.1`, and `1.0.1.0`
- `dotnet build ChartForgeX.sln -c Release --disable-build-servers` (0 warnings, 0 errors)
