### PR TITLE
Harden zero-radius markers and histogram binning

### DIFF
--- a/ChartForgeX.Examples/Program.cs
+++ b/ChartForgeX.Examples/Program.cs
@@ -554,7 +554,7 @@ var latencyDistribution = Chart.Create()
     .WithTheme(ChartTheme.ReportLight())
     .WithSize(760, 460)
     .WithDataLabels()
-    .AddHistogram("P95 samples", new[] { 28d, 31d, 36d, 42d, 47d, 58d, 64d, 72d, 86d, 91d, 118d, 146d, 182d }, 5, ChartColor.FromRgb(37, 99, 235));
+    .AddHistogram("P95 samples", new[] { 28d, 31d, 36d, 42d, 47d, 58d, 64d, 72d, 86d, 91d, 118d, 146d, 182d }, ChartHistogramBinLayout.FromWidth(28, 182, 35), ChartColor.FromRgb(37, 99, 235));
 
 SaveChart(latencyDistribution, "endpoint-latency-histogram-light");
 

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -72,13 +72,17 @@ internal static partial class SmokeTests {
         var stacked = Chart.Create()
             .WithSize(640, 360)
             .WithStackedBars()
+            .WithStackTotals()
             .AddHistogram("Observed", new[] { 0.11, 0.12, 0.25 }, decimalLayout)
             .AddBar("Target", new[] { new ChartPoint(0.15, 3), new ChartPoint(0.25, 2) });
-        var stackedBars = SvgDocument.Parse(stacked.ToSvg()).Root.FindByTag("rect")
+        var stackedSvg = stacked.ToSvg();
+        var stackedBars = SvgDocument.Parse(stackedSvg).Root.FindByTag("rect")
             .Where(element => element.GetAttribute("data-cfx-role") == "bar")
             .ToArray();
         Assert(stackedBars[2].GetAttribute("data-cfx-base") == "2", "Stacked regular bars should start at the matching histogram count.");
         Assert(ChartRange.FromChart(stacked).MaxY >= 5, "Stacked range calculation should include decimal-equivalent histogram and regular bar coordinates together.");
+        Assert(CountOccurrences(stackedSvg, "data-cfx-role=\"stack-total-label\"") == 2, "Stack totals should emit one label per decimal-equivalent histogram and regular bar coordinate.");
+        Assert(stacked.ToPng().Length > 64, "Decimal-equivalent mixed stack totals should preserve PNG rendering parity.");
 
         var narrowLayout = ChartHistogramBinLayout.FromWidth(0, 0.00000002, 0.00000001);
         var narrow = Chart.Create()

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using ChartForgeX.Core;
 using ChartForgeX.Primitives;
+using ChartForgeX.Rendering;
 using ChartForgeX.Svg;
 
 namespace ChartForgeX.Tests;
@@ -67,15 +68,27 @@ internal static partial class SmokeTests {
         Assert(histogramLeft + histogramWidth <= regularLeft + 0.001, "Grouped histogram and regular bars at the same numeric coordinate should receive distinct slots.");
         Assert(grouped.ToPng().Length > 64, "Mixed histogram and regular bars should preserve PNG rendering parity.");
 
+        var decimalLayout = ChartHistogramBinLayout.FromWidth(0.1, 0.3, 0.1);
         var stacked = Chart.Create()
             .WithSize(640, 360)
             .WithStackedBars()
-            .AddHistogram("Observed", new[] { 0.25, 0.75, 1.25, 1.75 }, layout)
-            .AddBar("Target", new[] { new ChartPoint(0.5, 3), new ChartPoint(1.5, 2) });
+            .AddHistogram("Observed", new[] { 0.11, 0.12, 0.25 }, decimalLayout)
+            .AddBar("Target", new[] { new ChartPoint(0.15, 3), new ChartPoint(0.25, 2) });
         var stackedBars = SvgDocument.Parse(stacked.ToSvg()).Root.FindByTag("rect")
             .Where(element => element.GetAttribute("data-cfx-role") == "bar")
             .ToArray();
         Assert(stackedBars[2].GetAttribute("data-cfx-base") == "2", "Stacked regular bars should start at the matching histogram count.");
+        Assert(ChartRange.FromChart(stacked).MaxY >= 5, "Stacked range calculation should include decimal-equivalent histogram and regular bar coordinates together.");
+
+        var narrowLayout = ChartHistogramBinLayout.FromWidth(0, 0.00000002, 0.00000001);
+        var narrow = Chart.Create()
+            .WithStackedBars()
+            .AddHistogram("Narrow bins", new[] { 0.000000001, 0.000000002, 0.000000015 }, narrowLayout)
+            .AddBar("Narrow target", new[] { new ChartPoint(0.000000015, 2) });
+        var narrowBars = SvgDocument.Parse(narrow.ToSvg()).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        Assert(narrowBars[2].GetAttribute("data-cfx-base") == "1", "Stacked bars should not match an earlier adjacent histogram bin merely because the bin width is below one millionth.");
     }
 
     private static void SeriesKindCapabilitiesExposeExclusiveRenderingOwnership() {

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -52,6 +52,13 @@ internal static partial class SmokeTests {
         var subDecimalLayout = ChartHistogramBinLayout.FromCount(0, 1e-28, 2);
         var subDecimalChart = Chart.Create().AddHistogram("Sub-decimal widths", new[] { 2e-29, 7e-29 }, subDecimalLayout);
         Assert(subDecimalChart.Series[0].Points.Select(point => point.Y).SequenceEqual(new[] { 1d, 1d }), "Histogram widths below decimal precision should fall back to binary bin assignment without division by zero.");
+        AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromWidth(1e16, 1e16 + 2, 1), "Width-based histogram layouts should reject internal bounds that cannot advance at the requested magnitude.");
+        AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromCount(1e16, 1e16 + 2, 2), "Count-based histogram layouts should reject internal bounds that cannot advance at the requested magnitude.");
+        AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromWidth(1e16, 1e16 + 12, 1.5), "Width-based histogram layouts should reject collapsed bounds in the middle of a layout.");
+        AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromCount(1e16, 1e16 + 8, 5), "Count-based histogram layouts should reject collapsed bounds in the middle of a layout.");
+        AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromWidth(1e16, 1e16 + 10, 4.75), "Width-based histogram layouts should reject a final remainder bin whose lower bound rounds to the maximum.");
+        var largeExactLayout = ChartHistogramBinLayout.FromCount(Math.Pow(2, 52), Math.Pow(2, 52) + 2_000_000_000, 1_000_000_000);
+        Assert(largeExactLayout.Count == 1_000_000_000 && largeExactLayout.Width == 2, "Large layouts with clearly separated exact bounds should avoid per-bin validation.");
         AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromWidth(0, 10, 0), "Histogram layouts should reject zero bin widths.");
         AssertThrows<ArgumentOutOfRangeException>(() => Chart.Create().AddHistogram("Outside", new[] { 11d }, layout), "Shared histogram layouts should reject values outside their bounds.");
     }

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -45,8 +45,37 @@ internal static partial class SmokeTests {
         var boundaryLayout = ChartHistogramBinLayout.FromWidth(0.1, 0.5, 0.1);
         var boundaryChart = Chart.Create().AddHistogram("Decimal boundaries", new[] { 0.1, 0.2, 0.3, 0.4, 0.5 }, boundaryLayout);
         Assert(boundaryChart.Series[0].Points.Select(point => point.Y).SequenceEqual(new[] { 1d, 1d, 1d, 2d }), "Decimal values on exact bin boundaries should be assigned to the following bin.");
+        var belowHalf = BitConverter.Int64BitsToDouble(BitConverter.DoubleToInt64Bits(0.5) - 1);
+        var adjacentBoundaryChart = Chart.Create().AddHistogram("Adjacent boundary values", new[] { belowHalf, 0.5 }, ChartHistogramBinLayout.FromWidth(0, 1, 0.1));
+        Assert(adjacentBoundaryChart.Series[0].Points[4].Y == 1 && adjacentBoundaryChart.Series[0].Points[5].Y == 1, "Histogram binning should preserve a representable value immediately below a boundary without moving it into the following bin.");
         AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromWidth(0, 10, 0), "Histogram layouts should reject zero bin widths.");
         AssertThrows<ArgumentOutOfRangeException>(() => Chart.Create().AddHistogram("Outside", new[] { 11d }, layout), "Shared histogram layouts should reject values outside their bounds.");
+    }
+
+    private static void HistogramBarsGroupWithRegularBars() {
+        var layout = ChartHistogramBinLayout.FromWidth(0, 2, 1);
+        var grouped = Chart.Create()
+            .WithSize(640, 360)
+            .AddHistogram("Observed", new[] { 0.25, 0.75, 1.25, 1.75 }, layout)
+            .AddBar("Target", new[] { new ChartPoint(0.5, 3), new ChartPoint(1.5, 2) });
+        var bars = SvgDocument.Parse(grouped.ToSvg()).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        var histogramLeft = double.Parse(bars[0].GetAttribute("x")!, CultureInfo.InvariantCulture);
+        var histogramWidth = double.Parse(bars[0].GetAttribute("width")!, CultureInfo.InvariantCulture);
+        var regularLeft = double.Parse(bars[2].GetAttribute("x")!, CultureInfo.InvariantCulture);
+        Assert(histogramLeft + histogramWidth <= regularLeft + 0.001, "Grouped histogram and regular bars at the same numeric coordinate should receive distinct slots.");
+        Assert(grouped.ToPng().Length > 64, "Mixed histogram and regular bars should preserve PNG rendering parity.");
+
+        var stacked = Chart.Create()
+            .WithSize(640, 360)
+            .WithStackedBars()
+            .AddHistogram("Observed", new[] { 0.25, 0.75, 1.25, 1.75 }, layout)
+            .AddBar("Target", new[] { new ChartPoint(0.5, 3), new ChartPoint(1.5, 2) });
+        var stackedBars = SvgDocument.Parse(stacked.ToSvg()).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        Assert(stackedBars[2].GetAttribute("data-cfx-base") == "2", "Stacked regular bars should start at the matching histogram count.");
     }
 
     private static void SeriesKindCapabilitiesExposeExclusiveRenderingOwnership() {

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -28,6 +28,10 @@ internal static partial class SmokeTests {
         Assert(layout.Count == 4 && Math.Abs(layout.Width - 3) < 0.000001, "Histogram layouts should preserve the requested bin width.");
         Assert(chart.Series[0].Points.Select(point => point.Y).SequenceEqual(new[] { 2d, 2d, 1d, 2d }), "Histogram values should use the requested width when assigning bins.");
         Assert(chart.Options.XAxisLabels.Select(label => label.Text).SequenceEqual(new[] { "0-3", "3-6", "6-9", "9-10" }), "Histogram labels should retain full-width bins and a final remainder bin.");
+        var decimalLayout = ChartHistogramBinLayout.FromWidth(0, 0.07, 0.005);
+        var remainderLayout = ChartHistogramBinLayout.FromWidth(0, 0.071, 0.005);
+        Assert(decimalLayout.Count == 14, "Histogram layouts should not create a phantom bin when floating-point division is negligibly above an integer.");
+        Assert(remainderLayout.Count == 15, "Histogram layouts should retain a final bin when the range has a real remainder.");
         AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromWidth(0, 10, 0), "Histogram layouts should reject zero bin widths.");
         AssertThrows<ArgumentOutOfRangeException>(() => Chart.Create().AddHistogram("Outside", new[] { 11d }, layout), "Shared histogram layouts should reject values outside their bounds.");
     }

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -52,5 +52,6 @@ internal static partial class SmokeTests {
     private static void SeriesKindCapabilitiesExposeExclusiveRenderingOwnership() {
         Assert(ChartSeriesKindCapabilities.IsExclusive(ChartSeriesKind.Heatmap), "Shared kind capabilities should classify exclusive rendering surfaces.");
         Assert(!ChartSeriesKindCapabilities.IsExclusive(ChartSeriesKind.Line), "Shared kind capabilities should keep cartesian line series non-exclusive.");
+        AssertThrows<ArgumentOutOfRangeException>(() => ChartSeriesKindCapabilities.IsExclusive((ChartSeriesKind)999), "Shared kind capabilities should reject undefined series kinds.");
     }
 }

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void HistogramValuesRenderAsBinnedBars() {
+        var chart = Chart.Create()
+            .WithSize(640, 360)
+            .WithDataLabels()
+            .AddHistogram("Latency samples", new[] { 1d, 2d, 2d, 3d, 5d }, 2, ChartColor.FromRgb(37, 99, 235));
+        var svg = chart.ToSvg();
+        Assert(CountOccurrences(svg, "data-cfx-role=\"bar\"") == 2, "Histogram values should render one bar per requested bin.");
+        Assert(svg.Contains(">1-3</text>", StringComparison.Ordinal), "Histogram bins should render range labels.");
+        Assert(svg.Contains(">3-5</text>", StringComparison.Ordinal), "Histogram bins should render range labels.");
+        Assert(svg.Contains(">3</text>", StringComparison.Ordinal), "Histogram data labels should render bin counts.");
+        Assert(chart.ToPng().Length > 64, "Histogram charts should render PNG output.");
+    }
+
+    private static void HistogramBinWidthPreservesRequestedIntervals() {
+        var layout = ChartHistogramBinLayout.FromWidth(0, 10, 3);
+        var chart = Chart.Create()
+            .WithSize(640, 360)
+            .AddHistogram("Requested width", new[] { 0d, 1d, 3d, 5d, 6d, 9d, 10d }, layout);
+
+        Assert(layout.Count == 4 && Math.Abs(layout.Width - 3) < 0.000001, "Histogram layouts should preserve the requested bin width.");
+        Assert(chart.Series[0].Points.Select(point => point.Y).SequenceEqual(new[] { 2d, 2d, 1d, 2d }), "Histogram values should use the requested width when assigning bins.");
+        Assert(chart.Options.XAxisLabels.Select(label => label.Text).SequenceEqual(new[] { "0-3", "3-6", "6-9", "9-10" }), "Histogram labels should retain full-width bins and a final remainder bin.");
+        AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromWidth(0, 10, 0), "Histogram layouts should reject zero bin widths.");
+        AssertThrows<ArgumentOutOfRangeException>(() => Chart.Create().AddHistogram("Outside", new[] { 11d }, layout), "Shared histogram layouts should reject values outside their bounds.");
+    }
+}

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using ChartForgeX.Core;
 using ChartForgeX.Primitives;
+using ChartForgeX.Svg;
 
 namespace ChartForgeX.Tests;
 
@@ -28,11 +30,27 @@ internal static partial class SmokeTests {
         Assert(layout.Count == 4 && Math.Abs(layout.Width - 3) < 0.000001, "Histogram layouts should preserve the requested bin width.");
         Assert(chart.Series[0].Points.Select(point => point.Y).SequenceEqual(new[] { 2d, 2d, 1d, 2d }), "Histogram values should use the requested width when assigning bins.");
         Assert(chart.Options.XAxisLabels.Select(label => label.Text).SequenceEqual(new[] { "0-3", "3-6", "6-9", "9-10" }), "Histogram labels should retain full-width bins and a final remainder bin.");
+        var bars = SvgDocument.Parse(chart.ToSvg()).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        var firstWidth = double.Parse(bars[0].GetAttribute("width")!, CultureInfo.InvariantCulture);
+        var finalWidth = double.Parse(bars[3].GetAttribute("width")!, CultureInfo.InvariantCulture);
+        Assert(Math.Abs(finalWidth / firstWidth - 1.0 / 3.0) < 0.01, "Histogram geometry should render a shorter remainder bin in proportion to its numeric width.");
         var decimalLayout = ChartHistogramBinLayout.FromWidth(0, 0.07, 0.005);
         var remainderLayout = ChartHistogramBinLayout.FromWidth(0, 0.071, 0.005);
+        var tinyRemainderLayout = ChartHistogramBinLayout.FromWidth(0, 1.0000000000005, 1);
         Assert(decimalLayout.Count == 14, "Histogram layouts should not create a phantom bin when floating-point division is negligibly above an integer.");
         Assert(remainderLayout.Count == 15, "Histogram layouts should retain a final bin when the range has a real remainder.");
+        Assert(tinyRemainderLayout.Count == 2, "Histogram layouts should retain representable remainder bins beyond floating-point rounding noise.");
+        var boundaryLayout = ChartHistogramBinLayout.FromWidth(0.1, 0.5, 0.1);
+        var boundaryChart = Chart.Create().AddHistogram("Decimal boundaries", new[] { 0.1, 0.2, 0.3, 0.4, 0.5 }, boundaryLayout);
+        Assert(boundaryChart.Series[0].Points.Select(point => point.Y).SequenceEqual(new[] { 1d, 1d, 1d, 2d }), "Decimal values on exact bin boundaries should be assigned to the following bin.");
         AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromWidth(0, 10, 0), "Histogram layouts should reject zero bin widths.");
         AssertThrows<ArgumentOutOfRangeException>(() => Chart.Create().AddHistogram("Outside", new[] { 11d }, layout), "Shared histogram layouts should reject values outside their bounds.");
+    }
+
+    private static void SeriesKindCapabilitiesExposeExclusiveRenderingOwnership() {
+        Assert(ChartSeriesKindCapabilities.IsExclusive(ChartSeriesKind.Heatmap), "Shared kind capabilities should classify exclusive rendering surfaces.");
+        Assert(!ChartSeriesKindCapabilities.IsExclusive(ChartSeriesKind.Line), "Shared kind capabilities should keep cartesian line series non-exclusive.");
     }
 }

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -93,6 +93,39 @@ internal static partial class SmokeTests {
             .Where(element => element.GetAttribute("data-cfx-role") == "bar")
             .ToArray();
         Assert(narrowBars[2].GetAttribute("data-cfx-base") == "1", "Stacked bars should not match an earlier adjacent histogram bin merely because the bin width is below one millionth.");
+
+        var center = 1.5;
+        var centerBits = BitConverter.DoubleToInt64Bits(center);
+        var leftOfCenter = BitConverter.Int64BitsToDouble(centerBits - 3);
+        var rightOfCenter = BitConverter.Int64BitsToDouble(centerBits + 3);
+        var transitive = Chart.Create()
+            .WithStackedBars()
+            .AddHistogram("Center", new[] { center }, ChartHistogramBinLayout.FromWidth(1, 2, 1))
+            .AddBar("Left", new[] { new ChartPoint(leftOfCenter, 2) })
+            .AddBar("Right", new[] { new ChartPoint(rightOfCenter, 3) });
+        var transitiveBars = SvgDocument.Parse(transitive.ToSvg()).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        Assert(transitiveBars[2].GetAttribute("data-cfx-base") == "3", "Stacked bars canonicalized to one histogram center should include every earlier equivalent coordinate.");
+        Assert(transitive.ToPng().Length > 64, "Canonical mixed histogram stack coordinates should preserve PNG rendering parity.");
+
+        var constantLayout = ChartHistogramBinLayout.FromCount(5, 5, 1);
+        var constant = Chart.Create()
+            .WithSize(640, 360)
+            .AddHistogram("First constant", new[] { 5d, 5d }, constantLayout)
+            .AddHistogram("Second constant", new[] { 5d }, constantLayout)
+            .AddBar("Constant target", new[] { new ChartPoint(5, 3) });
+        var constantBars = SvgDocument.Parse(constant.ToSvg()).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        var firstConstantLeft = double.Parse(constantBars[0].GetAttribute("x")!, CultureInfo.InvariantCulture);
+        var firstConstantWidth = double.Parse(constantBars[0].GetAttribute("width")!, CultureInfo.InvariantCulture);
+        var secondConstantLeft = double.Parse(constantBars[1].GetAttribute("x")!, CultureInfo.InvariantCulture);
+        var secondConstantWidth = double.Parse(constantBars[1].GetAttribute("width")!, CultureInfo.InvariantCulture);
+        var regularConstantLeft = double.Parse(constantBars[2].GetAttribute("x")!, CultureInfo.InvariantCulture);
+        Assert(firstConstantLeft + firstConstantWidth <= secondConstantLeft + 0.001 && secondConstantLeft + secondConstantWidth <= regularConstantLeft + 0.001,
+            "Grouped constant-value histograms and regular bars should receive distinct slots.");
+        Assert(constant.ToPng().Length > 64, "Grouped constant-value histogram slots should preserve PNG rendering parity.");
     }
 
     private static void SeriesKindCapabilitiesExposeExclusiveRenderingOwnership() {

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -128,6 +128,25 @@ internal static partial class SmokeTests {
         Assert(CountOccurrences(equivalentSvg, "data-cfx-role=\"stack-total-label\"") == 1, "Equivalent histogram centers should emit one combined stack-total label.");
         Assert(equivalentLayouts.ToPng().Length > 64, "Equivalent histogram layout aggregation should preserve PNG rendering parity.");
 
+        var chainCenter = 1.5;
+        var chainBits = BitConverter.DoubleToInt64Bits(chainCenter);
+        var chainMiddle = BitConverter.Int64BitsToDouble(chainBits + 3);
+        var chainEnd = BitConverter.Int64BitsToDouble(chainBits + 6);
+        var chainedLayouts = Chart.Create()
+            .WithStackedBars()
+            .WithStackTotals()
+            .AddHistogram("Chain start", new[] { chainCenter }, ChartHistogramBinLayout.FromCount(0, chainCenter * 2, 1))
+            .AddHistogram("Chain middle", new[] { chainMiddle }, ChartHistogramBinLayout.FromCount(0, chainMiddle * 2, 1))
+            .AddHistogram("Chain end", new[] { chainEnd }, ChartHistogramBinLayout.FromCount(0, chainEnd * 2, 1));
+        var chainedSvg = chainedLayouts.ToSvg();
+        var chainedBars = SvgDocument.Parse(chainedSvg).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        Assert(chainedBars[2].GetAttribute("data-cfx-base") == "2", "Transitive coordinate chains should share one stable stacked base.");
+        Assert(ChartRange.FromChart(chainedLayouts).MaxY >= 3, "Transitive coordinate chains should share one range stack key.");
+        Assert(CountOccurrences(chainedSvg, "data-cfx-role=\"stack-total-label\"") == 1, "Transitive coordinate chains should emit one combined stack-total label.");
+        Assert(chainedLayouts.ToPng().Length > 64, "Transitive coordinate chain aggregation should preserve PNG rendering parity.");
+
         var constantLayout = ChartHistogramBinLayout.FromCount(5, 5, 1);
         var constant = Chart.Create()
             .WithSize(640, 360)

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -49,6 +49,9 @@ internal static partial class SmokeTests {
         var belowHalf = BitConverter.Int64BitsToDouble(BitConverter.DoubleToInt64Bits(0.5) - 1);
         var adjacentBoundaryChart = Chart.Create().AddHistogram("Adjacent boundary values", new[] { belowHalf, 0.5 }, ChartHistogramBinLayout.FromWidth(0, 1, 0.1));
         Assert(adjacentBoundaryChart.Series[0].Points[4].Y == 1 && adjacentBoundaryChart.Series[0].Points[5].Y == 1, "Histogram binning should preserve a representable value immediately below a boundary without moving it into the following bin.");
+        var subDecimalLayout = ChartHistogramBinLayout.FromCount(0, 1e-28, 2);
+        var subDecimalChart = Chart.Create().AddHistogram("Sub-decimal widths", new[] { 2e-29, 7e-29 }, subDecimalLayout);
+        Assert(subDecimalChart.Series[0].Points.Select(point => point.Y).SequenceEqual(new[] { 1d, 1d }), "Histogram widths below decimal precision should fall back to binary bin assignment without division by zero.");
         AssertThrows<ArgumentOutOfRangeException>(() => ChartHistogramBinLayout.FromWidth(0, 10, 0), "Histogram layouts should reject zero bin widths.");
         AssertThrows<ArgumentOutOfRangeException>(() => Chart.Create().AddHistogram("Outside", new[] { 11d }, layout), "Shared histogram layouts should reject values outside their bounds.");
     }
@@ -108,6 +111,22 @@ internal static partial class SmokeTests {
             .ToArray();
         Assert(transitiveBars[2].GetAttribute("data-cfx-base") == "3", "Stacked bars canonicalized to one histogram center should include every earlier equivalent coordinate.");
         Assert(transitive.ToPng().Length > 64, "Canonical mixed histogram stack coordinates should preserve PNG rendering parity.");
+
+        var countLayout = ChartHistogramBinLayout.FromCount(0, 0.3, 3);
+        var widthLayout = ChartHistogramBinLayout.FromWidth(0, 0.3, 0.1);
+        var equivalentLayouts = Chart.Create()
+            .WithStackedBars()
+            .WithStackTotals()
+            .AddHistogram("Count layout", new[] { 0.01 }, countLayout)
+            .AddHistogram("Width layout", new[] { 0.01 }, widthLayout);
+        var equivalentSvg = equivalentLayouts.ToSvg();
+        var equivalentBars = SvgDocument.Parse(equivalentSvg).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        Assert(equivalentBars[3].GetAttribute("data-cfx-base") == "1", "Equivalent independently-created histogram layouts should stack their matching bins.");
+        Assert(ChartRange.FromChart(equivalentLayouts).MaxY >= 2, "Equivalent histogram centers should share one range stack key.");
+        Assert(CountOccurrences(equivalentSvg, "data-cfx-role=\"stack-total-label\"") == 1, "Equivalent histogram centers should emit one combined stack-total label.");
+        Assert(equivalentLayouts.ToPng().Length > 64, "Equivalent histogram layout aggregation should preserve PNG rendering parity.");
 
         var constantLayout = ChartHistogramBinLayout.FromCount(5, 5, 1);
         var constant = Chart.Create()

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -147,6 +147,20 @@ internal static partial class SmokeTests {
         Assert(CountOccurrences(chainedSvg, "data-cfx-role=\"stack-total-label\"") == 1, "Transitive coordinate chains should emit one combined stack-total label.");
         Assert(chainedLayouts.ToPng().Length > 64, "Transitive coordinate chain aggregation should preserve PNG rendering parity.");
 
+        var groupedChain = Chart.Create()
+            .AddHistogram("Grouped chain start", new[] { chainCenter }, ChartHistogramBinLayout.FromCount(0, chainCenter * 2, 1))
+            .AddHistogram("Grouped chain middle", new[] { chainMiddle }, ChartHistogramBinLayout.FromCount(0, chainMiddle * 2, 1))
+            .AddHistogram("Grouped chain end", new[] { chainEnd }, ChartHistogramBinLayout.FromCount(0, chainEnd * 2, 1));
+        var groupedChainBars = SvgDocument.Parse(groupedChain.ToSvg()).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        var groupedChainLeft = groupedChainBars.Select(bar => double.Parse(bar.GetAttribute("x")!, CultureInfo.InvariantCulture)).ToArray();
+        var groupedChainWidth = groupedChainBars.Select(bar => double.Parse(bar.GetAttribute("width")!, CultureInfo.InvariantCulture)).ToArray();
+        Assert(groupedChainWidth.Max() - groupedChainWidth.Min() < 0.001, "Transitive grouped layouts should use one shared bar width.");
+        Assert(groupedChainLeft[0] + groupedChainWidth[0] <= groupedChainLeft[1] + 0.001 && groupedChainLeft[1] + groupedChainWidth[1] <= groupedChainLeft[2] + 0.001,
+            "Transitive grouped layouts should use stable non-overlapping positions.");
+        Assert(groupedChain.ToPng().Length > 64, "Transitive grouped layout geometry should preserve PNG rendering parity.");
+
         var adjacentMinimum = 1.0;
         var adjacentMaximum = BitConverter.Int64BitsToDouble(BitConverter.DoubleToInt64Bits(adjacentMinimum) + 8);
         var adjacentLayout = ChartHistogramBinLayout.FromCount(adjacentMinimum, adjacentMaximum, 2);
@@ -164,6 +178,27 @@ internal static partial class SmokeTests {
         Assert(ChartRange.FromChart(adjacentBins).MaxY >= 6, "Adjacent ultra-narrow bins should preserve their independent range totals.");
         Assert(CountOccurrences(adjacentSvg, "data-cfx-role=\"stack-total-label\"") == 2, "Adjacent ultra-narrow bins should emit independent stack-total labels.");
         Assert(adjacentBins.ToPng().Length > 64, "Adjacent ultra-narrow bins should preserve PNG rendering parity.");
+
+        var epsilonLayout = ChartHistogramBinLayout.FromCount(0, double.Epsilon * 8, 2);
+        var epsilonBoundary = double.Epsilon * 4;
+        var mixedBoundary = Chart.Create()
+            .WithStackedBars()
+            .AddHistogram("Epsilon bins", new[] { 0d, double.Epsilon * 8, double.Epsilon * 8 }, epsilonLayout)
+            .AddBar("Boundary target", new[] { new ChartPoint(epsilonBoundary, 3) });
+        var mixedBoundaryBars = SvgDocument.Parse(mixedBoundary.ToSvg()).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        Assert(mixedBoundaryBars[2].GetAttribute("data-cfx-base") == "1", "An ambiguous regular coordinate should stack with the same ultra-narrow bin used for geometry.");
+        Assert(mixedBoundaryBars[2].GetAttribute("x") == mixedBoundaryBars[0].GetAttribute("x") && mixedBoundaryBars[2].GetAttribute("width") == mixedBoundaryBars[0].GetAttribute("width"),
+            "Mixed ultra-narrow bar geometry should use the coordinate map's selected histogram slot.");
+        Assert(mixedBoundary.ToPng().Length > 64, "Mixed ultra-narrow slot identity should preserve PNG rendering parity.");
+
+        var reorderedHistogram = Chart.Create().AddHistogram("Reordered", new[] { 0d, 1d }, ChartHistogramBinLayout.FromCount(0, 1, 2));
+        reorderedHistogram.Series[0].Points.Reverse();
+        AssertThrows<InvalidOperationException>(() => reorderedHistogram.ToSvg(), "Histogram rendering should reject point order that no longer matches the stored layout.");
+        var resizedHistogram = Chart.Create().AddHistogram("Resized", new[] { 0d, 1d }, ChartHistogramBinLayout.FromCount(0, 1, 2));
+        resizedHistogram.Series[0].Points.RemoveAt(0);
+        AssertThrows<InvalidOperationException>(() => resizedHistogram.ToPng(), "Histogram rendering should reject point counts that no longer match the stored layout.");
 
         var constantLayout = ChartHistogramBinLayout.FromCount(5, 5, 1);
         var constant = Chart.Create()

--- a/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/HistogramTests.cs
@@ -147,6 +147,24 @@ internal static partial class SmokeTests {
         Assert(CountOccurrences(chainedSvg, "data-cfx-role=\"stack-total-label\"") == 1, "Transitive coordinate chains should emit one combined stack-total label.");
         Assert(chainedLayouts.ToPng().Length > 64, "Transitive coordinate chain aggregation should preserve PNG rendering parity.");
 
+        var adjacentMinimum = 1.0;
+        var adjacentMaximum = BitConverter.Int64BitsToDouble(BitConverter.DoubleToInt64Bits(adjacentMinimum) + 8);
+        var adjacentLayout = ChartHistogramBinLayout.FromCount(adjacentMinimum, adjacentMaximum, 2);
+        var adjacentBins = Chart.Create()
+            .WithStackedBars()
+            .WithStackTotals()
+            .AddHistogram("Adjacent first", new[] { adjacentMinimum, adjacentMaximum, adjacentMaximum }, adjacentLayout)
+            .AddHistogram("Adjacent second", new[] { adjacentMinimum, adjacentMinimum, adjacentMinimum, adjacentMaximum, adjacentMaximum, adjacentMaximum, adjacentMaximum }, adjacentLayout);
+        var adjacentSvg = adjacentBins.ToSvg();
+        var adjacentBars = SvgDocument.Parse(adjacentSvg).Root.FindByTag("rect")
+            .Where(element => element.GetAttribute("data-cfx-role") == "bar")
+            .ToArray();
+        Assert(adjacentBars[2].GetAttribute("data-cfx-base") == "1", "The first ultra-narrow bin should stack only with its corresponding prior bin.");
+        Assert(adjacentBars[3].GetAttribute("data-cfx-base") == "2", "The second ultra-narrow bin should remain distinct from its adjacent prior bin.");
+        Assert(ChartRange.FromChart(adjacentBins).MaxY >= 6, "Adjacent ultra-narrow bins should preserve their independent range totals.");
+        Assert(CountOccurrences(adjacentSvg, "data-cfx-role=\"stack-total-label\"") == 2, "Adjacent ultra-narrow bins should emit independent stack-total labels.");
+        Assert(adjacentBins.ToPng().Length > 64, "Adjacent ultra-narrow bins should preserve PNG rendering parity.");
+
         var constantLayout = ChartHistogramBinLayout.FromCount(5, 5, 1);
         var constant = Chart.Create()
             .WithSize(640, 360)

--- a/ChartForgeX.Tests/SmokeTests/LineMarkerTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/LineMarkerTests.cs
@@ -41,5 +41,21 @@ internal static partial class SmokeTests {
         var offset = (sampleY * width + sampleX) * 4;
         Assert(Math.Abs(pixels[offset] - color.R) <= 48 && Math.Abs(pixels[offset + 1] - color.G) <= 48 && Math.Abs(pixels[offset + 2] - color.B) <= 48,
             "A zero marker radius should not punch marker-outline holes through PNG line paths.");
+
+        var markedArea = Chart.Create()
+            .WithSize(320, 200)
+            .WithTheme(theme => theme.WithMarkerRadius(4))
+            .AddArea("Area", points, color);
+        var markerlessArea = Chart.Create()
+            .WithSize(320, 200)
+            .WithTheme(theme => theme.WithMarkerRadius(0))
+            .AddArea("Area", points, color);
+        Assert(!SvgDocument.Parse(markerlessArea.ToSvg()).Root.FindByTag("circle").Any(), "A markerless area should not advertise a point marker in its SVG legend.");
+        var markedAreaPixels = ReadPngRgba(markedArea.ToPng(), out var areaWidth, out var areaHeight);
+        var markerlessAreaPixels = ReadPngRgba(markerlessArea.ToPng(), out _, out _);
+        var legendTop = areaHeight * 3 / 4;
+        var markedLegendInk = CountNearColorInRect(markedAreaPixels, areaWidth, 0, legendTop, areaWidth, areaHeight - legendTop, color.R, color.G, color.B, 24);
+        var markerlessLegendInk = CountNearColorInRect(markerlessAreaPixels, areaWidth, 0, legendTop, areaWidth, areaHeight - legendTop, color.R, color.G, color.B, 24);
+        Assert(markerlessLegendInk < markedLegendInk, "A markerless area should omit the PNG legend marker while retaining its line symbol.");
     }
 }

--- a/ChartForgeX.Tests/SmokeTests/LineMarkerTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/LineMarkerTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Svg;
+
+namespace ChartForgeX.Tests;
+
+internal static partial class SmokeTests {
+    private static void ZeroMarkerRadiusSuppressesOptionalLineMarkers() {
+        var color = ChartColor.FromRgb(37, 99, 235);
+        var points = new[] { new ChartPoint(1, 10), new ChartPoint(2, 30), new ChartPoint(3, 20) };
+        var referenceSvg = Chart.Create()
+            .WithSize(320, 200)
+            .WithTheme(theme => theme.WithMarkerRadius(4))
+            .AddLine("Values", points, color)
+            .ToSvg();
+        var referenceMarkers = SvgDocument.Parse(referenceSvg).Root
+            .FindByTag("circle")
+            .Where(element => element.GetAttribute("data-cfx-role") == "line-marker")
+            .ToArray();
+        Assert(referenceMarkers.Length == points.Length, "Positive marker radii should preserve one SVG marker per line point.");
+
+        var markerless = Chart.Create()
+            .WithSize(320, 200)
+            .WithTheme(theme => theme.WithMarkerRadius(0))
+            .AddLine("Values", points, color);
+        var markerlessSvg = markerless.ToSvg();
+        Assert(!markerlessSvg.Contains("data-cfx-role=\"line-marker\"", StringComparison.Ordinal), "A zero marker radius should omit optional SVG line markers.");
+
+        var pixels = ReadPngRgba(markerless.ToPng(), out var width, out _);
+        var middleX = double.Parse(referenceMarkers[1].GetAttribute("cx")!, CultureInfo.InvariantCulture);
+        var middleY = double.Parse(referenceMarkers[1].GetAttribute("cy")!, CultureInfo.InvariantCulture);
+        var nextX = double.Parse(referenceMarkers[2].GetAttribute("cx")!, CultureInfo.InvariantCulture);
+        var nextY = double.Parse(referenceMarkers[2].GetAttribute("cy")!, CultureInfo.InvariantCulture);
+        var length = Math.Sqrt(Math.Pow(nextX - middleX, 2) + Math.Pow(nextY - middleY, 2));
+        var sampleX = (int)Math.Round(middleX + (nextX - middleX) / length);
+        var sampleY = (int)Math.Round(middleY + (nextY - middleY) / length);
+        var offset = (sampleY * width + sampleX) * 4;
+        Assert(Math.Abs(pixels[offset] - color.R) <= 48 && Math.Abs(pixels[offset + 1] - color.G) <= 48 && Math.Abs(pixels[offset + 2] - color.B) <= 48,
+            "A zero marker radius should not punch marker-outline holes through PNG line paths.");
+    }
+}

--- a/ChartForgeX.Tests/SmokeTests/LineMarkerTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/LineMarkerTests.cs
@@ -28,6 +28,7 @@ internal static partial class SmokeTests {
             .AddLine("Values", points, color);
         var markerlessSvg = markerless.ToSvg();
         Assert(!markerlessSvg.Contains("data-cfx-role=\"line-marker\"", StringComparison.Ordinal), "A zero marker radius should omit optional SVG line markers.");
+        Assert(!SvgDocument.Parse(markerlessSvg).Root.FindByTag("circle").Any(), "A markerless line should not advertise a point marker in its SVG legend.");
 
         var pixels = ReadPngRgba(markerless.ToPng(), out var width, out _);
         var middleX = double.Parse(referenceMarkers[1].GetAttribute("cx")!, CultureInfo.InvariantCulture);

--- a/ChartForgeX.Tests/SmokeTests/SpecializedChartTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/SpecializedChartTests.cs
@@ -8,19 +8,6 @@ using ChartForgeX.Primitives;
 namespace ChartForgeX.Tests;
 
 internal static partial class SmokeTests {
-    private static void HistogramValuesRenderAsBinnedBars() {
-        var chart = Chart.Create()
-            .WithSize(640, 360)
-            .WithDataLabels()
-            .AddHistogram("Latency samples", new[] { 1d, 2d, 2d, 3d, 5d }, 2, ChartColor.FromRgb(37, 99, 235));
-        var svg = chart.ToSvg();
-        Assert(CountOccurrences(svg, "data-cfx-role=\"bar\"") == 2, "Histogram values should render one bar per requested bin.");
-        Assert(svg.Contains(">1-3</text>", StringComparison.Ordinal), "Histogram bins should render range labels.");
-        Assert(svg.Contains(">3-5</text>", StringComparison.Ordinal), "Histogram bins should render range labels.");
-        Assert(svg.Contains(">3</text>", StringComparison.Ordinal), "Histogram data labels should render bin counts.");
-        Assert(chart.ToPng().Length > 64, "Histogram charts should render PNG output.");
-    }
-
     private static void LollipopSeriesRenderStemsAndMarkers() {
         var chart = Chart.Create()
             .WithSize(640, 360)

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -252,6 +252,7 @@ internal static partial class SmokeTests {
         ("Legend rows wrap without leaving the layout implicit", LegendRowsWrapWithRoleMarkers),
         ("Histogram values render as binned bars", HistogramValuesRenderAsBinnedBars),
         ("Histogram bin width preserves requested intervals", HistogramBinWidthPreservesRequestedIntervals),
+        ("Histogram bars group with regular bars", HistogramBarsGroupWithRegularBars),
         ("Series kind capabilities expose exclusive rendering ownership", SeriesKindCapabilitiesExposeExclusiveRenderingOwnership),
         ("Lollipop series render stems and markers", LollipopSeriesRenderStemsAndMarkers),
         ("Range bar series render intervals", RangeBarSeriesRenderIntervals),

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -251,6 +251,7 @@ internal static partial class SmokeTests {
         ("Default numeric compact formatter is shared", DefaultNumericCompactFormatterIsShared),
         ("Legend rows wrap without leaving the layout implicit", LegendRowsWrapWithRoleMarkers),
         ("Histogram values render as binned bars", HistogramValuesRenderAsBinnedBars),
+        ("Histogram bin width preserves requested intervals", HistogramBinWidthPreservesRequestedIntervals),
         ("Lollipop series render stems and markers", LollipopSeriesRenderStemsAndMarkers),
         ("Range bar series render intervals", RangeBarSeriesRenderIntervals),
         ("Box plot series render statistical summaries", BoxPlotSeriesRenderStatisticalSummaries),

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -252,6 +252,7 @@ internal static partial class SmokeTests {
         ("Legend rows wrap without leaving the layout implicit", LegendRowsWrapWithRoleMarkers),
         ("Histogram values render as binned bars", HistogramValuesRenderAsBinnedBars),
         ("Histogram bin width preserves requested intervals", HistogramBinWidthPreservesRequestedIntervals),
+        ("Series kind capabilities expose exclusive rendering ownership", SeriesKindCapabilitiesExposeExclusiveRenderingOwnership),
         ("Lollipop series render stems and markers", LollipopSeriesRenderStemsAndMarkers),
         ("Range bar series render intervals", RangeBarSeriesRenderIntervals),
         ("Box plot series render statistical summaries", BoxPlotSeriesRenderStatisticalSummaries),

--- a/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
+++ b/ChartForgeX.Tests/SmokeTests/TestCatalog.cs
@@ -144,6 +144,7 @@ internal static partial class SmokeTests {
         ("Line visual style is reusable and configurable", LineVisualStyleIsReusableAndConfigurable),
         ("Line visual style defaults stay crisp and glow is opt-in", LineVisualStyleDefaultsStayCrispAndGlowIsOptIn),
         ("PNG scatter does not connect points", PngScatterDoesNotConnectPoints),
+        ("Zero marker radius suppresses optional line markers", ZeroMarkerRadiusSuppressesOptionalLineMarkers),
         ("Step line series render as stair steps", StepLineSeriesRenderAsStairSteps),
         ("Step area series render as stair-step areas", StepAreaSeriesRenderAsStairStepAreas),
         ("Data labels render when enabled", DataLabelsRenderWhenEnabled),

--- a/ChartForgeX/Core/Chart.Histogram.cs
+++ b/ChartForgeX/Core/Chart.Histogram.cs
@@ -20,35 +20,50 @@ public sealed partial class Chart {
         if (binCount < 1) throw new ArgumentOutOfRangeException(nameof(binCount), binCount, "Histogram bin count must be at least one.");
 
         var materialized = values.ToArray();
-        if (materialized.Length == 0) throw new ArgumentException("Histogram values must contain at least one value.", nameof(values));
-        for (var i = 0; i < materialized.Length; i++) ChartGuards.Finite(materialized[i], nameof(values));
+        ValidateHistogramValues(materialized, nameof(values));
+        return AddHistogramCore(name, materialized, ChartHistogramBinLayout.FromCount(materialized.Min(), materialized.Max(), binCount), color);
+    }
 
-        var min = materialized.Min();
-        var max = materialized.Max();
-        if (Math.Abs(max - min) < 0.000001) {
-            Options.XAxisLabels.Clear();
-            Options.XAxisLabels.Add(new ChartAxisLabel(min, FormatHistogramNumber(min)));
-            return Add(name, ChartSeriesKind.Bar, new[] { new ChartPoint(min, materialized.Length) }, color);
-        }
+    /// <summary>
+    /// Adds a histogram series using a reusable layout, allowing multiple series to share exact bin bounds.
+    /// </summary>
+    /// <param name="name">The series name.</param>
+    /// <param name="values">The raw numeric values to bin.</param>
+    /// <param name="layout">The shared bin layout.</param>
+    /// <param name="color">An optional series color.</param>
+    /// <returns>The current chart.</returns>
+    public Chart AddHistogram(string name, IEnumerable<double> values, ChartHistogramBinLayout layout, ChartColor? color = null) {
+        if (values == null) throw new ArgumentNullException(nameof(values));
+        if (layout == null) throw new ArgumentNullException(nameof(layout));
 
-        var counts = new int[binCount];
-        var width = (max - min) / binCount;
-        foreach (var value in materialized) {
-            var index = value >= max ? binCount - 1 : (int)Math.Floor((value - min) / width);
-            counts[Math.Max(0, Math.Min(binCount - 1, index))]++;
-        }
+        var materialized = values.ToArray();
+        ValidateHistogramValues(materialized, nameof(values));
+        return AddHistogramCore(name, materialized, layout, color);
+    }
 
-        var points = new List<ChartPoint>(binCount);
+    private Chart AddHistogramCore(string name, double[] values, ChartHistogramBinLayout layout, ChartColor? color) {
+        var counts = new int[layout.Count];
+        foreach (var value in values) counts[layout.GetIndex(value)]++;
+
+        var points = new List<ChartPoint>(layout.Count);
         Options.XAxisLabels.Clear();
-        for (var i = 0; i < binCount; i++) {
-            var start = min + width * i;
-            var end = i == binCount - 1 ? max : start + width;
-            var center = start + (end - start) / 2.0;
+        for (var i = 0; i < layout.Count; i++) {
+            var start = layout.GetLowerBound(i);
+            var end = layout.GetUpperBound(i);
+            var center = layout.GetCenter(i);
             points.Add(new ChartPoint(center, counts[i]));
-            Options.XAxisLabels.Add(new ChartAxisLabel(center, FormatHistogramNumber(start) + "-" + FormatHistogramNumber(end)));
+            var label = layout.Minimum == layout.Maximum
+                ? FormatHistogramNumber(start)
+                : FormatHistogramNumber(start) + "-" + FormatHistogramNumber(end);
+            Options.XAxisLabels.Add(new ChartAxisLabel(center, label));
         }
 
         return Add(name, ChartSeriesKind.Bar, points, color);
+    }
+
+    private static void ValidateHistogramValues(double[] values, string parameterName) {
+        if (values.Length == 0) throw new ArgumentException("Histogram values must contain at least one value.", parameterName);
+        for (var i = 0; i < values.Length; i++) ChartGuards.Finite(values[i], parameterName);
     }
 
     private static string FormatHistogramNumber(double value) => value.ToString("0.###", CultureInfo.InvariantCulture);

--- a/ChartForgeX/Core/Chart.Histogram.cs
+++ b/ChartForgeX/Core/Chart.Histogram.cs
@@ -58,7 +58,9 @@ public sealed partial class Chart {
             Options.XAxisLabels.Add(new ChartAxisLabel(center, label));
         }
 
-        return Add(name, ChartSeriesKind.Bar, points, color);
+        Add(name, ChartSeriesKind.Bar, points, color);
+        Series[Series.Count - 1].HistogramBinLayout = layout;
+        return this;
     }
 
     private static void ValidateHistogramValues(double[] values, string parameterName) {

--- a/ChartForgeX/Core/ChartGuards.cs
+++ b/ChartForgeX/Core/ChartGuards.cs
@@ -104,6 +104,7 @@ internal static class ChartGuards {
     }
 
     private static void ValidateSeriesShape(ChartSeries series) {
+        if (series.HistogramBinLayout != null) ValidateHistogramSeries(series);
         if (series.Kind == ChartSeriesKind.Bubble) {
             ValidateTupleSeries(series, 2, "Bubble");
             for (var i = 0; i + 1 < series.Points.Count; i += 2) {
@@ -155,6 +156,19 @@ internal static class ChartGuards {
                 RequireSameX(minimum, q3, "Box plot summary points must share the same x value.");
                 RequireSameX(minimum, maximum, "Box plot summary points must share the same x value.");
                 if (minimum.Y > q1.Y || q1.Y > median.Y || median.Y > q3.Y || q3.Y > maximum.Y) throw new InvalidOperationException("Box plot values must be ordered as minimum <= q1 <= median <= q3 <= maximum.");
+            }
+        }
+    }
+
+    private static void ValidateHistogramSeries(ChartSeries series) {
+        var layout = series.HistogramBinLayout!;
+        if (series.Kind != ChartSeriesKind.Bar || series.Points.Count != layout.Count) {
+            throw new InvalidOperationException("Histogram series must retain exactly one bar point per layout bin.");
+        }
+
+        for (var index = 0; index < series.Points.Count; index++) {
+            if (series.Points[index].X != layout.GetCenter(index)) {
+                throw new InvalidOperationException("Histogram series points must retain their layout bin order and center coordinates.");
             }
         }
     }

--- a/ChartForgeX/Core/ChartHistogramBinLayout.cs
+++ b/ChartForgeX/Core/ChartHistogramBinLayout.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace ChartForgeX.Core;
+
+/// <summary>
+/// Defines one reusable histogram binning scheme so multiple series can share identical bounds.
+/// </summary>
+public sealed class ChartHistogramBinLayout {
+    private ChartHistogramBinLayout(double minimum, double maximum, int count, double width) {
+        Minimum = minimum;
+        Maximum = maximum;
+        Count = count;
+        Width = width;
+    }
+
+    /// <summary>Gets the inclusive minimum covered by the layout.</summary>
+    public double Minimum { get; }
+
+    /// <summary>Gets the inclusive maximum covered by the layout.</summary>
+    public double Maximum { get; }
+
+    /// <summary>Gets the number of bins.</summary>
+    public int Count { get; }
+
+    /// <summary>Gets the requested bin width. The final bin may be narrower when a remainder exists.</summary>
+    public double Width { get; }
+
+    /// <summary>Creates an equal-width layout with an exact bin count.</summary>
+    public static ChartHistogramBinLayout FromCount(double minimum, double maximum, int binCount) {
+        ValidateRange(minimum, maximum);
+        if (binCount < 1) throw new ArgumentOutOfRangeException(nameof(binCount), binCount, "Histogram bin count must be at least one.");
+        if (minimum == maximum) return new ChartHistogramBinLayout(minimum, maximum, 1, 0);
+
+        return new ChartHistogramBinLayout(minimum, maximum, binCount, (maximum - minimum) / binCount);
+    }
+
+    /// <summary>Creates a layout that preserves the requested width and uses a shorter final bin for any remainder.</summary>
+    public static ChartHistogramBinLayout FromWidth(double minimum, double maximum, double binWidth) {
+        ValidateRange(minimum, maximum);
+        ChartGuards.Finite(binWidth, nameof(binWidth));
+        if (binWidth <= 0) throw new ArgumentOutOfRangeException(nameof(binWidth), binWidth, "Histogram bin width must be greater than zero.");
+        if (minimum == maximum) return new ChartHistogramBinLayout(minimum, maximum, 1, binWidth);
+
+        var count = Math.Max(1, (int)Math.Ceiling((maximum - minimum) / binWidth));
+        return new ChartHistogramBinLayout(minimum, maximum, count, binWidth);
+    }
+
+    /// <summary>Gets the inclusive lower bound for a bin.</summary>
+    public double GetLowerBound(int index) {
+        ValidateIndex(index);
+        return Minimum + Width * index;
+    }
+
+    /// <summary>Gets the upper bound for a bin. The final bin includes this value.</summary>
+    public double GetUpperBound(int index) {
+        ValidateIndex(index);
+        return index == Count - 1 ? Maximum : Minimum + Width * (index + 1);
+    }
+
+    /// <summary>Gets the midpoint used for the bin's chart coordinate.</summary>
+    public double GetCenter(int index) {
+        var lower = GetLowerBound(index);
+        return lower + (GetUpperBound(index) - lower) / 2.0;
+    }
+
+    internal int GetIndex(double value) {
+        ChartGuards.Finite(value, nameof(value));
+        if (value < Minimum || value > Maximum) {
+            throw new ArgumentOutOfRangeException(nameof(value), value, "Histogram values must fall within the shared bin layout.");
+        }
+
+        if (Count == 1 || value >= Maximum) return Count - 1;
+        return Math.Max(0, Math.Min(Count - 1, (int)Math.Floor((value - Minimum) / Width)));
+    }
+
+    private static void ValidateRange(double minimum, double maximum) {
+        ChartGuards.Finite(minimum, nameof(minimum));
+        ChartGuards.Finite(maximum, nameof(maximum));
+        if (maximum < minimum) throw new ArgumentOutOfRangeException(nameof(maximum), maximum, "Histogram maximum must be greater than or equal to its minimum.");
+        if (double.IsInfinity(maximum - minimum)) throw new ArgumentOutOfRangeException(nameof(maximum), maximum, "Histogram range must be finite.");
+    }
+
+    private void ValidateIndex(int index) {
+        if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException(nameof(index), index, "Histogram bin index is outside the layout.");
+    }
+}

--- a/ChartForgeX/Core/ChartHistogramBinLayout.cs
+++ b/ChartForgeX/Core/ChartHistogramBinLayout.cs
@@ -41,7 +41,15 @@ public sealed class ChartHistogramBinLayout {
         if (binWidth <= 0) throw new ArgumentOutOfRangeException(nameof(binWidth), binWidth, "Histogram bin width must be greater than zero.");
         if (minimum == maximum) return new ChartHistogramBinLayout(minimum, maximum, 1, binWidth);
 
-        var count = Math.Max(1, (int)Math.Ceiling((maximum - minimum) / binWidth));
+        var quotient = (maximum - minimum) / binWidth;
+        var nearestInteger = Math.Round(quotient);
+        var tolerance = Math.Max(1d, Math.Abs(quotient)) * 1e-12;
+        if (Math.Abs(quotient - nearestInteger) <= tolerance) quotient = nearestInteger;
+        if (double.IsInfinity(quotient) || quotient > int.MaxValue) {
+            throw new ArgumentOutOfRangeException(nameof(binWidth), binWidth, "Histogram bin width produces too many bins.");
+        }
+
+        var count = Math.Max(1, (int)Math.Ceiling(quotient));
         return new ChartHistogramBinLayout(minimum, maximum, count, binWidth);
     }
 

--- a/ChartForgeX/Core/ChartHistogramBinLayout.cs
+++ b/ChartForgeX/Core/ChartHistogramBinLayout.cs
@@ -15,7 +15,8 @@ public sealed class ChartHistogramBinLayout {
         Maximum = maximum;
         Count = count;
         Width = width;
-        if (width > 0 && TryConvertRoundTripDecimal(minimum, out var decimalMinimum) && TryConvertRoundTripDecimal(width, out var decimalWidth)) {
+        if (width > 0 && TryConvertRoundTripDecimal(minimum, out var decimalMinimum) &&
+            TryConvertRoundTripDecimal(width, out var decimalWidth) && decimalWidth > 0) {
             _decimalMinimum = decimalMinimum;
             _decimalWidth = decimalWidth;
         }
@@ -90,7 +91,8 @@ public sealed class ChartHistogramBinLayout {
 
     private bool TryGetDecimalIndex(double value, out int index) {
         index = 0;
-        if (!_decimalMinimum.HasValue || !_decimalWidth.HasValue || !TryConvertRoundTripDecimal(value, out var decimalValue)) return false;
+        if (!_decimalMinimum.HasValue || !_decimalWidth.HasValue || _decimalWidth.Value <= 0 ||
+            !TryConvertRoundTripDecimal(value, out var decimalValue)) return false;
 
         try {
             var quotient = (decimalValue - _decimalMinimum.Value) / _decimalWidth.Value;

--- a/ChartForgeX/Core/ChartHistogramBinLayout.cs
+++ b/ChartForgeX/Core/ChartHistogramBinLayout.cs
@@ -41,10 +41,7 @@ public sealed class ChartHistogramBinLayout {
         if (binWidth <= 0) throw new ArgumentOutOfRangeException(nameof(binWidth), binWidth, "Histogram bin width must be greater than zero.");
         if (minimum == maximum) return new ChartHistogramBinLayout(minimum, maximum, 1, binWidth);
 
-        var quotient = (maximum - minimum) / binWidth;
-        var nearestInteger = Math.Round(quotient);
-        var tolerance = Math.Max(1d, Math.Abs(quotient)) * 1e-12;
-        if (Math.Abs(quotient - nearestInteger) <= tolerance) quotient = nearestInteger;
+        var quotient = NormalizeNearInteger((maximum - minimum) / binWidth);
         if (double.IsInfinity(quotient) || quotient > int.MaxValue) {
             throw new ArgumentOutOfRangeException(nameof(binWidth), binWidth, "Histogram bin width produces too many bins.");
         }
@@ -78,7 +75,8 @@ public sealed class ChartHistogramBinLayout {
         }
 
         if (Count == 1 || value >= Maximum) return Count - 1;
-        return Math.Max(0, Math.Min(Count - 1, (int)Math.Floor((value - Minimum) / Width)));
+        var quotient = NormalizeNearInteger((value - Minimum) / Width);
+        return Math.Max(0, Math.Min(Count - 1, (int)Math.Floor(quotient)));
     }
 
     private static void ValidateRange(double minimum, double maximum) {
@@ -86,6 +84,16 @@ public sealed class ChartHistogramBinLayout {
         ChartGuards.Finite(maximum, nameof(maximum));
         if (maximum < minimum) throw new ArgumentOutOfRangeException(nameof(maximum), maximum, "Histogram maximum must be greater than or equal to its minimum.");
         if (double.IsInfinity(maximum - minimum)) throw new ArgumentOutOfRangeException(nameof(maximum), maximum, "Histogram range must be finite.");
+    }
+
+    private static double NormalizeNearInteger(double value) {
+        if (double.IsNaN(value) || double.IsInfinity(value)) return value;
+        var nearestInteger = Math.Round(value);
+        var magnitude = Math.Max(1d, Math.Abs(value));
+        var bits = BitConverter.DoubleToInt64Bits(magnitude);
+        var next = BitConverter.Int64BitsToDouble(bits + 1);
+        var tolerance = (next - magnitude) * 4;
+        return Math.Abs(value - nearestInteger) <= tolerance ? nearestInteger : value;
     }
 
     private void ValidateIndex(int index) {

--- a/ChartForgeX/Core/ChartHistogramBinLayout.cs
+++ b/ChartForgeX/Core/ChartHistogramBinLayout.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace ChartForgeX.Core;
 
@@ -6,11 +7,18 @@ namespace ChartForgeX.Core;
 /// Defines one reusable histogram binning scheme so multiple series can share identical bounds.
 /// </summary>
 public sealed class ChartHistogramBinLayout {
+    private readonly decimal? _decimalMinimum;
+    private readonly decimal? _decimalWidth;
+
     private ChartHistogramBinLayout(double minimum, double maximum, int count, double width) {
         Minimum = minimum;
         Maximum = maximum;
         Count = count;
         Width = width;
+        if (width > 0 && TryConvertRoundTripDecimal(minimum, out var decimalMinimum) && TryConvertRoundTripDecimal(width, out var decimalWidth)) {
+            _decimalMinimum = decimalMinimum;
+            _decimalWidth = decimalWidth;
+        }
     }
 
     /// <summary>Gets the inclusive minimum covered by the layout.</summary>
@@ -75,9 +83,27 @@ public sealed class ChartHistogramBinLayout {
         }
 
         if (Count == 1 || value >= Maximum) return Count - 1;
-        var quotient = NormalizeNearInteger((value - Minimum) / Width);
+        if (TryGetDecimalIndex(value, out var decimalIndex)) return Math.Max(0, Math.Min(Count - 1, decimalIndex));
+        var quotient = (value - Minimum) / Width;
         return Math.Max(0, Math.Min(Count - 1, (int)Math.Floor(quotient)));
     }
+
+    private bool TryGetDecimalIndex(double value, out int index) {
+        index = 0;
+        if (!_decimalMinimum.HasValue || !_decimalWidth.HasValue || !TryConvertRoundTripDecimal(value, out var decimalValue)) return false;
+
+        try {
+            var quotient = (decimalValue - _decimalMinimum.Value) / _decimalWidth.Value;
+            if (quotient < 0 || quotient > int.MaxValue) return false;
+            index = decimal.ToInt32(decimal.Floor(quotient));
+            return true;
+        } catch (OverflowException) {
+            return false;
+        }
+    }
+
+    private static bool TryConvertRoundTripDecimal(double value, out decimal result) =>
+        decimal.TryParse(value.ToString("R", CultureInfo.InvariantCulture), NumberStyles.Float, CultureInfo.InvariantCulture, out result);
 
     private static void ValidateRange(double minimum, double maximum) {
         ChartGuards.Finite(minimum, nameof(minimum));

--- a/ChartForgeX/Core/ChartHistogramBinLayout.cs
+++ b/ChartForgeX/Core/ChartHistogramBinLayout.cs
@@ -7,6 +7,7 @@ namespace ChartForgeX.Core;
 /// Defines one reusable histogram binning scheme so multiple series can share identical bounds.
 /// </summary>
 public sealed class ChartHistogramBinLayout {
+    private const int MaximumBoundaryValidationScanCount = 1_000_000;
     private readonly decimal? _decimalMinimum;
     private readonly decimal? _decimalWidth;
 
@@ -40,7 +41,9 @@ public sealed class ChartHistogramBinLayout {
         if (binCount < 1) throw new ArgumentOutOfRangeException(nameof(binCount), binCount, "Histogram bin count must be at least one.");
         if (minimum == maximum) return new ChartHistogramBinLayout(minimum, maximum, 1, 0);
 
-        return new ChartHistogramBinLayout(minimum, maximum, binCount, (maximum - minimum) / binCount);
+        var width = (maximum - minimum) / binCount;
+        ValidateRepresentableBounds(minimum, maximum, binCount, width, nameof(binCount), binCount);
+        return new ChartHistogramBinLayout(minimum, maximum, binCount, width);
     }
 
     /// <summary>Creates a layout that preserves the requested width and uses a shorter final bin for any remainder.</summary>
@@ -56,6 +59,7 @@ public sealed class ChartHistogramBinLayout {
         }
 
         var count = Math.Max(1, (int)Math.Ceiling(quotient));
+        ValidateRepresentableBounds(minimum, maximum, count, binWidth, nameof(binWidth), binWidth);
         return new ChartHistogramBinLayout(minimum, maximum, count, binWidth);
     }
 
@@ -122,6 +126,47 @@ public sealed class ChartHistogramBinLayout {
         var next = BitConverter.Int64BitsToDouble(bits + 1);
         var tolerance = (next - magnitude) * 4;
         return Math.Abs(value - nearestInteger) <= tolerance ? nearestInteger : value;
+    }
+
+    private static void ValidateRepresentableBounds(double minimum, double maximum, int count, double width, string parameterName, object actualValue) {
+        if (count <= 1) return;
+        var finalLowerBound = minimum + width * (count - 1);
+        if (finalLowerBound >= maximum) {
+            throw new ArgumentOutOfRangeException(parameterName, actualValue,
+                "Histogram bins must have strictly increasing bounds representable by double values for the requested range.");
+        }
+
+        if (HasClearlySeparatedBounds(minimum, maximum, count, width)) return;
+        if (count > MaximumBoundaryValidationScanCount) {
+            throw new ArgumentOutOfRangeException(parameterName, actualValue,
+                "Histogram bin precision requires validating too many internal bounds; use fewer bins or a wider numeric range.");
+        }
+
+        var previous = minimum;
+        for (var index = 1; index < count; index++) {
+            var current = minimum + width * index;
+            if (current <= previous || current >= maximum) {
+                throw new ArgumentOutOfRangeException(parameterName, actualValue,
+                    "Histogram bins must have strictly increasing bounds representable by double values for the requested range.");
+            }
+
+            previous = current;
+        }
+    }
+
+    private static bool HasClearlySeparatedBounds(double minimum, double maximum, int count, double width) {
+        var lastOffset = width * (count - 1);
+        var productUlp = GetUpperUlp(Math.Abs(lastOffset));
+        var boundMagnitude = Math.Max(Math.Abs(minimum), Math.Abs(maximum));
+        var boundUlp = GetUpperUlp(boundMagnitude);
+        var errorBudget = productUlp + boundUlp;
+        return !double.IsInfinity(errorBudget) && width > errorBudget;
+    }
+
+    private static double GetUpperUlp(double magnitude) {
+        var bits = BitConverter.DoubleToInt64Bits(magnitude);
+        var next = BitConverter.Int64BitsToDouble(bits + 1);
+        return next - magnitude;
     }
 
     private void ValidateIndex(int index) {

--- a/ChartForgeX/Core/ChartSeries.cs
+++ b/ChartForgeX/Core/ChartSeries.cs
@@ -65,6 +65,11 @@ public sealed class ChartSeries {
     internal int? HeatmapColumnCount { get; set; }
 
     /// <summary>
+    /// Gets or sets the shared histogram layout whose numeric bounds determine this bar series geometry.
+    /// </summary>
+    internal ChartHistogramBinLayout? HistogramBinLayout { get; set; }
+
+    /// <summary>
     /// Gets optional point-level data labels. Null entries use the formatted point value.
     /// </summary>
     public List<string?> PointLabels { get; } = new();

--- a/ChartForgeX/Core/ChartSeriesKindCapabilities.cs
+++ b/ChartForgeX/Core/ChartSeriesKindCapabilities.cs
@@ -1,0 +1,13 @@
+namespace ChartForgeX.Core;
+
+/// <summary>
+/// Exposes reusable classification rules for chart series kinds to hosts and adapters.
+/// </summary>
+public static class ChartSeriesKindCapabilities {
+    /// <summary>
+    /// Determines whether a series kind owns the chart surface and cannot be combined with cartesian annotations or unrelated series.
+    /// </summary>
+    /// <param name="kind">The series kind to classify.</param>
+    /// <returns><see langword="true"/> when the kind uses an exclusive rendering surface; otherwise <see langword="false"/>.</returns>
+    public static bool IsExclusive(ChartSeriesKind kind) => ChartSeriesKindTraits.IsExclusive(kind);
+}

--- a/ChartForgeX/Core/ChartSeriesKindCapabilities.cs
+++ b/ChartForgeX/Core/ChartSeriesKindCapabilities.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ChartForgeX.Core;
 
 /// <summary>
@@ -9,5 +11,9 @@ public static class ChartSeriesKindCapabilities {
     /// </summary>
     /// <param name="kind">The series kind to classify.</param>
     /// <returns><see langword="true"/> when the kind uses an exclusive rendering surface; otherwise <see langword="false"/>.</returns>
-    public static bool IsExclusive(ChartSeriesKind kind) => ChartSeriesKindTraits.IsExclusive(kind);
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="kind"/> is not a defined series kind.</exception>
+    public static bool IsExclusive(ChartSeriesKind kind) {
+        if (!Enum.IsDefined(typeof(ChartSeriesKind), kind)) throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown chart series kind.");
+        return ChartSeriesKindTraits.IsExclusive(kind);
+    }
 }

--- a/ChartForgeX/Core/ChartSeriesKindTraits.cs
+++ b/ChartForgeX/Core/ChartSeriesKindTraits.cs
@@ -132,6 +132,12 @@ internal static class ChartSeriesKindTraits {
         kind == ChartSeriesKind.Polar ||
         kind == ChartSeriesKind.TrendLine;
 
+    public static bool UsesOptionalLineMarker(ChartSeriesKind kind) =>
+        kind == ChartSeriesKind.Line ||
+        kind == ChartSeriesKind.StepLine ||
+        kind == ChartSeriesKind.Area ||
+        kind == ChartSeriesKind.StepArea;
+
     public static bool ContainsKind(Chart chart, ChartSeriesKind kind) {
         foreach (var series in chart.Series) {
             if (series != null && series.Kind == kind) return true;

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -247,7 +247,7 @@ public sealed partial class PngChartRenderer {
         if (s.Kind != ChartSeriesKind.Scatter) {
             DrawPremiumPngLinePath(c, linePoints, color, s.StrokeWidth, chart.Options.LineVisualStyle);
         }
-        if (s.Kind == ChartSeriesKind.Scatter || (!chart.Options.IsSparkline && (s.Kind == ChartSeriesKind.Line || s.Kind == ChartSeriesKind.StepLine))) {
+        if (s.Kind == ChartSeriesKind.Scatter || (!chart.Options.IsSparkline && ChartSeriesKindTraits.UsesOptionalLineMarker(s.Kind))) {
             var markerRadius = s.Kind == ChartSeriesKind.Scatter ? Math.Max(ChartVisualPrimitives.ScatterMarkerMinRadius, chart.Options.Theme.MarkerRadius + ChartVisualPrimitives.ScatterMarkerRadiusExtra) : chart.Options.Theme.MarkerRadius;
             for (var pointIndex = 0; pointIndex < s.Points.Count; pointIndex++) {
                 var p = s.Points[pointIndex];

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -69,14 +69,19 @@ public sealed partial class PngChartRenderer {
                 var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? StackBaseValue(chart, index, p) : 0;
                 var y = map.Y(baseValue + p.Y);
                 var baseY = chart.Options.BarMode == ChartBarMode.Stacked ? map.YOrBaseline(baseValue) : zeroY;
-                var barX = map.X(p.X) + layout.Offset - layout.BarWidth / 2;
+                var barWidth = layout.BarWidth;
+                var barX = map.X(p.X) + layout.Offset - barWidth / 2;
+                if (ChartHistogramBarSlot.TryResolve(chart, index, pointIndex, map, out var histogramX, out var histogramWidth)) {
+                    barX = histogramX;
+                    barWidth = histogramWidth;
+                }
                 var barY = Math.Min(y, baseY);
                 var barHeight = Math.Abs(baseY - y);
-                var radius = chart.Options.BarMode == ChartBarMode.Stacked ? Math.Min(3, layout.BarWidth / 2) : Math.Min(7, layout.BarWidth / 2);
+                var radius = chart.Options.BarMode == ChartBarMode.Stacked ? Math.Min(3, barWidth / 2) : Math.Min(7, barWidth / 2);
                 if (chart.Options.BarVisualStyle.Kind == ChartBarStyle.SegmentedCapsule) {
-                    DrawSegmentedBar(c, chart.Options.BarVisualStyle, barX, barY, layout.BarWidth, barHeight, p.Y, PointColor(chart, s, index, pointIndex), FillPattern(s, pointIndex));
+                    DrawSegmentedBar(c, chart.Options.BarVisualStyle, barX, barY, barWidth, barHeight, p.Y, PointColor(chart, s, index, pointIndex), FillPattern(s, pointIndex));
                 } else {
-                    DrawGradientBar(c, barX, barY, layout.BarWidth, barHeight, radius, PointColor(chart, s, index, pointIndex), FillPattern(s, pointIndex));
+                    DrawGradientBar(c, barX, barY, barWidth, barHeight, radius, PointColor(chart, s, index, pointIndex), FillPattern(s, pointIndex));
                 }
                 if (ShouldDrawDataLabels(chart, s)) {
                     var label = FormatDataLabel(chart, s, pointIndex, p.Y);
@@ -85,7 +90,7 @@ public sealed partial class PngChartRenderer {
                     var placement = DataLabelPlacement(chart, s);
                     if (placement == ChartDataLabelPlacement.Left || placement == ChartDataLabelPlacement.Right) {
                         var labelWidth = EstimatePngEmphasizedTextWidth(label, fontSize);
-                        var labelX = placement == ChartDataLabelPlacement.Right ? barX + layout.BarWidth + 8 : barX - labelWidth - 8;
+                        var labelX = placement == ChartDataLabelPlacement.Right ? barX + barWidth + 8 : barX - labelWidth - 8;
                         var labelY = barY + segmentHeight / 2 - fontSize / 2.0;
                         if (!ReservePngLabel(label, labelX, labelY, chart, plot, fontSize, reservedLabels)) continue;
                         DrawReadablePngLabel(c, plot, labelX, labelY, label, chart.Options.Theme.Text, ReadableLabelHalo(chart), fontSize, DataLabelStyle(chart, s, pointIndex));
@@ -99,7 +104,7 @@ public sealed partial class PngChartRenderer {
                                 : inside
                                     ? barY + segmentHeight / 2 - fontSize / 2.0
                                     : p.Y >= 0 ? barY - 10 - fontSize : barY + segmentHeight + 10 - fontSize;
-                        var labelX = map.X(p.X) + layout.Offset - EstimatePngEmphasizedTextWidth(label, fontSize) / 2.0;
+                        var labelX = barX + barWidth / 2.0 - EstimatePngEmphasizedTextWidth(label, fontSize) / 2.0;
                         if (!ReservePngLabel(label, labelX, labelY, chart, plot, fontSize, reservedLabels)) continue;
                         DrawReadablePngLabel(c, plot, labelX, labelY, label, chart.Options.Theme.Text, ReadableLabelHalo(chart), fontSize, DataLabelStyle(chart, s, pointIndex));
                     }
@@ -465,7 +470,7 @@ public sealed partial class PngChartRenderer {
     private static BarLayoutInfo BarLayout(Chart chart, ChartRect plot, int seriesIndex) {
         var barSeries = new List<int>();
         for (var i = 0; i < chart.Series.Count; i++) {
-            if (chart.Series[i].Kind == ChartSeriesKind.Bar) barSeries.Add(i);
+            if (chart.Series[i].Kind == ChartSeriesKind.Bar && chart.Series[i].HistogramBinLayout == null) barSeries.Add(i);
         }
 
         var groupCount = chart.Options.BarMode == ChartBarMode.Stacked ? 1 : Math.Max(1, barSeries.Count);
@@ -511,6 +516,7 @@ public sealed partial class PngChartRenderer {
         for (var i = 0; i < seriesIndex; i++) {
             var series = chart.Series[i];
             if (series.Kind != ChartSeriesKind.Bar) continue;
+            if ((series.HistogramBinLayout == null) != (chart.Series[seriesIndex].HistogramBinLayout == null)) continue;
             foreach (var candidate in series.Points) {
                 if (Math.Abs(candidate.X - point.X) >= 0.000001) continue;
                 if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -516,7 +516,6 @@ public sealed partial class PngChartRenderer {
         for (var i = 0; i < seriesIndex; i++) {
             var series = chart.Series[i];
             if (series.Kind != ChartSeriesKind.Bar) continue;
-            if ((series.HistogramBinLayout == null) != (chart.Series[seriesIndex].HistogramBinLayout == null)) continue;
             foreach (var candidate in series.Points) {
                 if (Math.Abs(candidate.X - point.X) >= 0.000001) continue;
                 if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -427,6 +427,7 @@ public sealed partial class PngChartRenderer {
     }
 
     private static void DrawMarker(RgbaCanvas c, Chart chart, double x, double y, double radius, ChartColor color) {
+        if (radius <= 0) return;
         c.DrawCircle(x, y, radius + ChartVisualPrimitives.PngMarkerOutlineRadiusExtra, chart.Options.Theme.CardBackground);
         c.DrawCircle(x, y, radius, color);
     }

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -470,7 +470,9 @@ public sealed partial class PngChartRenderer {
     private static BarLayoutInfo BarLayout(Chart chart, ChartRect plot, int seriesIndex) {
         var barSeries = new List<int>();
         for (var i = 0; i < chart.Series.Count; i++) {
-            if (chart.Series[i].Kind == ChartSeriesKind.Bar && chart.Series[i].HistogramBinLayout == null) barSeries.Add(i);
+            var series = chart.Series[i];
+            if (series.Kind == ChartSeriesKind.Bar &&
+                (series.HistogramBinLayout == null || series.HistogramBinLayout.Minimum == series.HistogramBinLayout.Maximum)) barSeries.Add(i);
         }
 
         var groupCount = chart.Options.BarMode == ChartBarMode.Stacked ? 1 : Math.Max(1, barSeries.Count);

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -546,7 +546,10 @@ public sealed partial class PngChartRenderer {
         var negativeTotals = new Dictionary<double, double>();
         foreach (var series in chart.Series) {
             if (series.Kind != ChartSeriesKind.Bar) continue;
-            foreach (var point in series.Points) AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, point.X, point.Y);
+            foreach (var point in series.Points) {
+                var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, point.X);
+                AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
+            }
         }
 
         var reservedLabels = new List<ChartLabelBounds>();

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -66,7 +66,7 @@ public sealed partial class PngChartRenderer {
             var reservedLabels = new List<ChartLabelBounds>();
             for (var pointIndex = 0; pointIndex < s.Points.Count; pointIndex++) {
                 var p = s.Points[pointIndex];
-                var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? StackBaseValue(chart, index, p) : 0;
+                var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, index, p) : 0;
                 var y = map.Y(baseValue + p.Y);
                 var baseY = chart.Options.BarMode == ChartBarMode.Stacked ? map.YOrBaseline(baseValue) : zeroY;
                 var barWidth = layout.BarWidth;
@@ -509,21 +509,6 @@ public sealed partial class PngChartRenderer {
         var barHeight = Math.Max(3, Math.Min(30, (groupHeight - gap * (groupCount - 1)) / groupCount));
         var offset = (groupPosition - (groupCount - 1) / 2.0) * (barHeight + gap);
         return new HorizontalBarLayoutInfo(barHeight, offset);
-    }
-
-    private static double StackBaseValue(Chart chart, int seriesIndex, ChartPoint point) {
-        var sum = 0.0;
-        for (var i = 0; i < seriesIndex; i++) {
-            var series = chart.Series[i];
-            if (series.Kind != ChartSeriesKind.Bar) continue;
-            foreach (var candidate in series.Points) {
-                if (Math.Abs(candidate.X - point.X) >= 0.000001) continue;
-                if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;
-                break;
-            }
-        }
-
-        return sum;
     }
 
     private static double StackHorizontalBaseValue(Chart chart, int seriesIndex, ChartPoint point) {

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -66,7 +66,7 @@ public sealed partial class PngChartRenderer {
             var reservedLabels = new List<ChartLabelBounds>();
             for (var pointIndex = 0; pointIndex < s.Points.Count; pointIndex++) {
                 var p = s.Points[pointIndex];
-                var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, barCoordinateMap, index, p) : 0;
+                var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, barCoordinateMap, index, pointIndex) : 0;
                 var y = map.Y(baseValue + p.Y);
                 var baseY = chart.Options.BarMode == ChartBarMode.Stacked ? map.YOrBaseline(baseValue) : zeroY;
                 var barWidth = layout.BarWidth;
@@ -544,13 +544,15 @@ public sealed partial class PngChartRenderer {
     }
 
     private static void DrawStackTotals(RgbaCanvas c, Chart chart, ChartBarCoordinateMap barCoordinateMap, ChartRect plot, ChartMapper map) {
-        var positiveTotals = new Dictionary<double, double>();
-        var negativeTotals = new Dictionary<double, double>();
-        foreach (var series in chart.Series) {
+        var positiveTotals = new Dictionary<ChartBarCoordinateKey, double>();
+        var negativeTotals = new Dictionary<ChartBarCoordinateKey, double>();
+        for (var seriesIndex = 0; seriesIndex < chart.Series.Count; seriesIndex++) {
+            var series = chart.Series[seriesIndex];
             if (series.Kind != ChartSeriesKind.Bar) continue;
-            foreach (var point in series.Points) {
-                var coordinate = barCoordinateMap.Resolve(point.X);
-                AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
+            for (var pointIndex = 0; pointIndex < series.Points.Count; pointIndex++) {
+                var point = series.Points[pointIndex];
+                var coordinate = barCoordinateMap.Resolve(seriesIndex, pointIndex);
+                AddBarStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
             }
         }
 
@@ -586,13 +588,13 @@ public sealed partial class PngChartRenderer {
         }
     }
 
-    private static void DrawStackTotalSet(RgbaCanvas c, Chart chart, ChartRect plot, ChartMapper map, Dictionary<double, double> totals, double offset, List<ChartLabelBounds> reservedLabels) {
+    private static void DrawStackTotalSet(RgbaCanvas c, Chart chart, ChartRect plot, ChartMapper map, Dictionary<ChartBarCoordinateKey, double> totals, double offset, List<ChartLabelBounds> reservedLabels) {
         foreach (var item in totals) {
             if (Math.Abs(item.Value) < 0.000001) continue;
             var label = FormatValue(chart, item.Value);
             var fontSize = chart.Options.Theme.DataLabelFontSize;
             var width = EstimatePngEmphasizedTextWidth(label, fontSize);
-            var x = Clamp(map.X(item.Key) - width / 2.0, plot.Left + 2, plot.Right - width - 2);
+            var x = Clamp(map.X(item.Key.Value) - width / 2.0, plot.Left + 2, plot.Right - width - 2);
             var y = Clamp(map.Y(item.Value) + offset - fontSize / 2.0, plot.Top + 2, plot.Bottom - fontSize - 2);
             if (!ReservePngLabel(label, x, y, chart, plot, fontSize, reservedLabels)) continue;
             DrawReadablePngLabel(c, x, y, label, chart.Options.Theme.Text, ReadableLabelHalo(chart), fontSize);
@@ -625,5 +627,10 @@ public sealed partial class PngChartRenderer {
         public double BarHeight { get; }
 
         public double Offset { get; }
+    }
+
+    private static void AddBarStackTotal(Dictionary<ChartBarCoordinateKey, double> totals, ChartBarCoordinateKey coordinate, double value) {
+        totals.TryGetValue(coordinate, out var current);
+        totals[coordinate] = current + value;
     }
 }

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -7,7 +7,7 @@ using ChartForgeX.Rendering;
 namespace ChartForgeX.Raster;
 
 public sealed partial class PngChartRenderer {
-    private static void DrawSeries(RgbaCanvas c, Chart chart, int index, ChartRect plot, ChartMapper map) {
+    private static void DrawSeries(RgbaCanvas c, Chart chart, ChartBarCoordinateMap barCoordinateMap, int index, ChartRect plot, ChartMapper map) {
         var s = chart.Series[index]; var color = SeriesColor(chart, index);
         if (s.Kind == ChartSeriesKind.HorizontalBar) {
             var layout = HorizontalBarLayout(chart, plot, index);
@@ -66,7 +66,7 @@ public sealed partial class PngChartRenderer {
             var reservedLabels = new List<ChartLabelBounds>();
             for (var pointIndex = 0; pointIndex < s.Points.Count; pointIndex++) {
                 var p = s.Points[pointIndex];
-                var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, index, p) : 0;
+                var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, barCoordinateMap, index, p) : 0;
                 var y = map.Y(baseValue + p.Y);
                 var baseY = chart.Options.BarMode == ChartBarMode.Stacked ? map.YOrBaseline(baseValue) : zeroY;
                 var barWidth = layout.BarWidth;
@@ -543,13 +543,13 @@ public sealed partial class PngChartRenderer {
         return sum;
     }
 
-    private static void DrawStackTotals(RgbaCanvas c, Chart chart, ChartRect plot, ChartMapper map) {
+    private static void DrawStackTotals(RgbaCanvas c, Chart chart, ChartBarCoordinateMap barCoordinateMap, ChartRect plot, ChartMapper map) {
         var positiveTotals = new Dictionary<double, double>();
         var negativeTotals = new Dictionary<double, double>();
         foreach (var series in chart.Series) {
             if (series.Kind != ChartSeriesKind.Bar) continue;
             foreach (var point in series.Points) {
-                var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, point.X);
+                var coordinate = barCoordinateMap.Resolve(point.X);
                 AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
             }
         }

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -549,7 +549,7 @@ public sealed partial class PngChartRenderer {
         foreach (var series in chart.Series) {
             if (series.Kind != ChartSeriesKind.Bar) continue;
             foreach (var point in series.Points) {
-                var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, point.X);
+                var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, point.X);
                 AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
             }
         }

--- a/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Cartesian.cs
@@ -71,7 +71,7 @@ public sealed partial class PngChartRenderer {
                 var baseY = chart.Options.BarMode == ChartBarMode.Stacked ? map.YOrBaseline(baseValue) : zeroY;
                 var barWidth = layout.BarWidth;
                 var barX = map.X(p.X) + layout.Offset - barWidth / 2;
-                if (ChartHistogramBarSlot.TryResolve(chart, index, pointIndex, map, out var histogramX, out var histogramWidth)) {
+                if (ChartHistogramBarSlot.TryResolve(chart, barCoordinateMap, index, pointIndex, map, out var histogramX, out var histogramWidth)) {
                     barX = histogramX;
                     barWidth = histogramWidth;
                 }

--- a/ChartForgeX/Raster/PngChartRenderer.Legend.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Legend.cs
@@ -20,7 +20,7 @@ public sealed partial class PngChartRenderer {
             var x = PngLegendRowX(chart, area, row.Width);
             foreach (var item in row.Items) {
                 var itemX = x + item.X;
-                DrawLegendSymbol(c, chart.Series[item.SeriesIndex].Kind, itemX, y - 5, item.Color, theme.CardBackground);
+                DrawLegendSymbol(c, chart.Series[item.SeriesIndex].Kind, itemX, y - 5, item.Color, theme.CardBackground, chart.Options.Theme.MarkerRadius > 0);
                 var labelMaxWidth = System.Math.Max(8, item.Width - symbolWidth - 14);
                 var labelFontSize = TextFontSizeForEmphasizedWidth(item.Label, labelMaxWidth, fontSize);
                 var label = TrimReadablePngLabelToWidth(item.Label, labelFontSize, labelMaxWidth);
@@ -243,11 +243,13 @@ public sealed partial class PngChartRenderer {
         public ChartColor Color { get; }
     }
 
-    private static void DrawLegendSymbol(RgbaCanvas c, ChartSeriesKind kind, double x, double y, ChartColor color, ChartColor background) {
+    private static void DrawLegendSymbol(RgbaCanvas c, ChartSeriesKind kind, double x, double y, ChartColor color, ChartColor background, bool showOptionalLineMarker) {
         if (IsLineLikeLegend(kind)) {
             c.DrawLine(x, y, x + 18, y, color, ChartVisualPrimitives.LegendLineStrokeWidth);
-            c.DrawCircle(x + 9, y, ChartVisualPrimitives.PngLegendMarkerOutlineRadius, background);
-            c.DrawCircle(x + 9, y, ChartVisualPrimitives.PngLegendLineMarkerRadius, color);
+            if (!UsesOptionalLineMarker(kind) || showOptionalLineMarker) {
+                c.DrawCircle(x + 9, y, ChartVisualPrimitives.PngLegendMarkerOutlineRadius, background);
+                c.DrawCircle(x + 9, y, ChartVisualPrimitives.PngLegendLineMarkerRadius, color);
+            }
         } else if (kind == ChartSeriesKind.Scatter || kind == ChartSeriesKind.Bubble) {
             c.DrawCircle(x + 9, y, ChartVisualPrimitives.PngLegendMarkerOutlineRadius, background);
             c.DrawCircle(x + 9, y, ChartVisualPrimitives.LegendMarkerRadius, color);
@@ -258,4 +260,6 @@ public sealed partial class PngChartRenderer {
             c.FillRoundedRect(x, y - ChartVisualPrimitives.LegendSwatchSize / 2, ChartVisualPrimitives.LegendSwatchSize, ChartVisualPrimitives.LegendSwatchSize, ChartVisualPrimitives.LegendSwatchRadius, color);
         }
     }
+
+    private static bool UsesOptionalLineMarker(ChartSeriesKind kind) => kind == ChartSeriesKind.Line || kind == ChartSeriesKind.StepLine;
 }

--- a/ChartForgeX/Raster/PngChartRenderer.Legend.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.Legend.cs
@@ -246,7 +246,7 @@ public sealed partial class PngChartRenderer {
     private static void DrawLegendSymbol(RgbaCanvas c, ChartSeriesKind kind, double x, double y, ChartColor color, ChartColor background, bool showOptionalLineMarker) {
         if (IsLineLikeLegend(kind)) {
             c.DrawLine(x, y, x + 18, y, color, ChartVisualPrimitives.LegendLineStrokeWidth);
-            if (!UsesOptionalLineMarker(kind) || showOptionalLineMarker) {
+            if (!ChartSeriesKindTraits.UsesOptionalLineMarker(kind) || showOptionalLineMarker) {
                 c.DrawCircle(x + 9, y, ChartVisualPrimitives.PngLegendMarkerOutlineRadius, background);
                 c.DrawCircle(x + 9, y, ChartVisualPrimitives.PngLegendLineMarkerRadius, color);
             }
@@ -260,6 +260,4 @@ public sealed partial class PngChartRenderer {
             c.FillRoundedRect(x, y - ChartVisualPrimitives.LegendSwatchSize / 2, ChartVisualPrimitives.LegendSwatchSize, ChartVisualPrimitives.LegendSwatchSize, ChartVisualPrimitives.LegendSwatchRadius, color);
         }
     }
-
-    private static bool UsesOptionalLineMarker(ChartSeriesKind kind) => kind == ChartSeriesKind.Line || kind == ChartSeriesKind.StepLine;
 }

--- a/ChartForgeX/Raster/PngChartRenderer.cs
+++ b/ChartForgeX/Raster/PngChartRenderer.cs
@@ -162,7 +162,8 @@ public sealed partial class PngChartRenderer {
                 DrawSpecialChart(DrawSunburst);
                 return c;
             }
-            var range = ChartRange.FromChart(chart);
+            var barCoordinateMap = ChartBarCoordinateMap.Create(chart);
+            var range = ChartRange.FromChart(chart, barCoordinateMap);
             IReadOnlyList<double> yTicks;
             IReadOnlyList<double> xTicks;
             ChartRange? secondaryRange = null;
@@ -196,7 +197,7 @@ public sealed partial class PngChartRenderer {
             var secondaryMap = secondaryRange == null ? null : new ChartMapper(plot, secondaryRange, o.XAxis, o.SecondaryYAxis);
             if (IsHorizontalBarChart(chart)) {
                 DrawHorizontalBarGrid(c, chart, plot, map, xTicks, yTicks);
-                for (var i = 0; i < chart.Series.Count; i++) DrawSeries(c, chart, i, plot, map);
+                for (var i = 0; i < chart.Series.Count; i++) DrawSeries(c, chart, barCoordinateMap, i, plot, map);
                 if (o.BarMode == ChartBarMode.Stacked && o.ShowStackTotals) DrawHorizontalStackTotals(c, chart, plot, map);
                 DrawLegend(c, chart);
                 return c;
@@ -236,8 +237,8 @@ public sealed partial class PngChartRenderer {
             if (chart.Options.ShowAxes) {
                 if (secondaryMap != null && secondaryTicks != null) DrawSecondaryYAxis(c, chart, plot, secondaryMap, secondaryTicks);
             }
-            for (var i = 0; i < chart.Series.Count; i++) DrawSeries(c, chart, i, plot, SeriesMap(chart.Series[i], map, secondaryMap));
-            if (o.BarMode == ChartBarMode.Stacked && o.ShowStackTotals) DrawStackTotals(c, chart, plot, map);
+            for (var i = 0; i < chart.Series.Count; i++) DrawSeries(c, chart, barCoordinateMap, i, plot, SeriesMap(chart.Series[i], map, secondaryMap));
+            if (o.BarMode == ChartBarMode.Stacked && o.ShowStackTotals) DrawStackTotals(c, chart, barCoordinateMap, plot, map);
             DrawAnnotationLines(c, chart, plot, map);
             DrawLegend(c, chart);
             return c;

--- a/ChartForgeX/Rendering/ChartBarCoordinateMap.cs
+++ b/ChartForgeX/Rendering/ChartBarCoordinateMap.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using ChartForgeX.Core;
+
+namespace ChartForgeX.Rendering;
+
+/// <summary>
+/// Assigns one stable, transitive coordinate key to numerically equivalent vertical bar points.
+/// The map is built once per chart operation so stacking, range calculation, and total labels
+/// share the same identity without repeatedly scanning histogram layouts.
+/// </summary>
+internal sealed class ChartBarCoordinateMap {
+    private readonly Dictionary<double, double> _canonicalCoordinates;
+
+    private ChartBarCoordinateMap(Dictionary<double, double> canonicalCoordinates) {
+        _canonicalCoordinates = canonicalCoordinates;
+    }
+
+    internal static ChartBarCoordinateMap Create(Chart chart) {
+        var coordinates = chart.Series
+            .Where(series => series.Kind == ChartSeriesKind.Bar)
+            .SelectMany(series => series.Points.Select(point => point.X))
+            .Distinct()
+            .OrderBy(value => value)
+            .ToArray();
+        var canonicalCoordinates = new Dictionary<double, double>(coordinates.Length);
+        if (coordinates.Length == 0) return new ChartBarCoordinateMap(canonicalCoordinates);
+
+        var canonical = coordinates[0];
+        canonicalCoordinates[canonical] = canonical;
+        for (var index = 1; index < coordinates.Length; index++) {
+            if (!ChartMath.SameCoordinate(coordinates[index - 1], coordinates[index])) canonical = coordinates[index];
+            canonicalCoordinates[coordinates[index]] = canonical;
+        }
+
+        return new ChartBarCoordinateMap(canonicalCoordinates);
+    }
+
+    internal double Resolve(double coordinate) =>
+        _canonicalCoordinates.TryGetValue(coordinate, out var canonical) ? canonical : coordinate;
+}

--- a/ChartForgeX/Rendering/ChartBarCoordinateMap.cs
+++ b/ChartForgeX/Rendering/ChartBarCoordinateMap.cs
@@ -12,15 +12,20 @@ namespace ChartForgeX.Rendering;
 /// </summary>
 internal sealed class ChartBarCoordinateMap {
     private readonly ChartBarCoordinateKey[][] _keys;
+    private readonly Dictionary<int, HistogramSlot> _histogramSlots;
+    private readonly Dictionary<int, int[]> _seriesIndices;
 
-    private ChartBarCoordinateMap(ChartBarCoordinateKey[][] keys) {
+    private ChartBarCoordinateMap(ChartBarCoordinateKey[][] keys, Dictionary<int, HistogramSlot> histogramSlots, Dictionary<int, int[]> seriesIndices) {
         _keys = keys;
+        _histogramSlots = histogramSlots;
+        _seriesIndices = seriesIndices;
     }
 
     internal static ChartBarCoordinateMap Create(Chart chart) {
         var keys = chart.Series.Select(series => new ChartBarCoordinateKey[series.Points.Count]).ToArray();
         var nodes = CreateNodes(chart).OrderBy(node => node.Coordinate).ThenBy(node => node.SeriesIndex).ThenBy(node => node.PointIndex).ToArray();
         var activeGroups = new List<CoordinateGroup>();
+        var allGroups = new List<CoordinateGroup>();
         var nextId = 0;
         foreach (var node in nodes) {
             activeGroups.RemoveAll(group => !ChartMath.SameCoordinate(group.LastCoordinate, node.Coordinate));
@@ -28,16 +33,35 @@ internal sealed class ChartBarCoordinateMap {
             if (group == null) {
                 group = new CoordinateGroup(new ChartBarCoordinateKey(nextId++, node.Coordinate));
                 activeGroups.Add(group);
+                allGroups.Add(group);
             }
 
             group.Add(node);
             keys[node.SeriesIndex][node.PointIndex] = group.Key;
         }
 
-        return new ChartBarCoordinateMap(keys);
+        var histogramSlots = allGroups
+            .Where(group => group.RepresentativeHistogramNode.HasValue)
+            .ToDictionary(group => group.Key.Id, group => new HistogramSlot(group.RepresentativeHistogramNode!.Value.Layout!, group.RepresentativeHistogramNode.Value.BinIndex));
+        var seriesIndices = allGroups.ToDictionary(group => group.Key.Id, group => group.SeriesIndices.OrderBy(index => index).ToArray());
+        return new ChartBarCoordinateMap(keys, histogramSlots, seriesIndices);
     }
 
     internal ChartBarCoordinateKey Resolve(int seriesIndex, int pointIndex) => _keys[seriesIndex][pointIndex];
+
+    internal IReadOnlyList<int> SeriesIndices(int seriesIndex, int pointIndex) => _seriesIndices[Resolve(seriesIndex, pointIndex).Id];
+
+    internal bool TryResolveHistogramSlot(int seriesIndex, int pointIndex, out ChartHistogramBinLayout layout, out int binIndex) {
+        if (_histogramSlots.TryGetValue(Resolve(seriesIndex, pointIndex).Id, out var slot)) {
+            layout = slot.Layout;
+            binIndex = slot.BinIndex;
+            return true;
+        }
+
+        layout = null!;
+        binIndex = -1;
+        return false;
+    }
 
     private static IEnumerable<CoordinateNode> CreateNodes(Chart chart) {
         for (var seriesIndex = 0; seriesIndex < chart.Series.Count; seriesIndex++) {
@@ -79,10 +103,17 @@ internal sealed class ChartBarCoordinateMap {
 
         internal double LastCoordinate { get; private set; }
 
+        internal IEnumerable<int> SeriesIndices => _seriesIndices;
+
+        internal CoordinateNode? RepresentativeHistogramNode { get; private set; }
+
         internal void Add(CoordinateNode node) {
             _seriesIndices.Add(node.SeriesIndex);
             LastCoordinate = node.Coordinate;
-            if (node.Layout != null) _lastHistogramNode = node;
+            if (node.Layout != null) {
+                if (!RepresentativeHistogramNode.HasValue) RepresentativeHistogramNode = node;
+                _lastHistogramNode = node;
+            }
         }
 
         internal bool TryGetCompatibility(CoordinateNode node, out int rank, out double distance) {
@@ -122,6 +153,16 @@ internal sealed class ChartBarCoordinateMap {
         internal int PointIndex { get; }
         internal double Coordinate { get; }
         internal ChartHistogramBinLayout? Layout { get; }
+        internal int BinIndex { get; }
+    }
+
+    private readonly struct HistogramSlot {
+        internal HistogramSlot(ChartHistogramBinLayout layout, int binIndex) {
+            Layout = layout;
+            BinIndex = binIndex;
+        }
+
+        internal ChartHistogramBinLayout Layout { get; }
         internal int BinIndex { get; }
     }
 

--- a/ChartForgeX/Rendering/ChartBarCoordinateMap.cs
+++ b/ChartForgeX/Rendering/ChartBarCoordinateMap.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ChartForgeX.Core;
@@ -5,37 +6,148 @@ using ChartForgeX.Core;
 namespace ChartForgeX.Rendering;
 
 /// <summary>
-/// Assigns one stable, transitive coordinate key to numerically equivalent vertical bar points.
-/// The map is built once per chart operation so stacking, range calculation, and total labels
-/// share the same identity without repeatedly scanning histogram layouts.
+/// Assigns one stable coordinate key to corresponding vertical bar points while preserving
+/// distinct histogram bins. The map is built once per chart operation so stacking, range
+/// calculation, and total labels share the same identity without repeated layout scans.
 /// </summary>
 internal sealed class ChartBarCoordinateMap {
-    private readonly Dictionary<double, double> _canonicalCoordinates;
+    private readonly ChartBarCoordinateKey[][] _keys;
 
-    private ChartBarCoordinateMap(Dictionary<double, double> canonicalCoordinates) {
-        _canonicalCoordinates = canonicalCoordinates;
+    private ChartBarCoordinateMap(ChartBarCoordinateKey[][] keys) {
+        _keys = keys;
     }
 
     internal static ChartBarCoordinateMap Create(Chart chart) {
-        var coordinates = chart.Series
-            .Where(series => series.Kind == ChartSeriesKind.Bar)
-            .SelectMany(series => series.Points.Select(point => point.X))
-            .Distinct()
-            .OrderBy(value => value)
-            .ToArray();
-        var canonicalCoordinates = new Dictionary<double, double>(coordinates.Length);
-        if (coordinates.Length == 0) return new ChartBarCoordinateMap(canonicalCoordinates);
+        var keys = chart.Series.Select(series => new ChartBarCoordinateKey[series.Points.Count]).ToArray();
+        var nodes = CreateNodes(chart).OrderBy(node => node.Coordinate).ThenBy(node => node.SeriesIndex).ThenBy(node => node.PointIndex).ToArray();
+        var activeGroups = new List<CoordinateGroup>();
+        var nextId = 0;
+        foreach (var node in nodes) {
+            activeGroups.RemoveAll(group => !ChartMath.SameCoordinate(group.LastCoordinate, node.Coordinate));
+            var group = FindBestGroup(activeGroups, node);
+            if (group == null) {
+                group = new CoordinateGroup(new ChartBarCoordinateKey(nextId++, node.Coordinate));
+                activeGroups.Add(group);
+            }
 
-        var canonical = coordinates[0];
-        canonicalCoordinates[canonical] = canonical;
-        for (var index = 1; index < coordinates.Length; index++) {
-            if (!ChartMath.SameCoordinate(coordinates[index - 1], coordinates[index])) canonical = coordinates[index];
-            canonicalCoordinates[coordinates[index]] = canonical;
+            group.Add(node);
+            keys[node.SeriesIndex][node.PointIndex] = group.Key;
         }
 
-        return new ChartBarCoordinateMap(canonicalCoordinates);
+        return new ChartBarCoordinateMap(keys);
     }
 
-    internal double Resolve(double coordinate) =>
-        _canonicalCoordinates.TryGetValue(coordinate, out var canonical) ? canonical : coordinate;
+    internal ChartBarCoordinateKey Resolve(int seriesIndex, int pointIndex) => _keys[seriesIndex][pointIndex];
+
+    private static IEnumerable<CoordinateNode> CreateNodes(Chart chart) {
+        for (var seriesIndex = 0; seriesIndex < chart.Series.Count; seriesIndex++) {
+            var series = chart.Series[seriesIndex];
+            if (series.Kind != ChartSeriesKind.Bar) continue;
+            for (var pointIndex = 0; pointIndex < series.Points.Count; pointIndex++) {
+                var layout = series.HistogramBinLayout;
+                var isHistogramBin = layout != null && layout.Minimum != layout.Maximum && pointIndex < layout.Count;
+                yield return new CoordinateNode(seriesIndex, pointIndex, series.Points[pointIndex].X, isHistogramBin ? layout : null, pointIndex);
+            }
+        }
+    }
+
+    private static CoordinateGroup? FindBestGroup(List<CoordinateGroup> groups, CoordinateNode node) {
+        CoordinateGroup? best = null;
+        var bestRank = int.MaxValue;
+        var bestDistance = double.PositiveInfinity;
+        foreach (var group in groups) {
+            if (!group.TryGetCompatibility(node, out var rank, out var distance)) continue;
+            if (rank > bestRank || rank == bestRank && distance >= bestDistance) continue;
+            best = group;
+            bestRank = rank;
+            bestDistance = distance;
+        }
+
+        return best;
+    }
+
+    private sealed class CoordinateGroup {
+        private readonly HashSet<int> _seriesIndices = new HashSet<int>();
+        private CoordinateNode? _lastHistogramNode;
+
+        internal CoordinateGroup(ChartBarCoordinateKey key) {
+            Key = key;
+            LastCoordinate = key.Value;
+        }
+
+        internal ChartBarCoordinateKey Key { get; }
+
+        internal double LastCoordinate { get; private set; }
+
+        internal void Add(CoordinateNode node) {
+            _seriesIndices.Add(node.SeriesIndex);
+            LastCoordinate = node.Coordinate;
+            if (node.Layout != null) _lastHistogramNode = node;
+        }
+
+        internal bool TryGetCompatibility(CoordinateNode node, out int rank, out double distance) {
+            rank = int.MaxValue;
+            distance = double.PositiveInfinity;
+            if (_seriesIndices.Contains(node.SeriesIndex) || !ChartMath.SameCoordinate(LastCoordinate, node.Coordinate)) return false;
+
+            if (node.Layout != null && _lastHistogramNode.HasValue) {
+                var histogramNode = _lastHistogramNode.Value;
+                if (EquivalentLayouts(node.Layout, histogramNode.Layout!)) {
+                    if (node.BinIndex != histogramNode.BinIndex) return false;
+                } else if (!EquivalentBounds(node, histogramNode)) {
+                    return false;
+                }
+
+                rank = 0;
+                distance = BoundDistance(node, histogramNode);
+                return true;
+            }
+
+            rank = node.Layout == null && !_lastHistogramNode.HasValue ? 0 : 1;
+            distance = Math.Abs(node.Coordinate - LastCoordinate);
+            return true;
+        }
+    }
+
+    private readonly struct CoordinateNode {
+        internal CoordinateNode(int seriesIndex, int pointIndex, double coordinate, ChartHistogramBinLayout? layout, int binIndex) {
+            SeriesIndex = seriesIndex;
+            PointIndex = pointIndex;
+            Coordinate = coordinate;
+            Layout = layout;
+            BinIndex = binIndex;
+        }
+
+        internal int SeriesIndex { get; }
+        internal int PointIndex { get; }
+        internal double Coordinate { get; }
+        internal ChartHistogramBinLayout? Layout { get; }
+        internal int BinIndex { get; }
+    }
+
+    private static bool EquivalentLayouts(ChartHistogramBinLayout left, ChartHistogramBinLayout right) =>
+        left.Count == right.Count && ChartMath.SameCoordinate(left.Minimum, right.Minimum) &&
+        ChartMath.SameCoordinate(left.Maximum, right.Maximum) && ChartMath.SameCoordinate(left.Width, right.Width);
+
+    private static bool EquivalentBounds(CoordinateNode left, CoordinateNode right) =>
+        ChartMath.SameCoordinate(left.Layout!.GetLowerBound(left.BinIndex), right.Layout!.GetLowerBound(right.BinIndex)) &&
+        ChartMath.SameCoordinate(left.Layout.GetUpperBound(left.BinIndex), right.Layout.GetUpperBound(right.BinIndex));
+
+    private static double BoundDistance(CoordinateNode left, CoordinateNode right) =>
+        Math.Abs(left.Layout!.GetLowerBound(left.BinIndex) - right.Layout!.GetLowerBound(right.BinIndex)) +
+        Math.Abs(left.Layout.GetUpperBound(left.BinIndex) - right.Layout.GetUpperBound(right.BinIndex));
+}
+
+internal readonly struct ChartBarCoordinateKey : IEquatable<ChartBarCoordinateKey> {
+    internal ChartBarCoordinateKey(int id, double value) {
+        Id = id;
+        Value = value;
+    }
+
+    internal int Id { get; }
+    internal double Value { get; }
+
+    public bool Equals(ChartBarCoordinateKey other) => Id == other.Id;
+    public override bool Equals(object? obj) => obj is ChartBarCoordinateKey other && Equals(other);
+    public override int GetHashCode() => Id;
 }

--- a/ChartForgeX/Rendering/ChartBarStacking.cs
+++ b/ChartForgeX/Rendering/ChartBarStacking.cs
@@ -8,8 +8,7 @@ namespace ChartForgeX.Rendering;
 internal static class ChartBarStacking {
     internal static double BaseValue(Chart chart, int seriesIndex, ChartPoint point) {
         var sum = 0.0;
-        var currentSeries = chart.Series[seriesIndex];
-        var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, currentSeries, point.X);
+        var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, point.X);
         for (var index = 0; index < seriesIndex; index++) {
             var series = chart.Series[index];
             if (series.Kind != ChartSeriesKind.Bar || !TryFindPoint(chart, series, coordinate, out var candidate)) continue;
@@ -21,14 +20,14 @@ internal static class ChartBarStacking {
 
     private static bool TryFindPoint(Chart chart, ChartSeries series, double coordinate, out ChartPoint point) {
         for (var index = 0; index < series.Points.Count; index++) {
-            var candidateCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, series.Points[index].X);
+            var candidateCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series.Points[index].X);
             if (candidateCoordinate != coordinate) continue;
             point = series.Points[index];
             return true;
         }
 
         for (var index = 0; index < series.Points.Count; index++) {
-            var candidateCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, series.Points[index].X);
+            var candidateCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series.Points[index].X);
             if (!ChartMath.SameCoordinate(candidateCoordinate, coordinate)) continue;
             point = series.Points[index];
             return true;

--- a/ChartForgeX/Rendering/ChartBarStacking.cs
+++ b/ChartForgeX/Rendering/ChartBarStacking.cs
@@ -8,24 +8,28 @@ namespace ChartForgeX.Rendering;
 internal static class ChartBarStacking {
     internal static double BaseValue(Chart chart, int seriesIndex, ChartPoint point) {
         var sum = 0.0;
+        var currentSeries = chart.Series[seriesIndex];
+        var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, currentSeries, point.X);
         for (var index = 0; index < seriesIndex; index++) {
             var series = chart.Series[index];
-            if (series.Kind != ChartSeriesKind.Bar || !TryFindPoint(series, point.X, out var candidate)) continue;
+            if (series.Kind != ChartSeriesKind.Bar || !TryFindPoint(chart, series, coordinate, out var candidate)) continue;
             if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;
         }
 
         return sum;
     }
 
-    private static bool TryFindPoint(ChartSeries series, double coordinate, out ChartPoint point) {
+    private static bool TryFindPoint(Chart chart, ChartSeries series, double coordinate, out ChartPoint point) {
         for (var index = 0; index < series.Points.Count; index++) {
-            if (series.Points[index].X != coordinate) continue;
+            var candidateCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, series.Points[index].X);
+            if (candidateCoordinate != coordinate) continue;
             point = series.Points[index];
             return true;
         }
 
         for (var index = 0; index < series.Points.Count; index++) {
-            if (!ChartMath.SameCoordinate(series.Points[index].X, coordinate)) continue;
+            var candidateCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, series.Points[index].X);
+            if (!ChartMath.SameCoordinate(candidateCoordinate, coordinate)) continue;
             point = series.Points[index];
             return true;
         }

--- a/ChartForgeX/Rendering/ChartBarStacking.cs
+++ b/ChartForgeX/Rendering/ChartBarStacking.cs
@@ -1,0 +1,36 @@
+using ChartForgeX.Core;
+
+namespace ChartForgeX.Rendering;
+
+/// <summary>
+/// Resolves vertical bar stack values with the same coordinate identity used by histogram slots and range calculation.
+/// </summary>
+internal static class ChartBarStacking {
+    internal static double BaseValue(Chart chart, int seriesIndex, ChartPoint point) {
+        var sum = 0.0;
+        for (var index = 0; index < seriesIndex; index++) {
+            var series = chart.Series[index];
+            if (series.Kind != ChartSeriesKind.Bar || !TryFindPoint(series, point.X, out var candidate)) continue;
+            if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;
+        }
+
+        return sum;
+    }
+
+    private static bool TryFindPoint(ChartSeries series, double coordinate, out ChartPoint point) {
+        for (var index = 0; index < series.Points.Count; index++) {
+            if (series.Points[index].X != coordinate) continue;
+            point = series.Points[index];
+            return true;
+        }
+
+        for (var index = 0; index < series.Points.Count; index++) {
+            if (!ChartMath.SameCoordinate(series.Points[index].X, coordinate)) continue;
+            point = series.Points[index];
+            return true;
+        }
+
+        point = default;
+        return false;
+    }
+}

--- a/ChartForgeX/Rendering/ChartBarStacking.cs
+++ b/ChartForgeX/Rendering/ChartBarStacking.cs
@@ -6,29 +6,21 @@ namespace ChartForgeX.Rendering;
 /// Resolves vertical bar stack values with the same coordinate identity used by histogram slots and range calculation.
 /// </summary>
 internal static class ChartBarStacking {
-    internal static double BaseValue(Chart chart, int seriesIndex, ChartPoint point) {
+    internal static double BaseValue(Chart chart, ChartBarCoordinateMap coordinateMap, int seriesIndex, ChartPoint point) {
         var sum = 0.0;
-        var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, point.X);
+        var coordinate = coordinateMap.Resolve(point.X);
         for (var index = 0; index < seriesIndex; index++) {
             var series = chart.Series[index];
-            if (series.Kind != ChartSeriesKind.Bar || !TryFindPoint(chart, series, coordinate, out var candidate)) continue;
+            if (series.Kind != ChartSeriesKind.Bar || !TryFindPoint(coordinateMap, series, coordinate, out var candidate)) continue;
             if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;
         }
 
         return sum;
     }
 
-    private static bool TryFindPoint(Chart chart, ChartSeries series, double coordinate, out ChartPoint point) {
+    private static bool TryFindPoint(ChartBarCoordinateMap coordinateMap, ChartSeries series, double coordinate, out ChartPoint point) {
         for (var index = 0; index < series.Points.Count; index++) {
-            var candidateCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series.Points[index].X);
-            if (candidateCoordinate != coordinate) continue;
-            point = series.Points[index];
-            return true;
-        }
-
-        for (var index = 0; index < series.Points.Count; index++) {
-            var candidateCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series.Points[index].X);
-            if (!ChartMath.SameCoordinate(candidateCoordinate, coordinate)) continue;
+            if (coordinateMap.Resolve(series.Points[index].X) != coordinate) continue;
             point = series.Points[index];
             return true;
         }

--- a/ChartForgeX/Rendering/ChartBarStacking.cs
+++ b/ChartForgeX/Rendering/ChartBarStacking.cs
@@ -6,21 +6,22 @@ namespace ChartForgeX.Rendering;
 /// Resolves vertical bar stack values with the same coordinate identity used by histogram slots and range calculation.
 /// </summary>
 internal static class ChartBarStacking {
-    internal static double BaseValue(Chart chart, ChartBarCoordinateMap coordinateMap, int seriesIndex, ChartPoint point) {
+    internal static double BaseValue(Chart chart, ChartBarCoordinateMap coordinateMap, int seriesIndex, int pointIndex) {
         var sum = 0.0;
-        var coordinate = coordinateMap.Resolve(point.X);
+        var point = chart.Series[seriesIndex].Points[pointIndex];
+        var coordinate = coordinateMap.Resolve(seriesIndex, pointIndex);
         for (var index = 0; index < seriesIndex; index++) {
             var series = chart.Series[index];
-            if (series.Kind != ChartSeriesKind.Bar || !TryFindPoint(coordinateMap, series, coordinate, out var candidate)) continue;
+            if (series.Kind != ChartSeriesKind.Bar || !TryFindPoint(coordinateMap, index, series, coordinate, out var candidate)) continue;
             if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;
         }
 
         return sum;
     }
 
-    private static bool TryFindPoint(ChartBarCoordinateMap coordinateMap, ChartSeries series, double coordinate, out ChartPoint point) {
+    private static bool TryFindPoint(ChartBarCoordinateMap coordinateMap, int seriesIndex, ChartSeries series, ChartBarCoordinateKey coordinate, out ChartPoint point) {
         for (var index = 0; index < series.Points.Count; index++) {
-            if (coordinateMap.Resolve(series.Points[index].X) != coordinate) continue;
+            if (!coordinateMap.Resolve(seriesIndex, index).Equals(coordinate)) continue;
             point = series.Points[index];
             return true;
         }

--- a/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
+++ b/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
@@ -43,7 +43,15 @@ internal static class ChartHistogramBarSlot {
             return pointIndex < layout.Count;
         }
 
-        var coordinate = series.Points[pointIndex].X;
+        return TryFindHistogramBin(chart, series.Points[pointIndex].X, out layout, out binIndex);
+    }
+
+    internal static double CanonicalCoordinate(Chart chart, ChartSeries series, double coordinate) {
+        if (series.HistogramBinLayout != null || !TryFindHistogramBin(chart, coordinate, out var layout, out var binIndex)) return coordinate;
+        return layout.GetCenter(binIndex);
+    }
+
+    private static bool TryFindHistogramBin(Chart chart, double coordinate, out ChartHistogramBinLayout layout, out int binIndex) {
         for (var seriesIndex = 0; seriesIndex < chart.Series.Count; seriesIndex++) {
             var candidate = chart.Series[seriesIndex].HistogramBinLayout;
             if (candidate == null) continue;

--- a/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
+++ b/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
@@ -13,20 +13,21 @@ internal static class ChartHistogramBarSlot {
 
     public static bool TryResolve(Chart chart, int seriesIndex, int pointIndex, ChartMapper map, out double left, out double width) {
         var series = chart.Series[seriesIndex];
-        var layout = series.HistogramBinLayout;
-        if (layout == null || layout.Minimum == layout.Maximum || pointIndex < 0 || pointIndex >= layout.Count) {
+        if (pointIndex < 0 || pointIndex >= series.Points.Count || !TryResolveBin(chart, series, pointIndex, out var layout, out var binIndex) || layout.Minimum == layout.Maximum) {
             left = 0;
             width = 0;
             return false;
         }
 
-        var lower = map.X(layout.GetLowerBound(pointIndex));
-        var upper = map.X(layout.GetUpperBound(pointIndex));
+        var lowerBound = layout.GetLowerBound(binIndex);
+        var upperBound = layout.GetUpperBound(binIndex);
+        var lower = map.X(lowerBound);
+        var upper = map.X(upperBound);
         var binLeft = Math.Min(lower, upper);
         var binWidth = Math.Abs(upper - lower);
-        var histogramSeries = HistogramSeries(chart);
-        var groupCount = chart.Options.BarMode == ChartBarMode.Stacked ? 1 : Math.Max(1, histogramSeries.Count);
-        var groupPosition = chart.Options.BarMode == ChartBarMode.Stacked ? 0 : Math.Max(0, histogramSeries.IndexOf(seriesIndex));
+        var groupedSeries = GroupedSeries(chart, lowerBound, upperBound, layout.GetCenter(binIndex));
+        var groupCount = chart.Options.BarMode == ChartBarMode.Stacked ? 1 : Math.Max(1, groupedSeries.Count);
+        var groupPosition = chart.Options.BarMode == ChartBarMode.Stacked ? 0 : Math.Max(0, groupedSeries.IndexOf(seriesIndex));
         var inset = binWidth * OuterInsetRatio;
         var occupiedWidth = Math.Max(0, binWidth - inset * 2);
         var gap = groupCount == 1 ? 0 : occupiedWidth * GroupGapRatio / (groupCount - 1);
@@ -35,12 +36,63 @@ internal static class ChartHistogramBarSlot {
         return true;
     }
 
-    private static List<int> HistogramSeries(Chart chart) {
+    private static bool TryResolveBin(Chart chart, ChartSeries series, int pointIndex, out ChartHistogramBinLayout layout, out int binIndex) {
+        if (series.HistogramBinLayout != null) {
+            layout = series.HistogramBinLayout;
+            binIndex = pointIndex;
+            return pointIndex < layout.Count;
+        }
+
+        var coordinate = series.Points[pointIndex].X;
+        for (var seriesIndex = 0; seriesIndex < chart.Series.Count; seriesIndex++) {
+            var candidate = chart.Series[seriesIndex].HistogramBinLayout;
+            if (candidate == null) continue;
+            if (coordinate < candidate.Minimum || coordinate > candidate.Maximum) continue;
+            var candidateIndex = candidate.GetIndex(coordinate);
+            if (!SameCoordinate(candidate.GetCenter(candidateIndex), coordinate)) continue;
+            layout = candidate;
+            binIndex = candidateIndex;
+            return true;
+        }
+
+        layout = null!;
+        binIndex = -1;
+        return false;
+    }
+
+    private static List<int> GroupedSeries(Chart chart, double lowerBound, double upperBound, double center) {
         var result = new List<int>();
         for (var i = 0; i < chart.Series.Count; i++) {
-            if (chart.Series[i].Kind == ChartSeriesKind.Bar && chart.Series[i].HistogramBinLayout != null) result.Add(i);
+            var series = chart.Series[i];
+            if (series.Kind != ChartSeriesKind.Bar) continue;
+            if (series.HistogramBinLayout != null) {
+                if (ContainsBin(series.HistogramBinLayout, lowerBound, upperBound, center)) result.Add(i);
+                continue;
+            }
+
+            for (var pointIndex = 0; pointIndex < series.Points.Count; pointIndex++) {
+                if (!SameCoordinate(series.Points[pointIndex].X, center)) continue;
+                result.Add(i);
+                break;
+            }
         }
 
         return result;
+    }
+
+    private static bool ContainsBin(ChartHistogramBinLayout layout, double lowerBound, double upperBound, double center) {
+        if (center < layout.Minimum || center > layout.Maximum) return false;
+        var index = layout.GetIndex(center);
+        return SameCoordinate(layout.GetLowerBound(index), lowerBound) && SameCoordinate(layout.GetUpperBound(index), upperBound);
+    }
+
+    private static bool SameCoordinate(double left, double right) {
+        if (left == right) return true;
+        if (double.IsNaN(left) || double.IsNaN(right) || double.IsInfinity(left) || double.IsInfinity(right)) return false;
+        var magnitude = Math.Max(Math.Abs(left), Math.Abs(right));
+        if (magnitude == 0) return false;
+        var bits = BitConverter.DoubleToInt64Bits(magnitude);
+        var next = BitConverter.Int64BitsToDouble(bits + 1);
+        return Math.Abs(left - right) <= (next - magnitude) * 4;
     }
 }

--- a/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
+++ b/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
@@ -49,7 +49,7 @@ internal static class ChartHistogramBarSlot {
             if (candidate == null) continue;
             if (coordinate < candidate.Minimum || coordinate > candidate.Maximum) continue;
             var candidateIndex = candidate.GetIndex(coordinate);
-            if (!SameCoordinate(candidate.GetCenter(candidateIndex), coordinate)) continue;
+            if (!ChartMath.SameCoordinate(candidate.GetCenter(candidateIndex), coordinate)) continue;
             layout = candidate;
             binIndex = candidateIndex;
             return true;
@@ -71,7 +71,7 @@ internal static class ChartHistogramBarSlot {
             }
 
             for (var pointIndex = 0; pointIndex < series.Points.Count; pointIndex++) {
-                if (!SameCoordinate(series.Points[pointIndex].X, center)) continue;
+                if (!ChartMath.SameCoordinate(series.Points[pointIndex].X, center)) continue;
                 result.Add(i);
                 break;
             }
@@ -83,16 +83,6 @@ internal static class ChartHistogramBarSlot {
     private static bool ContainsBin(ChartHistogramBinLayout layout, double lowerBound, double upperBound, double center) {
         if (center < layout.Minimum || center > layout.Maximum) return false;
         var index = layout.GetIndex(center);
-        return SameCoordinate(layout.GetLowerBound(index), lowerBound) && SameCoordinate(layout.GetUpperBound(index), upperBound);
-    }
-
-    private static bool SameCoordinate(double left, double right) {
-        if (left == right) return true;
-        if (double.IsNaN(left) || double.IsNaN(right) || double.IsInfinity(left) || double.IsInfinity(right)) return false;
-        var magnitude = Math.Max(Math.Abs(left), Math.Abs(right));
-        if (magnitude == 0) return false;
-        var bits = BitConverter.DoubleToInt64Bits(magnitude);
-        var next = BitConverter.Int64BitsToDouble(bits + 1);
-        return Math.Abs(left - right) <= (next - magnitude) * 4;
+        return ChartMath.SameCoordinate(layout.GetLowerBound(index), lowerBound) && ChartMath.SameCoordinate(layout.GetUpperBound(index), upperBound);
     }
 }

--- a/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
+++ b/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
@@ -46,11 +46,6 @@ internal static class ChartHistogramBarSlot {
         return TryFindHistogramBin(chart, series.Points[pointIndex].X, out layout, out binIndex);
     }
 
-    internal static double CanonicalCoordinate(Chart chart, double coordinate) {
-        if (!TryFindHistogramBin(chart, coordinate, out var layout, out var binIndex)) return coordinate;
-        return layout.GetCenter(binIndex);
-    }
-
     private static bool TryFindHistogramBin(Chart chart, double coordinate, out ChartHistogramBinLayout layout, out int binIndex) {
         for (var seriesIndex = 0; seriesIndex < chart.Series.Count; seriesIndex++) {
             var candidate = chart.Series[seriesIndex].HistogramBinLayout;

--- a/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
+++ b/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using ChartForgeX.Core;
+
+namespace ChartForgeX.Rendering;
+
+/// <summary>
+/// Resolves histogram bins into shared SVG/PNG bar slots while preserving numeric bin widths.
+/// </summary>
+internal static class ChartHistogramBarSlot {
+    private const double OuterInsetRatio = 0.08;
+    private const double GroupGapRatio = 0.04;
+
+    public static bool TryResolve(Chart chart, int seriesIndex, int pointIndex, ChartMapper map, out double left, out double width) {
+        var series = chart.Series[seriesIndex];
+        var layout = series.HistogramBinLayout;
+        if (layout == null || layout.Minimum == layout.Maximum || pointIndex < 0 || pointIndex >= layout.Count) {
+            left = 0;
+            width = 0;
+            return false;
+        }
+
+        var lower = map.X(layout.GetLowerBound(pointIndex));
+        var upper = map.X(layout.GetUpperBound(pointIndex));
+        var binLeft = Math.Min(lower, upper);
+        var binWidth = Math.Abs(upper - lower);
+        var histogramSeries = HistogramSeries(chart);
+        var groupCount = chart.Options.BarMode == ChartBarMode.Stacked ? 1 : Math.Max(1, histogramSeries.Count);
+        var groupPosition = chart.Options.BarMode == ChartBarMode.Stacked ? 0 : Math.Max(0, histogramSeries.IndexOf(seriesIndex));
+        var inset = binWidth * OuterInsetRatio;
+        var occupiedWidth = Math.Max(0, binWidth - inset * 2);
+        var gap = groupCount == 1 ? 0 : occupiedWidth * GroupGapRatio / (groupCount - 1);
+        width = Math.Max(1, (occupiedWidth - gap * (groupCount - 1)) / groupCount);
+        left = binLeft + inset + groupPosition * (width + gap);
+        return true;
+    }
+
+    private static List<int> HistogramSeries(Chart chart) {
+        var result = new List<int>();
+        for (var i = 0; i < chart.Series.Count; i++) {
+            if (chart.Series[i].Kind == ChartSeriesKind.Bar && chart.Series[i].HistogramBinLayout != null) result.Add(i);
+        }
+
+        return result;
+    }
+}

--- a/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
+++ b/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
@@ -11,9 +11,9 @@ internal static class ChartHistogramBarSlot {
     private const double OuterInsetRatio = 0.08;
     private const double GroupGapRatio = 0.04;
 
-    public static bool TryResolve(Chart chart, int seriesIndex, int pointIndex, ChartMapper map, out double left, out double width) {
+    public static bool TryResolve(Chart chart, ChartBarCoordinateMap coordinateMap, int seriesIndex, int pointIndex, ChartMapper map, out double left, out double width) {
         var series = chart.Series[seriesIndex];
-        if (pointIndex < 0 || pointIndex >= series.Points.Count || !TryResolveBin(chart, series, pointIndex, out var layout, out var binIndex) || layout.Minimum == layout.Maximum) {
+        if (pointIndex < 0 || pointIndex >= series.Points.Count || !coordinateMap.TryResolveHistogramSlot(seriesIndex, pointIndex, out var layout, out var binIndex) || layout.Minimum == layout.Maximum) {
             left = 0;
             width = 0;
             return false;
@@ -25,9 +25,9 @@ internal static class ChartHistogramBarSlot {
         var upper = map.X(upperBound);
         var binLeft = Math.Min(lower, upper);
         var binWidth = Math.Abs(upper - lower);
-        var groupedSeries = GroupedSeries(chart, lowerBound, upperBound, layout.GetCenter(binIndex));
+        var groupedSeries = coordinateMap.SeriesIndices(seriesIndex, pointIndex);
         var groupCount = chart.Options.BarMode == ChartBarMode.Stacked ? 1 : Math.Max(1, groupedSeries.Count);
-        var groupPosition = chart.Options.BarMode == ChartBarMode.Stacked ? 0 : Math.Max(0, groupedSeries.IndexOf(seriesIndex));
+        var groupPosition = chart.Options.BarMode == ChartBarMode.Stacked ? 0 : Math.Max(0, IndexOf(groupedSeries, seriesIndex));
         var inset = binWidth * OuterInsetRatio;
         var occupiedWidth = Math.Max(0, binWidth - inset * 2);
         var gap = groupCount == 1 ? 0 : occupiedWidth * GroupGapRatio / (groupCount - 1);
@@ -36,56 +36,11 @@ internal static class ChartHistogramBarSlot {
         return true;
     }
 
-    private static bool TryResolveBin(Chart chart, ChartSeries series, int pointIndex, out ChartHistogramBinLayout layout, out int binIndex) {
-        if (series.HistogramBinLayout != null) {
-            layout = series.HistogramBinLayout;
-            binIndex = pointIndex;
-            return pointIndex < layout.Count;
+    private static int IndexOf(IReadOnlyList<int> values, int value) {
+        for (var index = 0; index < values.Count; index++) {
+            if (values[index] == value) return index;
         }
 
-        return TryFindHistogramBin(chart, series.Points[pointIndex].X, out layout, out binIndex);
-    }
-
-    private static bool TryFindHistogramBin(Chart chart, double coordinate, out ChartHistogramBinLayout layout, out int binIndex) {
-        for (var seriesIndex = 0; seriesIndex < chart.Series.Count; seriesIndex++) {
-            var candidate = chart.Series[seriesIndex].HistogramBinLayout;
-            if (candidate == null) continue;
-            if (coordinate < candidate.Minimum || coordinate > candidate.Maximum) continue;
-            var candidateIndex = candidate.GetIndex(coordinate);
-            if (!ChartMath.SameCoordinate(candidate.GetCenter(candidateIndex), coordinate)) continue;
-            layout = candidate;
-            binIndex = candidateIndex;
-            return true;
-        }
-
-        layout = null!;
-        binIndex = -1;
-        return false;
-    }
-
-    private static List<int> GroupedSeries(Chart chart, double lowerBound, double upperBound, double center) {
-        var result = new List<int>();
-        for (var i = 0; i < chart.Series.Count; i++) {
-            var series = chart.Series[i];
-            if (series.Kind != ChartSeriesKind.Bar) continue;
-            if (series.HistogramBinLayout != null) {
-                if (ContainsBin(series.HistogramBinLayout, lowerBound, upperBound, center)) result.Add(i);
-                continue;
-            }
-
-            for (var pointIndex = 0; pointIndex < series.Points.Count; pointIndex++) {
-                if (!ChartMath.SameCoordinate(series.Points[pointIndex].X, center)) continue;
-                result.Add(i);
-                break;
-            }
-        }
-
-        return result;
-    }
-
-    private static bool ContainsBin(ChartHistogramBinLayout layout, double lowerBound, double upperBound, double center) {
-        if (center < layout.Minimum || center > layout.Maximum) return false;
-        var index = layout.GetIndex(center);
-        return ChartMath.SameCoordinate(layout.GetLowerBound(index), lowerBound) && ChartMath.SameCoordinate(layout.GetUpperBound(index), upperBound);
+        return -1;
     }
 }

--- a/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
+++ b/ChartForgeX/Rendering/ChartHistogramBarSlot.cs
@@ -46,8 +46,8 @@ internal static class ChartHistogramBarSlot {
         return TryFindHistogramBin(chart, series.Points[pointIndex].X, out layout, out binIndex);
     }
 
-    internal static double CanonicalCoordinate(Chart chart, ChartSeries series, double coordinate) {
-        if (series.HistogramBinLayout != null || !TryFindHistogramBin(chart, coordinate, out var layout, out var binIndex)) return coordinate;
+    internal static double CanonicalCoordinate(Chart chart, double coordinate) {
+        if (!TryFindHistogramBin(chart, coordinate, out var layout, out var binIndex)) return coordinate;
         return layout.GetCenter(binIndex);
     }
 

--- a/ChartForgeX/Rendering/ChartMath.cs
+++ b/ChartForgeX/Rendering/ChartMath.cs
@@ -15,4 +15,15 @@ internal static class ChartMath {
     }
 
     internal static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+
+    internal static bool SameCoordinate(double left, double right) {
+        if (left == right) return true;
+        if (!IsFinite(left) || !IsFinite(right)) return false;
+        var magnitude = Math.Max(Math.Abs(left), Math.Abs(right));
+        if (magnitude == 0) return false;
+        var bits = BitConverter.DoubleToInt64Bits(magnitude);
+        var next = BitConverter.Int64BitsToDouble(bits + 1);
+        var tolerance = next - magnitude;
+        return IsFinite(tolerance) && Math.Abs(left - right) <= tolerance * 4;
+    }
 }

--- a/ChartForgeX/Rendering/ChartRange.cs
+++ b/ChartForgeX/Rendering/ChartRange.cs
@@ -44,7 +44,8 @@ internal sealed class ChartRange {
                 }
                 foreach (var point in series.Points) {
                     range.IncludeY(point.Y);
-                    AddStackValue(point.Y >= 0 ? positiveBarStacks : negativeBarStacks, point.X, point.Y);
+                    var stackCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, point.X);
+                    AddStackValue(point.Y >= 0 ? positiveBarStacks : negativeBarStacks, stackCoordinate, point.Y);
                 }
 
                 if (UsesZeroBaseline(chart.Options.YAxis)) range.IncludeY(0);
@@ -118,7 +119,7 @@ internal sealed class ChartRange {
                     range.IncludeX(p.X);
                     range.IncludeY(p.Y);
                     if (series.Kind == ChartSeriesKind.Bar) {
-                        var stackCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, p.X);
+                        var stackCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, p.X);
                         AddStackValue(p.Y >= 0 ? positiveBarStacks : negativeBarStacks, stackCoordinate, p.Y);
                     }
                 } else if (series.Kind == ChartSeriesKind.StackedArea) {

--- a/ChartForgeX/Rendering/ChartRange.cs
+++ b/ChartForgeX/Rendering/ChartRange.cs
@@ -204,9 +204,26 @@ internal sealed class ChartRange {
     }
 
     private static void AddStackValue(Dictionary<double, double> stacks, double x, double y) {
-        double current;
-        stacks.TryGetValue(x, out current);
-        stacks[x] = current + y;
+        if (stacks.TryGetValue(x, out var current)) {
+            stacks[x] = current + y;
+            return;
+        }
+
+        var matchingKey = 0.0;
+        var hasMatchingKey = false;
+        foreach (var existing in stacks.Keys) {
+            if (!ChartMath.SameCoordinate(existing, x)) continue;
+            matchingKey = existing;
+            hasMatchingKey = true;
+            break;
+        }
+
+        if (hasMatchingKey) {
+            stacks[matchingKey] += y;
+            return;
+        }
+
+        stacks[x] = y;
     }
 
     private void Include(ChartAnnotation annotation) {

--- a/ChartForgeX/Rendering/ChartRange.cs
+++ b/ChartForgeX/Rendering/ChartRange.cs
@@ -34,6 +34,23 @@ internal sealed class ChartRange {
 
             if (ChartSeriesKindTraits.UsesVerticalBaseline(series.Kind)) usesVerticalBaseline = true;
 
+            if (series.Kind == ChartSeriesKind.Bar && series.HistogramBinLayout != null) {
+                if (series.HistogramBinLayout.Minimum == series.HistogramBinLayout.Maximum) {
+                    range.IncludeX(series.HistogramBinLayout.Minimum - 0.5);
+                    range.IncludeX(series.HistogramBinLayout.Maximum + 0.5);
+                } else {
+                    range.IncludeX(series.HistogramBinLayout.Minimum);
+                    range.IncludeX(series.HistogramBinLayout.Maximum);
+                }
+                foreach (var point in series.Points) {
+                    range.IncludeY(point.Y);
+                    AddStackValue(point.Y >= 0 ? positiveBarStacks : negativeBarStacks, point.X, point.Y);
+                }
+
+                if (UsesZeroBaseline(chart.Options.YAxis)) range.IncludeY(0);
+                continue;
+            }
+
             if (series.Kind == ChartSeriesKind.Bubble) {
                 for (var i = 0; i + 1 < series.Points.Count; i += 2) {
                     var center = series.Points[i];
@@ -238,6 +255,12 @@ internal sealed class ChartRange {
     }
 
     private static void IncludeSeriesX(ChartRange range, ChartSeries series) {
+        if (series.Kind == ChartSeriesKind.Bar && series.HistogramBinLayout != null) {
+            range.IncludeX(series.HistogramBinLayout.Minimum);
+            range.IncludeX(series.HistogramBinLayout.Maximum);
+            return;
+        }
+
         if (series.Kind == ChartSeriesKind.HorizontalBar) {
             foreach (var point in series.Points) range.IncludeX(point.Y);
             return;

--- a/ChartForgeX/Rendering/ChartRange.cs
+++ b/ChartForgeX/Rendering/ChartRange.cs
@@ -20,15 +20,16 @@ internal sealed class ChartRange {
         var barXValues = new List<double>();
         var bubbleXValues = new List<double>();
         var horizontalBarYValues = new List<double>();
-        var positiveBarStacks = new Dictionary<double, double>();
-        var negativeBarStacks = new Dictionary<double, double>();
+        var positiveBarStacks = new Dictionary<ChartBarCoordinateKey, double>();
+        var negativeBarStacks = new Dictionary<ChartBarCoordinateKey, double>();
         var positiveHorizontalBarStacks = new Dictionary<double, double>();
         var negativeHorizontalBarStacks = new Dictionary<double, double>();
         var positiveAreaStacks = new Dictionary<double, double>();
         var negativeAreaStacks = new Dictionary<double, double>();
         var hasHorizontalBars = false;
         var usesVerticalBaseline = false;
-        foreach (var series in chart.Series) {
+        for (var seriesIndex = 0; seriesIndex < chart.Series.Count; seriesIndex++) {
+            var series = chart.Series[seriesIndex];
             if (ChartSeriesKindTraits.IsExclusive(series.Kind)) continue;
             if (series.YAxis == ChartAxisSide.Secondary && !ChartSeriesKindTraits.UsesHorizontalBaseline(series.Kind)) {
                 IncludeSeriesX(range, series);
@@ -45,10 +46,11 @@ internal sealed class ChartRange {
                     range.IncludeX(series.HistogramBinLayout.Minimum);
                     range.IncludeX(series.HistogramBinLayout.Maximum);
                 }
-                foreach (var point in series.Points) {
+                for (var pointIndex = 0; pointIndex < series.Points.Count; pointIndex++) {
+                    var point = series.Points[pointIndex];
                     range.IncludeY(point.Y);
-                    var stackCoordinate = coordinateMap.Resolve(point.X);
-                    AddStackValue(point.Y >= 0 ? positiveBarStacks : negativeBarStacks, stackCoordinate, point.Y);
+                    var stackCoordinate = coordinateMap.Resolve(seriesIndex, pointIndex);
+                    AddBarStackValue(point.Y >= 0 ? positiveBarStacks : negativeBarStacks, stackCoordinate, point.Y);
                 }
 
                 if (UsesZeroBaseline(chart.Options.YAxis)) range.IncludeY(0);
@@ -109,7 +111,8 @@ internal sealed class ChartRange {
                 continue;
             }
 
-            foreach (var p in series.Points) {
+            for (var pointIndex = 0; pointIndex < series.Points.Count; pointIndex++) {
+                var p = series.Points[pointIndex];
                 if (ChartSeriesKindTraits.UsesHorizontalBaseline(series.Kind)) {
                     hasHorizontalBars = true;
                     horizontalBarYValues.Add(p.X);
@@ -122,8 +125,8 @@ internal sealed class ChartRange {
                     range.IncludeX(p.X);
                     range.IncludeY(p.Y);
                     if (series.Kind == ChartSeriesKind.Bar) {
-                        var stackCoordinate = coordinateMap.Resolve(p.X);
-                        AddStackValue(p.Y >= 0 ? positiveBarStacks : negativeBarStacks, stackCoordinate, p.Y);
+                        var stackCoordinate = coordinateMap.Resolve(seriesIndex, pointIndex);
+                        AddBarStackValue(p.Y >= 0 ? positiveBarStacks : negativeBarStacks, stackCoordinate, p.Y);
                     }
                 } else if (series.Kind == ChartSeriesKind.StackedArea) {
                     range.IncludeX(p.X);
@@ -213,6 +216,11 @@ internal sealed class ChartRange {
     private static void AddStackValue(Dictionary<double, double> stacks, double x, double y) {
         stacks.TryGetValue(x, out var current);
         stacks[x] = current + y;
+    }
+
+    private static void AddBarStackValue(Dictionary<ChartBarCoordinateKey, double> stacks, ChartBarCoordinateKey coordinate, double value) {
+        stacks.TryGetValue(coordinate, out var current);
+        stacks[coordinate] = current + value;
     }
 
     private void Include(ChartAnnotation annotation) {

--- a/ChartForgeX/Rendering/ChartRange.cs
+++ b/ChartForgeX/Rendering/ChartRange.cs
@@ -117,7 +117,10 @@ internal sealed class ChartRange {
                     barXValues.Add(p.X);
                     range.IncludeX(p.X);
                     range.IncludeY(p.Y);
-                    if (series.Kind == ChartSeriesKind.Bar) AddStackValue(p.Y >= 0 ? positiveBarStacks : negativeBarStacks, p.X, p.Y);
+                    if (series.Kind == ChartSeriesKind.Bar) {
+                        var stackCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, p.X);
+                        AddStackValue(p.Y >= 0 ? positiveBarStacks : negativeBarStacks, stackCoordinate, p.Y);
+                    }
                 } else if (series.Kind == ChartSeriesKind.StackedArea) {
                     range.IncludeX(p.X);
                     range.IncludeY(p.Y);
@@ -204,26 +207,8 @@ internal sealed class ChartRange {
     }
 
     private static void AddStackValue(Dictionary<double, double> stacks, double x, double y) {
-        if (stacks.TryGetValue(x, out var current)) {
-            stacks[x] = current + y;
-            return;
-        }
-
-        var matchingKey = 0.0;
-        var hasMatchingKey = false;
-        foreach (var existing in stacks.Keys) {
-            if (!ChartMath.SameCoordinate(existing, x)) continue;
-            matchingKey = existing;
-            hasMatchingKey = true;
-            break;
-        }
-
-        if (hasMatchingKey) {
-            stacks[matchingKey] += y;
-            return;
-        }
-
-        stacks[x] = y;
+        stacks.TryGetValue(x, out var current);
+        stacks[x] = current + y;
     }
 
     private void Include(ChartAnnotation annotation) {

--- a/ChartForgeX/Rendering/ChartRange.cs
+++ b/ChartForgeX/Rendering/ChartRange.cs
@@ -12,7 +12,10 @@ internal sealed class ChartRange {
     public double MinY { get; private set; } = double.PositiveInfinity;
     public double MaxY { get; private set; } = double.NegativeInfinity;
 
-    public static ChartRange FromChart(Chart chart, bool applyOptionBounds = true) {
+    public static ChartRange FromChart(Chart chart, bool applyOptionBounds = true) =>
+        FromChart(chart, ChartBarCoordinateMap.Create(chart), applyOptionBounds);
+
+    internal static ChartRange FromChart(Chart chart, ChartBarCoordinateMap coordinateMap, bool applyOptionBounds = true) {
         var range = new ChartRange();
         var barXValues = new List<double>();
         var bubbleXValues = new List<double>();
@@ -44,7 +47,7 @@ internal sealed class ChartRange {
                 }
                 foreach (var point in series.Points) {
                     range.IncludeY(point.Y);
-                    var stackCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, point.X);
+                    var stackCoordinate = coordinateMap.Resolve(point.X);
                     AddStackValue(point.Y >= 0 ? positiveBarStacks : negativeBarStacks, stackCoordinate, point.Y);
                 }
 
@@ -119,7 +122,7 @@ internal sealed class ChartRange {
                     range.IncludeX(p.X);
                     range.IncludeY(p.Y);
                     if (series.Kind == ChartSeriesKind.Bar) {
-                        var stackCoordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, p.X);
+                        var stackCoordinate = coordinateMap.Resolve(p.X);
                         AddStackValue(p.Y >= 0 ? positiveBarStacks : negativeBarStacks, stackCoordinate, p.Y);
                     }
                 } else if (series.Kind == ChartSeriesKind.StackedArea) {

--- a/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
@@ -284,7 +284,8 @@ public sealed partial class SvgChartRenderer {
     private static BarLayoutInfo BarLayout(Chart chart, ChartRect plot, int seriesIndex) {
         var barSeries = chart.Series
             .Select((series, index) => new { series, index })
-            .Where(item => item.series.Kind == ChartSeriesKind.Bar && item.series.HistogramBinLayout == null)
+            .Where(item => item.series.Kind == ChartSeriesKind.Bar &&
+                (item.series.HistogramBinLayout == null || item.series.HistogramBinLayout.Minimum == item.series.HistogramBinLayout.Maximum))
             .Select(item => item.index)
             .ToArray();
         var groupCount = chart.Options.BarMode == ChartBarMode.Stacked ? 1 : Math.Max(1, barSeries.Length);

--- a/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
@@ -174,7 +174,7 @@ public sealed partial class SvgChartRenderer {
         var reservedLabels = new List<ChartLabelBounds>();
         for (var pointIndex = 0; pointIndex < s.Points.Count; pointIndex++) {
             var p = s.Points[pointIndex];
-            var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, barCoordinateMap, index, p) : 0;
+            var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, barCoordinateMap, index, pointIndex) : 0;
             var y = map.Y(baseValue + p.Y);
             var baseY = chart.Options.BarMode == ChartBarMode.Stacked ? map.YOrBaseline(baseValue) : zeroY;
             var top = Math.Min(y, baseY);
@@ -320,13 +320,15 @@ public sealed partial class SvgChartRenderer {
     }
 
     private static void DrawStackTotals(StringBuilder sb, Chart chart, ChartBarCoordinateMap barCoordinateMap, ChartRect plot, ChartMapper map) {
-        var positiveTotals = new Dictionary<double, double>();
-        var negativeTotals = new Dictionary<double, double>();
-        foreach (var series in chart.Series) {
+        var positiveTotals = new Dictionary<ChartBarCoordinateKey, double>();
+        var negativeTotals = new Dictionary<ChartBarCoordinateKey, double>();
+        for (var seriesIndex = 0; seriesIndex < chart.Series.Count; seriesIndex++) {
+            var series = chart.Series[seriesIndex];
             if (series.Kind != ChartSeriesKind.Bar) continue;
-            foreach (var point in series.Points) {
-                var coordinate = barCoordinateMap.Resolve(point.X);
-                AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
+            for (var pointIndex = 0; pointIndex < series.Points.Count; pointIndex++) {
+                var point = series.Points[pointIndex];
+                var coordinate = barCoordinateMap.Resolve(seriesIndex, pointIndex);
+                AddBarStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
             }
         }
 
@@ -335,11 +337,11 @@ public sealed partial class SvgChartRenderer {
         DrawStackTotalSet(sb, chart, negativeTotals, plot, map, 14, reservedLabels);
     }
 
-    private static void DrawStackTotalSet(StringBuilder sb, Chart chart, Dictionary<double, double> totals, ChartRect plot, ChartMapper map, double offset, List<ChartLabelBounds> reservedLabels) {
-        foreach (var item in totals.OrderBy(item => item.Key)) {
+    private static void DrawStackTotalSet(StringBuilder sb, Chart chart, Dictionary<ChartBarCoordinateKey, double> totals, ChartRect plot, ChartMapper map, double offset, List<ChartLabelBounds> reservedLabels) {
+        foreach (var item in totals.OrderBy(item => item.Key.Value)) {
             if (Math.Abs(item.Value) < 0.000001) continue;
             var label = FormatValue(chart, item.Value);
-            var x = map.X(item.Key);
+            var x = map.X(item.Key.Value);
             var y = map.Y(item.Value) + offset;
             if (!ReserveSvgLabel(label, x, y, chart, plot, reservedLabels)) continue;
             DrawDataLabel(sb, chart, label, x, y, plot, "stack-total-label");
@@ -350,5 +352,10 @@ public sealed partial class SvgChartRenderer {
         double current;
         totals.TryGetValue(x, out current);
         totals[x] = current + y;
+    }
+
+    private static void AddBarStackTotal(Dictionary<ChartBarCoordinateKey, double> totals, ChartBarCoordinateKey coordinate, double value) {
+        totals.TryGetValue(coordinate, out var current);
+        totals[coordinate] = current + value;
     }
 }

--- a/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
@@ -325,7 +325,7 @@ public sealed partial class SvgChartRenderer {
         foreach (var series in chart.Series) {
             if (series.Kind != ChartSeriesKind.Bar) continue;
             foreach (var point in series.Points) {
-                var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, point.X);
+                var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, point.X);
                 AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
             }
         }

--- a/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
@@ -174,7 +174,7 @@ public sealed partial class SvgChartRenderer {
         var reservedLabels = new List<ChartLabelBounds>();
         for (var pointIndex = 0; pointIndex < s.Points.Count; pointIndex++) {
             var p = s.Points[pointIndex];
-            var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? StackBaseValue(chart, index, p) : 0;
+            var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, index, p) : 0;
             var y = map.Y(baseValue + p.Y);
             var baseY = chart.Options.BarMode == ChartBarMode.Stacked ? map.YOrBaseline(baseValue) : zeroY;
             var top = Math.Min(y, baseY);
@@ -301,21 +301,6 @@ public sealed partial class SvgChartRenderer {
         var barWidth = Math.Max(3, (groupWidth - gap * (groupCount - 1)) / groupCount);
         var offset = (groupPosition - (groupCount - 1) / 2.0) * (barWidth + gap);
         return new BarLayoutInfo(barWidth, offset);
-    }
-
-    private static double StackBaseValue(Chart chart, int seriesIndex, ChartPoint point) {
-        var sum = 0.0;
-        for (var i = 0; i < seriesIndex; i++) {
-            var series = chart.Series[i];
-            if (series.Kind != ChartSeriesKind.Bar) continue;
-            foreach (var candidate in series.Points) {
-                if (Math.Abs(candidate.X - point.X) >= 0.000001) continue;
-                if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;
-                break;
-            }
-        }
-
-        return sum;
     }
 
     private static double StackAreaBaseValue(Chart chart, int seriesIndex, ChartPoint point) {

--- a/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
@@ -181,7 +181,7 @@ public sealed partial class SvgChartRenderer {
             var height = Math.Abs(baseY - y);
             var barWidth = layout.BarWidth;
             var x = map.X(p.X) + layout.Offset - barWidth / 2;
-            if (ChartHistogramBarSlot.TryResolve(chart, index, pointIndex, map, out var histogramX, out var histogramWidth)) {
+            if (ChartHistogramBarSlot.TryResolve(chart, barCoordinateMap, index, pointIndex, map, out var histogramX, out var histogramWidth)) {
                 x = histogramX;
                 barWidth = histogramWidth;
             }

--- a/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
@@ -167,14 +167,14 @@ public sealed partial class SvgChartRenderer {
         if (ShouldDrawDataLabels(chart, s)) DrawPointLabels(sb, chart, s, s.Points.Select(p => new ChartPoint(map.X(p.X), map.Y(p.Y))).ToArray(), plot);
     }
 
-    private static void DrawBars(StringBuilder sb, Chart chart, int index, ChartRect plot, ChartRange range, ChartMapper map, string id) {
+    private static void DrawBars(StringBuilder sb, Chart chart, ChartBarCoordinateMap barCoordinateMap, int index, ChartRect plot, ChartRange range, ChartMapper map, string id) {
         var s = chart.Series[index];
         var layout = BarLayout(chart, plot, index);
         var zeroY = map.YBaseline();
         var reservedLabels = new List<ChartLabelBounds>();
         for (var pointIndex = 0; pointIndex < s.Points.Count; pointIndex++) {
             var p = s.Points[pointIndex];
-            var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, index, p) : 0;
+            var baseValue = chart.Options.BarMode == ChartBarMode.Stacked ? ChartBarStacking.BaseValue(chart, barCoordinateMap, index, p) : 0;
             var y = map.Y(baseValue + p.Y);
             var baseY = chart.Options.BarMode == ChartBarMode.Stacked ? map.YOrBaseline(baseValue) : zeroY;
             var top = Math.Min(y, baseY);
@@ -319,13 +319,13 @@ public sealed partial class SvgChartRenderer {
         return sum;
     }
 
-    private static void DrawStackTotals(StringBuilder sb, Chart chart, ChartRect plot, ChartMapper map) {
+    private static void DrawStackTotals(StringBuilder sb, Chart chart, ChartBarCoordinateMap barCoordinateMap, ChartRect plot, ChartMapper map) {
         var positiveTotals = new Dictionary<double, double>();
         var negativeTotals = new Dictionary<double, double>();
         foreach (var series in chart.Series) {
             if (series.Kind != ChartSeriesKind.Bar) continue;
             foreach (var point in series.Points) {
-                var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, point.X);
+                var coordinate = barCoordinateMap.Resolve(point.X);
                 AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
             }
         }

--- a/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
@@ -323,7 +323,10 @@ public sealed partial class SvgChartRenderer {
         var negativeTotals = new Dictionary<double, double>();
         foreach (var series in chart.Series) {
             if (series.Kind != ChartSeriesKind.Bar) continue;
-            foreach (var point in series.Points) AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, point.X, point.Y);
+            foreach (var point in series.Points) {
+                var coordinate = ChartHistogramBarSlot.CanonicalCoordinate(chart, series, point.X);
+                AddStackTotal(point.Y >= 0 ? positiveTotals : negativeTotals, coordinate, point.Y);
+            }
         }
 
         var reservedLabels = new List<ChartLabelBounds>();

--- a/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
@@ -179,10 +179,15 @@ public sealed partial class SvgChartRenderer {
             var baseY = chart.Options.BarMode == ChartBarMode.Stacked ? map.YOrBaseline(baseValue) : zeroY;
             var top = Math.Min(y, baseY);
             var height = Math.Abs(baseY - y);
-            var x = map.X(p.X) + layout.Offset - layout.BarWidth / 2;
-            var radius = chart.Options.BarMode == ChartBarMode.Stacked ? Math.Min(3, layout.BarWidth / 2) : Math.Min(7, layout.BarWidth / 2);
+            var barWidth = layout.BarWidth;
+            var x = map.X(p.X) + layout.Offset - barWidth / 2;
+            if (ChartHistogramBarSlot.TryResolve(chart, index, pointIndex, map, out var histogramX, out var histogramWidth)) {
+                x = histogramX;
+                barWidth = histogramWidth;
+            }
+            var radius = chart.Options.BarMode == ChartBarMode.Stacked ? Math.Min(3, barWidth / 2) : Math.Min(7, barWidth / 2);
             if (chart.Options.BarVisualStyle.Kind == ChartBarStyle.SegmentedCapsule) {
-                DrawSvgSegmentedBar(sb, chart, s, index, pointIndex, id, p.X, p.Y, baseValue, x, top, layout.BarWidth, height);
+                DrawSvgSegmentedBar(sb, chart, s, index, pointIndex, id, p.X, p.Y, baseValue, x, top, barWidth, height);
             } else {
                 AppendSvg(sb, writer => writer
                     .StartElement("rect")
@@ -195,21 +200,21 @@ public sealed partial class SvgChartRenderer {
                     .Attribute("data-cfx-color", PointColor(chart, s, index, pointIndex).ToHex())
                     .Attribute("x", x)
                     .Attribute("y", top)
-                    .Attribute("width", layout.BarWidth)
+                    .Attribute("width", barWidth)
                     .Attribute("height", height)
                     .Attribute("rx", radius)
                     .Attribute("fill", BarFill(chart, s, index, pointIndex, id))
                     .Attribute("opacity", ChartVisualPrimitives.BarFillOpacity)
                     .EndEmptyElement()
                     .Line());
-                DrawSvgFillPatternOverlay(sb, s, index, pointIndex, id, x, top, layout.BarWidth, height, radius, "bar-pattern");
-                DrawSvgBarHighlight(sb, x, top, layout.BarWidth, height);
+                DrawSvgFillPatternOverlay(sb, s, index, pointIndex, id, x, top, barWidth, height, radius, "bar-pattern");
+                DrawSvgBarHighlight(sb, x, top, barWidth, height);
             }
             if (ShouldDrawDataLabels(chart, s)) {
                 var label = FormatDataLabel(chart, s, pointIndex, p.Y);
                 var placement = DataLabelPlacement(chart, s);
                 if (placement == ChartDataLabelPlacement.Left || placement == ChartDataLabelPlacement.Right) {
-                    var labelX = placement == ChartDataLabelPlacement.Right ? x + layout.BarWidth + 8 : x - 8;
+                    var labelX = placement == ChartDataLabelPlacement.Right ? x + barWidth + 8 : x - 8;
                     var anchor = placement == ChartDataLabelPlacement.Right ? "start" : "end";
                     if (!ReserveSvgHorizontalLabel(label, labelX, top + height / 2, anchor, chart, plot, reservedLabels)) continue;
                     DrawHorizontalValueLabel(sb, chart, label, labelX, top + height / 2, anchor, plot, s, pointIndex);
@@ -225,8 +230,8 @@ public sealed partial class SvgChartRenderer {
                         : inside
                             ? top + height / 2
                             : p.Y >= 0 ? top - 10 : top + height + 10;
-                if (!ReserveSvgLabel(label, x + layout.BarWidth / 2, labelY, chart, plot, reservedLabels)) continue;
-                DrawDataLabel(sb, chart, label, x + layout.BarWidth / 2, labelY, plot, series: s, pointIndex: pointIndex);
+                if (!ReserveSvgLabel(label, x + barWidth / 2, labelY, chart, plot, reservedLabels)) continue;
+                DrawDataLabel(sb, chart, label, x + barWidth / 2, labelY, plot, series: s, pointIndex: pointIndex);
             }
         }
     }
@@ -279,7 +284,7 @@ public sealed partial class SvgChartRenderer {
     private static BarLayoutInfo BarLayout(Chart chart, ChartRect plot, int seriesIndex) {
         var barSeries = chart.Series
             .Select((series, index) => new { series, index })
-            .Where(item => item.series.Kind == ChartSeriesKind.Bar)
+            .Where(item => item.series.Kind == ChartSeriesKind.Bar && item.series.HistogramBinLayout == null)
             .Select(item => item.index)
             .ToArray();
         var groupCount = chart.Options.BarMode == ChartBarMode.Stacked ? 1 : Math.Max(1, barSeries.Length);
@@ -303,6 +308,7 @@ public sealed partial class SvgChartRenderer {
         for (var i = 0; i < seriesIndex; i++) {
             var series = chart.Series[i];
             if (series.Kind != ChartSeriesKind.Bar) continue;
+            if ((series.HistogramBinLayout == null) != (chart.Series[seriesIndex].HistogramBinLayout == null)) continue;
             foreach (var candidate in series.Points) {
                 if (Math.Abs(candidate.X - point.X) >= 0.000001) continue;
                 if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;

--- a/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.CartesianMarks.cs
@@ -308,7 +308,6 @@ public sealed partial class SvgChartRenderer {
         for (var i = 0; i < seriesIndex; i++) {
             var series = chart.Series[i];
             if (series.Kind != ChartSeriesKind.Bar) continue;
-            if ((series.HistogramBinLayout == null) != (chart.Series[seriesIndex].HistogramBinLayout == null)) continue;
             foreach (var candidate in series.Points) {
                 if (Math.Abs(candidate.X - point.X) >= 0.000001) continue;
                 if ((point.Y >= 0 && candidate.Y >= 0) || (point.Y < 0 && candidate.Y < 0)) sum += candidate.Y;

--- a/ChartForgeX/Svg/SvgChartRenderer.Helpers.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Helpers.cs
@@ -28,7 +28,7 @@ public sealed partial class SvgChartRenderer {
                 writer.StartElement("g").Attribute("data-cfx-role", "legend-item").Attribute("data-cfx-series", item.SeriesIndex);
                 if (item.PointIndex >= 0) writer.Attribute("data-cfx-point", item.PointIndex);
                 writer.Attribute("data-cfx-kind", series.Kind.ToString()).Attribute("data-cfx-label", item.Label).EndStartElement().Line();
-                DrawLegendSymbol(writer, series.Kind, item.X, -4, item.Color, t.CardBackground);
+                DrawLegendSymbol(writer, series.Kind, item.X, -4, item.Color, t.CardBackground, chart.Options.Theme.MarkerRadius > 0);
                 var style = chart.Options.LegendStyle;
                 var labelMaxWidth = Math.Max(8, item.Width - 30);
                 var labelFontSize = TextFontSizeForSvgWidth(item.Label, labelMaxWidth, StyleFontSize(style, t.LegendFontSize));
@@ -162,10 +162,10 @@ public sealed partial class SvgChartRenderer {
 
     private static bool IsVerticalLegend(ChartLegendPosition position) => IsLeftLegend(position) || IsRightLegend(position);
 
-    private static void DrawLegendSymbol(SvgMarkupWriter writer, ChartSeriesKind kind, double x, double y, ChartColor color, ChartColor background) {
+    private static void DrawLegendSymbol(SvgMarkupWriter writer, ChartSeriesKind kind, double x, double y, ChartColor color, ChartColor background, bool showOptionalLineMarker) {
         if (IsLineLikeLegend(kind)) {
             WriteLegendLineSymbol(writer, x, y, color);
-            WriteLegendCircleSymbol(writer, x, y, color, background);
+            if (!UsesOptionalLineMarker(kind) || showOptionalLineMarker) WriteLegendCircleSymbol(writer, x, y, color, background);
         } else if (kind == ChartSeriesKind.Scatter || kind == ChartSeriesKind.Bubble) {
             WriteLegendCircleSymbol(writer, x, y, color, background);
         } else if (kind == ChartSeriesKind.Candlestick || kind == ChartSeriesKind.Ohlc) {
@@ -175,6 +175,8 @@ public sealed partial class SvgChartRenderer {
             writer.StartElement("rect").Attribute("x", x).Attribute("y", y - 5).Attribute("width", "10").Attribute("height", "10").Attribute("rx", "2").Attribute("fill", color.ToCss()).EndEmptyElement().Line();
         }
     }
+
+    private static bool UsesOptionalLineMarker(ChartSeriesKind kind) => kind == ChartSeriesKind.Line || kind == ChartSeriesKind.StepLine;
 
     private static void WriteLegendLineSymbol(SvgMarkupWriter writer, double x, double y, ChartColor color) {
         writer.StartElement("line").Attribute("x1", x).Attribute("y1", y).Attribute("x2", x + 18).Attribute("y2", y).Attribute("stroke", color.ToCss()).Attribute("stroke-width", ChartVisualPrimitives.LegendLineStrokeWidth).Attribute("stroke-linecap", "round").EndEmptyElement().Line();

--- a/ChartForgeX/Svg/SvgChartRenderer.Helpers.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.Helpers.cs
@@ -165,7 +165,7 @@ public sealed partial class SvgChartRenderer {
     private static void DrawLegendSymbol(SvgMarkupWriter writer, ChartSeriesKind kind, double x, double y, ChartColor color, ChartColor background, bool showOptionalLineMarker) {
         if (IsLineLikeLegend(kind)) {
             WriteLegendLineSymbol(writer, x, y, color);
-            if (!UsesOptionalLineMarker(kind) || showOptionalLineMarker) WriteLegendCircleSymbol(writer, x, y, color, background);
+            if (!ChartSeriesKindTraits.UsesOptionalLineMarker(kind) || showOptionalLineMarker) WriteLegendCircleSymbol(writer, x, y, color, background);
         } else if (kind == ChartSeriesKind.Scatter || kind == ChartSeriesKind.Bubble) {
             WriteLegendCircleSymbol(writer, x, y, color, background);
         } else if (kind == ChartSeriesKind.Candlestick || kind == ChartSeriesKind.Ohlc) {
@@ -175,8 +175,6 @@ public sealed partial class SvgChartRenderer {
             writer.StartElement("rect").Attribute("x", x).Attribute("y", y - 5).Attribute("width", "10").Attribute("height", "10").Attribute("rx", "2").Attribute("fill", color.ToCss()).EndEmptyElement().Line();
         }
     }
-
-    private static bool UsesOptionalLineMarker(ChartSeriesKind kind) => kind == ChartSeriesKind.Line || kind == ChartSeriesKind.StepLine;
 
     private static void WriteLegendLineSymbol(SvgMarkupWriter writer, double x, double y, ChartColor color) {
         writer.StartElement("line").Attribute("x1", x).Attribute("y1", y).Attribute("x2", x + 18).Attribute("y2", y).Attribute("stroke", color.ToCss()).Attribute("stroke-width", ChartVisualPrimitives.LegendLineStrokeWidth).Attribute("stroke-linecap", "round").EndEmptyElement().Line();

--- a/ChartForgeX/Svg/SvgChartRenderer.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.cs
@@ -644,7 +644,7 @@ public sealed partial class SvgChartRenderer {
             if (s.Kind == ChartSeriesKind.StepArea) line = BuildStepLinePath(mapped);
             var lineRole = s.Kind == ChartSeriesKind.StepLine ? "step-line" : s.Kind == ChartSeriesKind.StepArea ? "step-area-line" : s.Kind == ChartSeriesKind.Area ? "area-line" : "line";
             DrawPremiumSvgLinePath(sb, lineRole, index, mapped.Length, line, c, s.StrokeWidth, chart.Options.LineVisualStyle);
-            if (!chart.Options.IsSparkline && chart.Options.Theme.MarkerRadius > 0) {
+            if (!chart.Options.IsSparkline && chart.Options.Theme.MarkerRadius > 0 && ChartSeriesKindTraits.UsesOptionalLineMarker(s.Kind)) {
                 for (var pointIndex = 0; pointIndex < mapped.Length; pointIndex++) {
                     var p = mapped[pointIndex];
                     var raw = s.Points[pointIndex];

--- a/ChartForgeX/Svg/SvgChartRenderer.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.cs
@@ -644,7 +644,7 @@ public sealed partial class SvgChartRenderer {
             if (s.Kind == ChartSeriesKind.StepArea) line = BuildStepLinePath(mapped);
             var lineRole = s.Kind == ChartSeriesKind.StepLine ? "step-line" : s.Kind == ChartSeriesKind.StepArea ? "step-area-line" : s.Kind == ChartSeriesKind.Area ? "area-line" : "line";
             DrawPremiumSvgLinePath(sb, lineRole, index, mapped.Length, line, c, s.StrokeWidth, chart.Options.LineVisualStyle);
-            if (!chart.Options.IsSparkline) {
+            if (!chart.Options.IsSparkline && chart.Options.Theme.MarkerRadius > 0) {
                 for (var pointIndex = 0; pointIndex < mapped.Length; pointIndex++) {
                     var p = mapped[pointIndex];
                     var raw = s.Points[pointIndex];

--- a/ChartForgeX/Svg/SvgChartRenderer.cs
+++ b/ChartForgeX/Svg/SvgChartRenderer.cs
@@ -92,7 +92,8 @@ public sealed partial class SvgChartRenderer {
         var w = o.Size.Width;
         var h = o.Size.Height;
         var plot = PlotArea(chart);
-        var range = ChartRange.FromChart(chart);
+        var barCoordinateMap = ChartBarCoordinateMap.Create(chart);
+        var range = ChartRange.FromChart(chart, barCoordinateMap);
         IReadOnlyList<double> xTicks = Array.Empty<double>();
         IReadOnlyList<double> yTicks = Array.Empty<double>();
         ChartRange? secondaryRange = null;
@@ -357,7 +358,7 @@ public sealed partial class SvgChartRenderer {
         if (IsHorizontalBarChart(chart)) {
             DrawHorizontalBarGrid(sb, chart, plot, xTicks, yTicks, map);
             AppendSvgStart(sb, writer => writer.StartElement("g").Attribute("clip-path", $"url(#{id}-plotClip)").EndStartElement().Line());
-            for (var i = 0; i < chart.Series.Count; i++) DrawSeries(sb, chart, i, plot, range, map, id);
+            for (var i = 0; i < chart.Series.Count; i++) DrawSeries(sb, chart, barCoordinateMap, i, plot, range, map, id);
             AppendSvgEnd(sb, "g");
             if (o.BarMode == ChartBarMode.Stacked && o.ShowStackTotals) DrawHorizontalStackTotals(sb, chart, plot, map);
             DrawLegend(sb, chart, w, h);
@@ -370,8 +371,8 @@ public sealed partial class SvgChartRenderer {
         DrawGrid(sb, chart, plot, xTicks, yTicks, map);
         if (secondaryMap != null && secondaryTicks != null) DrawSecondaryYAxis(sb, chart, plot, secondaryTicks, secondaryMap);
         AppendSvgStart(sb, writer => writer.StartElement("g").Attribute("clip-path", $"url(#{id}-plotClip)").EndStartElement().Line());
-        for (var i = 0; i < chart.Series.Count; i++) DrawSeries(sb, chart, i, plot, range, SeriesMap(chart.Series[i], map, secondaryMap), id);
-        if (o.BarMode == ChartBarMode.Stacked && o.ShowStackTotals) DrawStackTotals(sb, chart, plot, map);
+        for (var i = 0; i < chart.Series.Count; i++) DrawSeries(sb, chart, barCoordinateMap, i, plot, range, SeriesMap(chart.Series[i], map, secondaryMap), id);
+        if (o.BarMode == ChartBarMode.Stacked && o.ShowStackTotals) DrawStackTotals(sb, chart, barCoordinateMap, plot, map);
         AppendSvgEnd(sb, "g");
         DrawAnnotationLines(sb, chart, plot, map);
         DrawLegend(sb, chart, w, h);
@@ -606,10 +607,10 @@ public sealed partial class SvgChartRenderer {
         return $"M {F(left)} {F(cy)} A {F(radius)} {F(radius)} 0 1 1 {F(right)} {F(cy)} A {F(radius)} {F(radius)} 0 1 1 {F(left)} {F(cy)} M {F(innerLeft)} {F(cy)} A {F(innerRadius)} {F(innerRadius)} 0 1 0 {F(innerRight)} {F(cy)} A {F(innerRadius)} {F(innerRadius)} 0 1 0 {F(innerLeft)} {F(cy)} Z";
     }
 
-    private static void DrawSeries(StringBuilder sb, Chart chart, int index, ChartRect plot, ChartRange range, ChartMapper map, string id) {
+    private static void DrawSeries(StringBuilder sb, Chart chart, ChartBarCoordinateMap barCoordinateMap, int index, ChartRect plot, ChartRange range, ChartMapper map, string id) {
         var s = chart.Series[index]; var c = Color(chart, index); if (s.Points.Count == 0) return;
         if (s.Kind == ChartSeriesKind.HorizontalBar) { DrawHorizontalBars(sb, chart, index, plot, map, id); return; }
-        if (s.Kind == ChartSeriesKind.Bar) { DrawBars(sb, chart, index, plot, range, map, id); return; }
+        if (s.Kind == ChartSeriesKind.Bar) { DrawBars(sb, chart, barCoordinateMap, index, plot, range, map, id); return; }
         if (s.Kind == ChartSeriesKind.Lollipop) { DrawLollipops(sb, chart, index, plot, map); return; }
         if (s.Kind == ChartSeriesKind.RangeBar) { DrawRangeBars(sb, chart, index, plot, map, id); return; }
         if (s.Kind == ChartSeriesKind.BoxPlot) { DrawBoxPlots(sb, chart, index, plot, map); return; }

--- a/ChartForgeX/Themes/ChartTheme.cs
+++ b/ChartForgeX/Themes/ChartTheme.cs
@@ -184,7 +184,9 @@ public sealed partial class ChartTheme {
     }
 
     /// <summary>
-    /// Gets or sets the marker radius used by SVG line and scatter renderers.
+    /// Gets or sets the marker radius used by SVG and PNG point-capable renderers.
+    /// A value of zero suppresses optional line markers while preserving markers required by
+    /// scatter and specialized chart types.
     /// </summary>
     public double MarkerRadius {
         get => _markerRadius;
@@ -374,7 +376,7 @@ public sealed partial class ChartTheme {
     /// <summary>
     /// Applies the marker radius used by point-capable renderers.
     /// </summary>
-    /// <param name="markerRadius">The marker radius.</param>
+    /// <param name="markerRadius">The non-negative marker radius. Use zero to suppress optional line markers.</param>
     /// <returns>The current theme.</returns>
     public ChartTheme WithMarkerRadius(double markerRadius) {
         MarkerRadius = markerRadius;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <ChartForgeXProductVersion>1.0.1</ChartForgeXProductVersion>
+    <ChartForgeXProductVersion>1.0.2</ChartForgeXProductVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ChartForgeX' Or '$(MSBuildProjectName)' == 'ChartForgeX.Interactivity' Or '$(MSBuildProjectName)' == 'ChartForgeX.Interactivity.Html' Or '$(MSBuildProjectName)' == 'ChartForgeX.Markup' Or '$(MSBuildProjectName)' == 'ChartForgeX.Mermaid' Or '$(MSBuildProjectName)' == 'ChartForgeX.Markup.Mermaid'">


### PR DESCRIPTION
## Summary

- define `ChartTheme.MarkerRadius = 0` as the shared way to suppress optional line and area markers in both plot marks and legends
- preserve SVG/PNG marker parity while keeping scatter and specialized minimum-radius markers unchanged
- add `ChartHistogramBinLayout` so multiple histogram series can share exact count- or width-based bounds
- assign human decimal boundary values consistently while preserving the immediately-lower IEEE value in its original bin
- avoid floating-point phantom bins, retain real remainder bins, and render proportional numeric bin widths in SVG and PNG
- group regular bars with histogram bars at matching numeric bin centers instead of letting independent layouts overlap
- use one ULP-scale coordinate identity for grouping, stacking, and range calculation so decimal-equivalent stacks are not clipped while narrow adjacent bins remain distinct
- expose the validated `ChartSeriesKindCapabilities.IsExclusive` API so adapters can reuse ChartForgeX's series ownership rules instead of copying enum lists
- prepare all six ChartForgeX packages as version 1.0.2

## Downstream

ImagePlayground PR #218 consumes these contracts while keeping all 33 `New-ImageChart*` commands as thin PowerShell adapters. It uses the shared marker, histogram, and exclusive-series rules without adding a renderer or temporary package workaround. Its hosted checks should be rerun after all six 1.0.2 packages are public.