### PR TITLE
Improve Mermaid flowchart layout and sizing

### DIFF
--- a/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
+++ b/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Interactivity.Html</PackageId>
-    <Version>1.0.2</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Self-contained HTML, SVG, and graph explorer interaction adapter for ChartForgeX charts and graph scenes.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
+++ b/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Interactivity</PackageId>
-    <Version>1.0.2</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Host-neutral interaction contracts for ChartForgeX chart renderers and adapters.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Markup.Mermaid/ChartForgeX.Markup.Mermaid.csproj
+++ b/ChartForgeX.Markup.Mermaid/ChartForgeX.Markup.Mermaid.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Markup.Mermaid</PackageId>
-    <Version>1.0.2</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Mermaid fenced-block adapter for ChartForgeX markup visual artifact pipelines.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Markup.Mermaid/MermaidVisualMarkupBlockParser.Cloning.cs
+++ b/ChartForgeX.Markup.Mermaid/MermaidVisualMarkupBlockParser.Cloning.cs
@@ -3,15 +3,25 @@ using ChartForgeX.Mermaid;
 namespace ChartForgeX.Markup.Mermaid;
 
 public sealed partial class MermaidVisualMarkupBlockParser {
-    private static MermaidFlowchartRenderOptions Clone(MermaidFlowchartRenderOptions options) =>
-        new() {
+    private static MermaidFlowchartRenderOptions Clone(MermaidFlowchartRenderOptions options) {
+        var clone = new MermaidFlowchartRenderOptions {
             Id = options.Id,
             Title = options.Title,
             Subtitle = options.Subtitle,
-            Width = options.Width,
-            Height = options.Height,
-            Padding = options.Padding
+            FitContent = options.FitContent,
+            Padding = options.Padding,
+            MinimumFittedWidth = options.MinimumFittedWidth,
+            MinimumFittedHeight = options.MinimumFittedHeight,
+            MaximumFittedWidth = options.MaximumFittedWidth,
+            MaximumFittedHeight = options.MaximumFittedHeight
         };
+        if (options.HasExplicitViewportSize) {
+            clone.Width = options.Width;
+            clone.Height = options.Height;
+        }
+
+        return clone;
+    }
 
     private static MermaidSequenceRenderOptions Clone(MermaidSequenceRenderOptions options) =>
         new() {

--- a/ChartForgeX.Markup.Mermaid/MermaidVisualMarkupBlockParser.cs
+++ b/ChartForgeX.Markup.Mermaid/MermaidVisualMarkupBlockParser.cs
@@ -383,8 +383,10 @@ public sealed partial class MermaidVisualMarkupBlockParser : IVisualMarkupBlockP
         if (TryGetAttribute(block, "id", out var id) && !string.IsNullOrWhiteSpace(id)) options.Id = id;
         if (TryGetAttribute(block, "title", out var title) && !string.IsNullOrWhiteSpace(title)) options.Title = title;
         if (TryGetAttribute(block, "subtitle", out var subtitle) && !string.IsNullOrWhiteSpace(subtitle)) options.Subtitle = subtitle;
-        if (TryReadDoubleAttribute(block, "width", out var parsedWidth)) options.Width = parsedWidth;
-        if (TryReadDoubleAttribute(block, "height", out var parsedHeight)) options.Height = parsedHeight;
+        var hasExplicitWidth = TryReadDoubleAttribute(block, "width", out var parsedWidth);
+        var hasExplicitHeight = TryReadDoubleAttribute(block, "height", out var parsedHeight);
+        if (hasExplicitWidth) options.Width = parsedWidth;
+        if (hasExplicitHeight) options.Height = parsedHeight;
         if (TryReadDoubleAttribute(block, "padding", out var parsedPadding)) options.Padding = parsedPadding;
         return options;
     }

--- a/ChartForgeX.Markup/ChartForgeX.Markup.csproj
+++ b/ChartForgeX.Markup/ChartForgeX.Markup.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Markup</PackageId>
-    <Version>1.0.2</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Markdown-friendly ChartForgeX markup parser and code emitter for charts and topology diagrams.</Description>
     <PackageReleaseNotes>Adds direct validation and projection for visual fences discovered by another Markdown parser.</PackageReleaseNotes>

--- a/ChartForgeX.Mermaid/ChartForgeX.Mermaid.csproj
+++ b/ChartForgeX.Mermaid/ChartForgeX.Mermaid.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX.Mermaid</PackageId>
-    <Version>1.0.2</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Native Mermaid compatibility parsing foundations for ChartForgeX visual artifact pipelines.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX.Mermaid/MermaidFlowchartLayering.cs
+++ b/ChartForgeX.Mermaid/MermaidFlowchartLayering.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+
+namespace ChartForgeX.Mermaid;
+
+/// <summary>
+/// Infers deterministic topology layers from Mermaid flowchart edges.
+/// </summary>
+internal static class MermaidFlowchartLayering {
+    public static IReadOnlyDictionary<string, int> Infer(MermaidFlowchartDocument document) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+
+        var order = new Dictionary<string, int>(StringComparer.Ordinal);
+        var adjacency = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var incoming = new Dictionary<string, int>(StringComparer.Ordinal);
+        var layers = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var index = 0; index < document.Nodes.Count; index++) {
+            var id = document.Nodes[index].Id;
+            if (order.ContainsKey(id)) continue;
+            order[id] = order.Count;
+            adjacency[id] = new List<string>();
+            incoming[id] = 0;
+            layers[id] = 0;
+        }
+
+        var edges = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var edge in document.Edges) {
+            var sourceId = edge.SourceId;
+            var targetId = edge.TargetId;
+            if (IsBackwardOnly(edge.Operator)) {
+                sourceId = edge.TargetId;
+                targetId = edge.SourceId;
+            }
+
+            if (!adjacency.ContainsKey(sourceId)
+                || !adjacency.ContainsKey(targetId)
+                || string.Equals(sourceId, targetId, StringComparison.Ordinal)) {
+                continue;
+            }
+
+            var key = sourceId + "\u001f" + targetId;
+            if (!edges.Add(key)) continue;
+            adjacency[sourceId].Add(targetId);
+            incoming[targetId]++;
+        }
+
+        var ready = new SortedSet<NodeOrder>(NodeOrderComparer.Instance);
+        foreach (var node in order) {
+            if (incoming[node.Key] == 0) ready.Add(new NodeOrder(node.Key, node.Value));
+        }
+
+        var processed = new HashSet<string>(StringComparer.Ordinal);
+        while (processed.Count < order.Count) {
+            if (ready.Count == 0) {
+                // Mermaid permits cycles. Break the next cycle at its first declared node,
+                // retaining a deterministic forward flow for the remaining edges.
+                foreach (var node in order) {
+                    if (processed.Contains(node.Key)) continue;
+                    ready.Add(new NodeOrder(node.Key, node.Value));
+                    break;
+                }
+            }
+
+            var current = ready.Min;
+            ready.Remove(current);
+            if (!processed.Add(current.Id)) continue;
+
+            foreach (var target in adjacency[current.Id]) {
+                if (processed.Contains(target)) continue;
+                layers[target] = Math.Max(layers[target], layers[current.Id] + 1);
+                incoming[target] = Math.Max(0, incoming[target] - 1);
+                if (incoming[target] == 0) ready.Add(new NodeOrder(target, order[target]));
+            }
+        }
+
+        return layers;
+    }
+
+    private static bool IsBackwardOnly(string edgeOperator) =>
+        edgeOperator.IndexOf('<') >= 0 && edgeOperator.IndexOf('>') < 0;
+
+    private readonly struct NodeOrder {
+        public NodeOrder(string id, int order) {
+            Id = id;
+            Order = order;
+        }
+
+        public string Id { get; }
+
+        public int Order { get; }
+    }
+
+    private sealed class NodeOrderComparer : IComparer<NodeOrder> {
+        public static NodeOrderComparer Instance { get; } = new NodeOrderComparer();
+
+        public int Compare(NodeOrder left, NodeOrder right) {
+            var order = left.Order.CompareTo(right.Order);
+            return order != 0 ? order : StringComparer.Ordinal.Compare(left.Id, right.Id);
+        }
+    }
+}

--- a/ChartForgeX.Mermaid/MermaidFlowchartParser.cs
+++ b/ChartForgeX.Mermaid/MermaidFlowchartParser.cs
@@ -476,7 +476,7 @@ internal static class MermaidFlowchartParser {
     }
 
     private static string Unquote(string value) {
-        if (value.Length >= 2 && ((value[0] == '"' && value[value.Length - 1] == '"') || (value[0] == '\'' && value[value.Length - 1] == '\''))) return value.Substring(1, value.Length - 2);
+        if (value.Length >= 2 && value[0] == '"' && value[value.Length - 1] == '"') return value.Substring(1, value.Length - 2);
         return value;
     }
 

--- a/ChartForgeX.Mermaid/MermaidFlowchartParser.cs
+++ b/ChartForgeX.Mermaid/MermaidFlowchartParser.cs
@@ -108,7 +108,7 @@ internal static class MermaidFlowchartParser {
         var bracketEnd = value.LastIndexOf(']');
         if (bracketStart > 0 && bracketEnd > bracketStart) {
             id = value.Substring(0, bracketStart).Trim();
-            title = value.Substring(bracketStart + 1, bracketEnd - bracketStart - 1).Trim();
+            title = Unquote(value.Substring(bracketStart + 1, bracketEnd - bracketStart - 1).Trim());
         } else {
             title = Unquote(value);
             id = Slug(title);
@@ -232,7 +232,7 @@ internal static class MermaidFlowchartParser {
             if (text[index + 1] != ']') continue;
             if (text[index] != '/' && text[index] != '\\') continue;
 
-            label = text.Substring(contentStart, index - contentStart);
+            label = Unquote(text.Substring(contentStart, index - contentStart));
             shape = openingSlash == '/'
                 ? text[index] == '/' ? MermaidFlowchartNodeShape.Parallelogram : MermaidFlowchartNodeShape.Trapezoid
                 : text[index] == '\\' ? MermaidFlowchartNodeShape.ParallelogramAlt : MermaidFlowchartNodeShape.TrapezoidAlt;
@@ -254,7 +254,7 @@ internal static class MermaidFlowchartParser {
             return false;
         }
 
-        label = text.Substring(contentStart, closeIndex - contentStart);
+        label = Unquote(text.Substring(contentStart, closeIndex - contentStart));
         shape = nodeShape;
         position = closeIndex + close.Length;
         return true;
@@ -290,7 +290,7 @@ internal static class MermaidFlowchartParser {
         if (secondPipe < 0) return false;
 
         edgeOperator = before;
-        label = text.Substring(firstPipe + 1, secondPipe - firstPipe - 1).Trim();
+        label = Unquote(text.Substring(firstPipe + 1, secondPipe - firstPipe - 1).Trim());
         position = secondPipe + 1;
         return true;
     }
@@ -310,7 +310,7 @@ internal static class MermaidFlowchartParser {
             if (candidateLabel.Length == 0) continue;
 
             edgeOperator = text.Substring(start, suffixIndex + suffix.Length - start).Trim();
-            label = candidateLabel;
+            label = Unquote(candidateLabel);
             position = suffixIndex + suffix.Length;
             return true;
         }

--- a/ChartForgeX.Mermaid/MermaidFlowchartRendering.cs
+++ b/ChartForgeX.Mermaid/MermaidFlowchartRendering.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using ChartForgeX.Topology;
 using ChartForgeX.VisualArtifacts;
 
@@ -26,6 +27,8 @@ public static class MermaidFlowchartRendering {
             .WithSubtitle(ResolveSubtitle(document, options))
             .WithViewport(options.Width, options.Height, options.Padding)
             .WithLayout(TopologyLayoutMode.Layered, ToVisualLinkDirection(document.Direction));
+        var inferredLayers = MermaidFlowchartLayering.Infer(document);
+        var fitViewport = options.FitContent && !options.HasExplicitViewportSize;
 
         for (var index = 0; index < document.Subgraphs.Count; index++) {
             var subgraph = document.Subgraphs[index];
@@ -53,13 +56,16 @@ public static class MermaidFlowchartRendering {
                 groupId: node.SubgraphId,
                 href: node.Href,
                 tooltip: node.Tooltip,
-                width: ToNodeWidth(node.Shape),
+                width: ToNodeWidth(node.Shape, label, options.FitContent),
                 height: ToNodeHeight(node.Shape),
                 color: StyleValue(node.Styles, "stroke") ?? StyleValue(node.Styles, "color"),
                 cssClass: "cfx-mermaid-node cfx-mermaid-shape-" + ToShapeToken(node.Shape));
 
             var target = chart.Nodes[chart.Nodes.Count - 1];
+            target.ShowStatusBadge = false;
             target.DisplayMode = ToDisplayMode(node.Shape);
+            target.PreserveDisplayModeSize = target.DisplayMode == TopologyNodeDisplayMode.Pill;
+            target.MaximumLabelCharacters = 28;
             target.BackgroundColor = StyleValue(node.Styles, "fill");
             target.Metadata["mermaid.id"] = node.Id;
             target.Metadata["mermaid.shape"] = node.Shape.ToString();
@@ -67,6 +73,10 @@ public static class MermaidFlowchartRendering {
             target.Metadata["mermaid.source.line"] = node.Span.Line.ToString(CultureInfo.InvariantCulture);
             target.Metadata["mermaid.source.column"] = node.Span.Column.ToString(CultureInfo.InvariantCulture);
             target.Metadata["mermaid.order"] = index.ToString(CultureInfo.InvariantCulture);
+            if (inferredLayers.TryGetValue(node.Id, out var inferredLayer)) {
+                target.Metadata["layer"] = inferredLayer.ToString(CultureInfo.InvariantCulture);
+                target.Metadata["mermaid.layer"] = inferredLayer.ToString(CultureInfo.InvariantCulture);
+            }
             if (node.SubgraphId != null) target.Metadata["mermaid.subgraph"] = node.SubgraphId;
             if (node.Classes.Count > 0) target.Metadata["mermaid.classes"] = string.Join(",", node.Classes);
             WriteStyleMetadata(target.Metadata, node.Styles, "mermaid.style.");
@@ -99,6 +109,8 @@ public static class MermaidFlowchartRendering {
             if (!string.IsNullOrWhiteSpace(edge.Label)) target.Metadata["mermaid.label"] = edge.Label!;
             WriteStyleMetadata(target.Metadata, edge.Styles, "mermaid.style.");
         }
+
+        if (fitViewport) ApplyContentFittedViewport(chart, document.Direction, options);
 
         return chart;
     }
@@ -239,7 +251,14 @@ public static class MermaidFlowchartRendering {
         }
     }
 
-    private static double ToNodeWidth(MermaidFlowchartNodeShape shape) {
+    private static double ToNodeWidth(MermaidFlowchartNodeShape shape, string label, bool fitContent) {
+        var shapeWidth = BaseNodeWidth(shape);
+        if (!fitContent) return shapeWidth;
+        var labelWidth = 70 + Math.Min(28, Math.Max(0, label.Length)) * 7.1;
+        return Clamp(Math.Max(shapeWidth, labelWidth), shapeWidth, 268);
+    }
+
+    private static double BaseNodeWidth(MermaidFlowchartNodeShape shape) {
         switch (shape) {
             case MermaidFlowchartNodeShape.Circle:
             case MermaidFlowchartNodeShape.DoubleCircle:
@@ -251,6 +270,51 @@ public static class MermaidFlowchartRendering {
                 return 132;
         }
     }
+
+    private static void ApplyContentFittedViewport(
+        TopologyChart chart,
+        MermaidFlowchartDirection direction,
+        MermaidFlowchartRenderOptions options) {
+        if (chart.Nodes.Count == 0) return;
+        var padding = options.Padding;
+        var headerHeight = string.IsNullOrWhiteSpace(chart.Title) ? 0 : 72;
+        var layers = chart.Nodes
+            .GroupBy(node => node.Metadata.TryGetValue("layer", out var value)
+                && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layer)
+                    ? layer
+                    : 0)
+            .OrderBy(group => group.Key)
+            .ToArray();
+        var horizontal = direction is MermaidFlowchartDirection.LeftToRight or MermaidFlowchartDirection.RightToLeft;
+        double requiredWidth;
+        double requiredHeight;
+        if (horizontal) {
+            requiredWidth = padding * 2
+                + layers.Sum(layer => layer.Max(node => node.Width))
+                + Math.Max(0, layers.Length - 1) * 72;
+            requiredHeight = padding * 2 + headerHeight
+                + layers.Max(layer => layer.Sum(node => node.Height) + Math.Max(0, layer.Count() - 1) * 34);
+        } else {
+            requiredWidth = padding * 2
+                + layers.Max(layer => layer.Sum(node => node.Width) + Math.Max(0, layer.Count() - 1) * 34);
+            requiredHeight = padding * 2 + headerHeight
+                + layers.Sum(layer => layer.Max(node => node.Height))
+                + Math.Max(0, layers.Length - 1) * 58;
+        }
+
+        if (chart.Groups.Count > 0) {
+            requiredWidth += horizontal ? chart.Groups.Count * 16 : 48;
+            requiredHeight += horizontal ? 48 : chart.Groups.Count * 16;
+        }
+
+        chart.WithViewport(
+            Clamp(requiredWidth, Math.Min(options.MinimumFittedWidth, options.MaximumFittedWidth), Math.Max(options.MinimumFittedWidth, options.MaximumFittedWidth)),
+            Clamp(requiredHeight, Math.Min(options.MinimumFittedHeight, options.MaximumFittedHeight), Math.Max(options.MinimumFittedHeight, options.MaximumFittedHeight)),
+            padding);
+    }
+
+    private static double Clamp(double value, double minimum, double maximum) =>
+        Math.Max(minimum, Math.Min(maximum, value));
 
     private static double ToNodeHeight(MermaidFlowchartNodeShape shape) {
         switch (shape) {
@@ -286,6 +350,11 @@ public sealed class MermaidFlowchartRenderOptions {
     private double _width = 1200;
     private double _height = 700;
     private double _padding = 32;
+    private double _minimumFittedWidth = 640;
+    private double _minimumFittedHeight = 320;
+    private double _maximumFittedWidth = 2800;
+    private double _maximumFittedHeight = 1800;
+    private bool _hasExplicitViewportSize;
 
     /// <summary>Gets or sets the rendered artifact id.</summary>
     public string? Id { get; set; }
@@ -296,12 +365,19 @@ public sealed class MermaidFlowchartRenderOptions {
     /// <summary>Gets or sets an optional chart subtitle override.</summary>
     public string? Subtitle { get; set; }
 
+    /// <summary>Gets or sets whether the viewport and node widths should fit the parsed graph content.</summary>
+    public bool FitContent { get; set; } = true;
+
+    /// <summary>Gets whether a caller explicitly assigned the viewport width or height.</summary>
+    public bool HasExplicitViewportSize => _hasExplicitViewportSize;
+
     /// <summary>Gets or sets the topology viewport width.</summary>
     public double Width {
         get => _width;
         set {
             if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Mermaid flowchart width must be finite and greater than zero.");
             _width = value;
+            _hasExplicitViewportSize = true;
         }
     }
 
@@ -311,6 +387,7 @@ public sealed class MermaidFlowchartRenderOptions {
         set {
             if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Mermaid flowchart height must be finite and greater than zero.");
             _height = value;
+            _hasExplicitViewportSize = true;
         }
     }
 
@@ -320,6 +397,42 @@ public sealed class MermaidFlowchartRenderOptions {
         set {
             if (double.IsNaN(value) || double.IsInfinity(value) || value < 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Mermaid flowchart padding must be finite and non-negative.");
             _padding = value;
+        }
+    }
+
+    /// <summary>Gets or sets the minimum width used by content-fitted flowcharts.</summary>
+    public double MinimumFittedWidth {
+        get => _minimumFittedWidth;
+        set {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Minimum fitted width must be finite and greater than zero.");
+            _minimumFittedWidth = value;
+        }
+    }
+
+    /// <summary>Gets or sets the minimum height used by content-fitted flowcharts.</summary>
+    public double MinimumFittedHeight {
+        get => _minimumFittedHeight;
+        set {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Minimum fitted height must be finite and greater than zero.");
+            _minimumFittedHeight = value;
+        }
+    }
+
+    /// <summary>Gets or sets the maximum width used by content-fitted flowcharts.</summary>
+    public double MaximumFittedWidth {
+        get => _maximumFittedWidth;
+        set {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Maximum fitted width must be finite and greater than zero.");
+            _maximumFittedWidth = value;
+        }
+    }
+
+    /// <summary>Gets or sets the maximum height used by content-fitted flowcharts.</summary>
+    public double MaximumFittedHeight {
+        get => _maximumFittedHeight;
+        set {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Maximum fitted height must be finite and greater than zero.");
+            _maximumFittedHeight = value;
         }
     }
 }

--- a/ChartForgeX.Mermaid/MermaidFlowchartRendering.cs
+++ b/ChartForgeX.Mermaid/MermaidFlowchartRendering.cs
@@ -64,7 +64,7 @@ public static class MermaidFlowchartRendering {
             var target = chart.Nodes[chart.Nodes.Count - 1];
             target.ShowStatusBadge = false;
             target.DisplayMode = ToDisplayMode(node.Shape);
-            target.PreserveDisplayModeSize = target.DisplayMode == TopologyNodeDisplayMode.Pill;
+            target.PreserveDisplayModeSize = target.DisplayMode is TopologyNodeDisplayMode.Pill or TopologyNodeDisplayMode.Tile;
             target.MaximumLabelCharacters = 28;
             target.BackgroundColor = StyleValue(node.Styles, "fill");
             target.Metadata["mermaid.id"] = node.Id;
@@ -130,6 +130,7 @@ public static class MermaidFlowchartRendering {
         artifact.Title = topology.Title ?? string.Empty;
         artifact.Subtitle = topology.Subtitle ?? string.Empty;
         artifact.NaturalSize = new VisualArtifactSize(topology.Viewport.Width, topology.Viewport.Height);
+        artifact.PreserveNaturalSize = options.HasExplicitViewportSize;
         artifact.ExportFormats = VisualArtifactExportFormat.Svg | VisualArtifactExportFormat.Png | VisualArtifactExportFormat.Html;
         artifact.Metadata["mermaid.kind"] = document.Kind.ToString();
         artifact.Metadata["mermaid.header"] = document.Header;

--- a/ChartForgeX.Mermaid/MermaidFlowchartRendering.cs
+++ b/ChartForgeX.Mermaid/MermaidFlowchartRendering.cs
@@ -149,8 +149,10 @@ public static class MermaidFlowchartRendering {
     /// <param name="document">The parsed Mermaid flowchart document.</param>
     /// <param name="options">Optional conversion and rendering defaults.</param>
     /// <returns>SVG markup.</returns>
-    public static string ToSvg(this MermaidFlowchartDocument document, MermaidFlowchartRenderOptions? options = null) =>
-        document.ToTopologyChart(options).ToSvg();
+    public static string ToSvg(this MermaidFlowchartDocument document, MermaidFlowchartRenderOptions? options = null) {
+        options ??= new MermaidFlowchartRenderOptions();
+        return document.ToTopologyChart(options).ToSvg(ToTopologyRenderOptions(options));
+    }
 
     /// <summary>
     /// Renders a Mermaid flowchart document to static PNG through ChartForgeX topology rendering.
@@ -158,8 +160,13 @@ public static class MermaidFlowchartRendering {
     /// <param name="document">The parsed Mermaid flowchart document.</param>
     /// <param name="options">Optional conversion and rendering defaults.</param>
     /// <returns>PNG bytes.</returns>
-    public static byte[] ToPng(this MermaidFlowchartDocument document, MermaidFlowchartRenderOptions? options = null) =>
-        document.ToTopologyChart(options).ToPng();
+    public static byte[] ToPng(this MermaidFlowchartDocument document, MermaidFlowchartRenderOptions? options = null) {
+        options ??= new MermaidFlowchartRenderOptions();
+        return document.ToTopologyChart(options).ToPng(ToTopologyRenderOptions(options));
+    }
+
+    private static TopologyRenderOptions ToTopologyRenderOptions(MermaidFlowchartRenderOptions options) =>
+        new TopologyRenderOptions { FitContentToViewport = options.HasExplicitViewportSize };
 
     private static string ResolveTitle(MermaidFlowchartDocument document, MermaidFlowchartRenderOptions options) {
         if (!string.IsNullOrWhiteSpace(options.Title)) return options.Title!;

--- a/ChartForgeX.Tests/SmokeTests/MermaidParserTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/MermaidParserTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using ChartForgeX.Core;
 using ChartForgeX.Mermaid;
 using ChartForgeX.Topology;
@@ -9,7 +10,7 @@ namespace ChartForgeX.Tests;
 internal static partial class SmokeTests {
     private static void MermaidParserDetectsFlowchartHeaderAndSourceSpans() {
         const string source = @"flowchart LR
-  user[User] --> app[Native app]
+  user[User] --> app[""Native app""]
   app --> cfx[ChartForgeX]";
 
         var result = new MermaidParser().ParseFlowchart(source);
@@ -26,6 +27,7 @@ internal static partial class SmokeTests {
         Assert(result.Document.Nodes.Count == 3, "Mermaid flowchart parser should extract node references from edge statements.");
         Assert(result.Document.Edges.Count == 2, "Mermaid flowchart parser should extract edge statements.");
         Assert(result.Document.Nodes[0].Id == "user" && result.Document.Nodes[0].Text == "User", "Mermaid flowchart parser should parse bracket node labels.");
+        Assert(result.Document.Nodes[1].Text == "Native app", "Mermaid flowchart parser should remove Mermaid label delimiters from quoted node text.");
         Assert(result.Document.Edges[0].SourceId == "user" && result.Document.Edges[0].TargetId == "app", "Mermaid flowchart parser should preserve edge endpoints.");
     }
 
@@ -150,10 +152,35 @@ flowchart LR
         Assert(topology.LayoutMode == TopologyLayoutMode.Layered, "Mermaid flowchart topology conversion should use deterministic layered layout.");
         Assert(topology.LayoutDirection == TopologyLayoutDirection.LeftToRight, "Mermaid flowchart topology conversion should preserve Mermaid LR direction.");
         Assert(topology.Nodes.Count == 3 && topology.Edges.Count == 2, "Mermaid flowchart topology conversion should map parsed nodes and edges.");
+        Assert(topology.Nodes[0].Metadata["layer"] == "0"
+            && topology.Nodes[1].Metadata["layer"] == "1"
+            && topology.Nodes[2].Metadata["layer"] == "2",
+            "Mermaid flowchart conversion should infer distinct topology layers from edge order instead of stacking generic nodes in one column.");
+        Assert(topology.Viewport.Height < 700 && topology.Viewport.Width >= 640,
+            "Mermaid flowchart conversion should fit the viewport to graph content instead of preserving a mostly empty fixed canvas.");
+        Assert(topology.Nodes[1].Width > 132,
+            "Mermaid flowchart conversion should widen nodes for useful labels instead of clipping them to the legacy fixed width.");
+        Assert(!topology.Nodes[0].ShowStatusBadge,
+            "Mermaid flowchart conversion should suppress meaningless unknown-health badges on semantic diagram nodes.");
         Assert(topology.Nodes[2].Metadata["mermaid.shape"] == MermaidFlowchartNodeShape.Rhombus.ToString(), "Mermaid flowchart topology conversion should preserve node shape metadata.");
         Assert(topology.Edges[0].Label == "opens", "Mermaid flowchart topology conversion should preserve edge labels.");
         Assert(topology.Edges[1].LineStyle == TopologyEdgeLineStyle.Dotted, "Mermaid flowchart topology conversion should map dotted Mermaid edges.");
         Assert(topology.Edges[1].Metadata["mermaid.operator"] == "-.->", "Mermaid flowchart topology conversion should preserve raw edge operators.");
+        Assert(!topology.ToSvg().Contains("data-cfx-role=\"topology-node-status\"", StringComparison.Ordinal),
+            "Mermaid flowchart SVG should omit health-status badges when the source carries no health semantics.");
+
+        var backwardDocument = new MermaidParser().ParseFlowchart("flowchart LR\n  left[Left] <-- right[Right]").Document
+            ?? throw new InvalidOperationException("Backward Mermaid flowchart should produce a document.");
+        var backwardTopology = backwardDocument.ToTopologyChart();
+        Assert(backwardTopology.Nodes.Single(node => node.Id == "right").Metadata["layer"] == "0"
+            && backwardTopology.Nodes.Single(node => node.Id == "left").Metadata["layer"] == "1",
+            "Backward Mermaid arrows should infer layout layers in their semantic arrow direction.");
+
+        var roundedDocument = new MermaidParser().ParseFlowchart("flowchart LR\n  app(Native application service) --> done[Done]").Document
+            ?? throw new InvalidOperationException("Rounded Mermaid flowchart should produce a document.");
+        var roundedTopology = roundedDocument.ToTopologyChart();
+        Assert(roundedTopology.Nodes[0].Width > 112 && roundedTopology.ToSvg().Contains("Native application service", StringComparison.Ordinal),
+            "Rounded Mermaid nodes should preserve fitted width and their complete useful label through final topology rendering.");
 
         var artifact = document.ToVisualArtifact(new MermaidFlowchartRenderOptions { Id = "native-visual" });
         Assert(artifact.Kind == VisualArtifactKind.Mermaid, "Mermaid flowchart visual artifact should report Mermaid artifact kind.");
@@ -194,7 +221,7 @@ linkStyle 0 stroke:#f00,stroke-dasharray: 5 5";
 
     private static void MermaidFlowchartRendersStaticSvgAndPng() {
         const string source = @"flowchart TD
-  a[Start] --> b[(Store)]
+  a(Native application service) --> b[(Store)]
   b --> c((Done))";
 
         var result = new MermaidParser().ParseFlowchart(source);
@@ -202,9 +229,14 @@ linkStyle 0 stroke:#f00,stroke-dasharray: 5 5";
         var document = result.Document ?? throw new InvalidOperationException("Mermaid flowchart parser should produce a document.");
 
         var options = new MermaidFlowchartRenderOptions { Id = "render-proof", Title = "Render proof", Width = 640, Height = 360 };
+        var topology = document.ToTopologyChart(options);
         var svg = document.ToSvg(options);
         var png = document.ToPng(options);
 
+        Assert(topology.Viewport.Width == 640 && topology.Viewport.Height == 360,
+            "Explicit Mermaid flowchart viewport dimensions should take precedence over automatic content fitting.");
+        Assert(topology.Nodes[0].Width > 112 && svg.Contains("Native application service", StringComparison.Ordinal),
+            "Explicit Mermaid viewport dimensions should not disable label-aware node sizing.");
         Assert(svg.Contains("<svg", StringComparison.Ordinal) && svg.Contains("Render proof", StringComparison.Ordinal), "Mermaid flowchart SVG rendering should emit a topology SVG.");
         Assert(png.Length > 64 && png[0] == 0x89 && png[1] == 0x50 && png[2] == 0x4E && png[3] == 0x47, "Mermaid flowchart PNG rendering should emit a valid PNG.");
     }

--- a/ChartForgeX.Tests/SmokeTests/MermaidParserTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/MermaidParserTests.cs
@@ -188,8 +188,11 @@ flowchart LR
         var tileDocument = new MermaidParser().ParseFlowchart("flowchart LR\n  report((Quarterly operations report))").Document
             ?? throw new InvalidOperationException("Tile-label Mermaid flowchart should produce a document.");
         var tileSvg = tileDocument.ToSvg();
+        var tileTopology = tileDocument.ToTopologyChart();
         Assert(tileSvg.Contains("Quarterly operations report", StringComparison.Ordinal),
             "Mermaid tile nodes should apply their node-specific label limit instead of the topology tile default.");
+        Assert(tileTopology.Nodes[0].PreserveDisplayModeSize,
+            "Content-fitted Mermaid tiles should preserve the dimensions used to calculate their fitted viewport.");
 
         var artifact = document.ToVisualArtifact(new MermaidFlowchartRenderOptions { Id = "native-visual" });
         Assert(artifact.Kind == VisualArtifactKind.Mermaid, "Mermaid flowchart visual artifact should report Mermaid artifact kind.");
@@ -240,6 +243,10 @@ linkStyle 0 stroke:#f00,stroke-dasharray: 5 5";
         var topology = document.ToTopologyChart(options);
         var svg = document.ToSvg(options);
         var png = document.ToPng(options);
+        var artifact = document.ToVisualArtifact(options);
+        var artifactSvg = artifact.ToSvg();
+        var artifactHtml = artifact.ToHtmlPage();
+        var artifactPng = artifact.ToPng();
 
         Assert(topology.Viewport.Width == 640 && topology.Viewport.Height == 360,
             "Explicit Mermaid flowchart viewport dimensions should take precedence over automatic content fitting.");
@@ -250,6 +257,23 @@ linkStyle 0 stroke:#f00,stroke-dasharray: 5 5";
         Assert(png[16] == 0 && png[17] == 0 && png[18] == 2 && png[19] == 128
             && png[20] == 0 && png[21] == 0 && png[22] == 1 && png[23] == 104,
             "Explicit Mermaid PNG dimensions should remain 640x360 when layered content needs scaling.");
+        Assert(artifact.PreserveNaturalSize && artifactSvg.Contains("width=\"640\"", StringComparison.Ordinal) && artifactSvg.Contains("height=\"360\"", StringComparison.Ordinal),
+            "Mermaid artifacts should carry the explicit natural-size export policy into generic SVG rendering.");
+        Assert(artifactHtml.Contains("width=\"640\"", StringComparison.Ordinal) && artifactHtml.Contains("height=\"360\"", StringComparison.Ordinal),
+            "Mermaid artifacts should carry the explicit natural-size export policy into generic HTML rendering.");
+        Assert(artifactPng[16] == 0 && artifactPng[17] == 0 && artifactPng[18] == 2 && artifactPng[19] == 128
+            && artifactPng[20] == 0 && artifactPng[21] == 0 && artifactPng[22] == 1 && artifactPng[23] == 104,
+            "Mermaid artifacts should carry the explicit natural-size export policy into generic PNG rendering.");
+        artifact.NaturalSize = new VisualArtifactSize(480, 270);
+        var resizedArtifactSvg = artifact.ToSvg();
+        Assert(resizedArtifactSvg.Contains("width=\"480\"", StringComparison.Ordinal) && resizedArtifactSvg.Contains("height=\"270\"", StringComparison.Ordinal),
+            "Generic topology artifact rendering should honor the artifact natural size when it differs from the model viewport.");
+        Assert(topology.Viewport.Width == 640 && topology.Viewport.Height == 360,
+            "Generic artifact rendering should preserve the caller's topology model while applying an export-only natural size.");
+        var missingNaturalSize = VisualArtifact.Create("missing-natural-size", VisualArtifactKind.Mermaid, topology);
+        missingNaturalSize.PreserveNaturalSize = true;
+        AssertThrows<InvalidOperationException>(() => missingNaturalSize.ToSvg(),
+            "Generic artifact rendering should reject a preserve-natural-size request when no natural size is defined.");
         Assert(svg.Contains("<svg", StringComparison.Ordinal) && svg.Contains("Render proof", StringComparison.Ordinal), "Mermaid flowchart SVG rendering should emit a topology SVG.");
         Assert(png.Length > 64 && png[0] == 0x89 && png[1] == 0x50 && png[2] == 0x4E && png[3] == 0x47, "Mermaid flowchart PNG rendering should emit a valid PNG.");
     }

--- a/ChartForgeX.Tests/SmokeTests/MermaidParserTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/MermaidParserTests.cs
@@ -35,14 +35,15 @@ internal static partial class SmokeTests {
         const string source = @"flowchart LR
   user[User] -->|opens| app(Native app)
   app -- renders --> cfx{ChartForgeX}
-  cfx -.-> report((Report))";
+  cfx -.-> report((Report))
+  era['90s'] -->|'kept'| report";
 
         var result = new MermaidParser().ParseFlowchart(source);
 
         Assert(!result.HasErrors, "Mermaid flowchart parser should parse common nodes, edges, and labels: " + MermaidDiagnostics(result));
         Assert(result.Document != null, "Mermaid flowchart parser should produce a document.");
-        Assert(result.Document!.Nodes.Count == 4, "Mermaid flowchart parser should de-duplicate nodes by id.");
-        Assert(result.Document.Edges.Count == 3, "Mermaid flowchart parser should parse each edge.");
+        Assert(result.Document!.Nodes.Count == 5, "Mermaid flowchart parser should de-duplicate nodes by id.");
+        Assert(result.Document.Edges.Count == 4, "Mermaid flowchart parser should parse each edge.");
         Assert(result.Document.Nodes[0].Shape == MermaidFlowchartNodeShape.Rectangle, "Mermaid flowchart parser should parse rectangle nodes.");
         Assert(result.Document.Nodes[1].Shape == MermaidFlowchartNodeShape.Rounded, "Mermaid flowchart parser should parse rounded nodes.");
         Assert(result.Document.Nodes[2].Shape == MermaidFlowchartNodeShape.Rhombus, "Mermaid flowchart parser should parse rhombus nodes.");
@@ -50,6 +51,8 @@ internal static partial class SmokeTests {
         Assert(result.Document.Edges[0].Label == "opens", "Mermaid flowchart parser should parse pipe edge labels.");
         Assert(result.Document.Edges[1].Label == "renders", "Mermaid flowchart parser should parse inline edge labels.");
         Assert(result.Document.Edges[2].Operator == "-.->", "Mermaid flowchart parser should preserve dotted edge operators.");
+        Assert(result.Document.Nodes[4].Text == "'90s'", "Mermaid flowchart parser should preserve literal apostrophes in bracket labels.");
+        Assert(result.Document.Edges[3].Label == "'kept'", "Mermaid flowchart parser should preserve literal apostrophes in pipe edge labels.");
     }
 
     private static void MermaidParserParsesFlowchartChainedEdgesAndStandaloneNodes() {
@@ -182,6 +185,12 @@ flowchart LR
         Assert(roundedTopology.Nodes[0].Width > 112 && roundedTopology.ToSvg().Contains("Native application service", StringComparison.Ordinal),
             "Rounded Mermaid nodes should preserve fitted width and their complete useful label through final topology rendering.");
 
+        var tileDocument = new MermaidParser().ParseFlowchart("flowchart LR\n  report((Quarterly operations report))").Document
+            ?? throw new InvalidOperationException("Tile-label Mermaid flowchart should produce a document.");
+        var tileSvg = tileDocument.ToSvg();
+        Assert(tileSvg.Contains("Quarterly operations report", StringComparison.Ordinal),
+            "Mermaid tile nodes should apply their node-specific label limit instead of the topology tile default.");
+
         var artifact = document.ToVisualArtifact(new MermaidFlowchartRenderOptions { Id = "native-visual" });
         Assert(artifact.Kind == VisualArtifactKind.Mermaid, "Mermaid flowchart visual artifact should report Mermaid artifact kind.");
         Assert(artifact.SourceLanguage == VisualArtifactSourceLanguage.Mermaid, "Mermaid flowchart visual artifact should preserve source language.");
@@ -220,9 +229,8 @@ linkStyle 0 stroke:#f00,stroke-dasharray: 5 5";
     }
 
     private static void MermaidFlowchartRendersStaticSvgAndPng() {
-        const string source = @"flowchart TD
-  a(Native application service) --> b[(Store)]
-  b --> c((Done))";
+        const string source = @"flowchart LR
+  a(Native application service) --> b[(Store)] --> c((Validate)) --> d[Publish] --> e[Done]";
 
         var result = new MermaidParser().ParseFlowchart(source);
         Assert(!result.HasErrors, "Mermaid flowchart parser should parse render source: " + MermaidDiagnostics(result));
@@ -237,6 +245,11 @@ linkStyle 0 stroke:#f00,stroke-dasharray: 5 5";
             "Explicit Mermaid flowchart viewport dimensions should take precedence over automatic content fitting.");
         Assert(topology.Nodes[0].Width > 112 && svg.Contains("Native application service", StringComparison.Ordinal),
             "Explicit Mermaid viewport dimensions should not disable label-aware node sizing.");
+        Assert(svg.Contains("width=\"640\"", StringComparison.Ordinal) && svg.Contains("height=\"360\"", StringComparison.Ordinal),
+            "Explicit Mermaid SVG dimensions should remain the requested output size when layered content needs scaling.");
+        Assert(png[16] == 0 && png[17] == 0 && png[18] == 2 && png[19] == 128
+            && png[20] == 0 && png[21] == 0 && png[22] == 1 && png[23] == 104,
+            "Explicit Mermaid PNG dimensions should remain 640x360 when layered content needs scaling.");
         Assert(svg.Contains("<svg", StringComparison.Ordinal) && svg.Contains("Render proof", StringComparison.Ordinal), "Mermaid flowchart SVG rendering should emit a topology SVG.");
         Assert(png.Length > 64 && png[0] == 0x89 && png[1] == 0x50 && png[2] == 0x4E && png[3] == 0x47, "Mermaid flowchart PNG rendering should emit a valid PNG.");
     }

--- a/ChartForgeX.Tests/SmokeTests/TopologyReviewRegressionTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/TopologyReviewRegressionTests.cs
@@ -39,6 +39,47 @@ internal static partial class SmokeTests {
         Assert(chart.ToPng(options).Length > 64, "Stacked icon labels and badges should render as PNG.");
     }
 
+    private static void TopologyWrappedTileLabelsHonorNodeCharacterLimits() {
+        var chart = TopologyChart.Create()
+            .WithId("wrapped-tile-limit")
+            .WithViewport(260, 150, 20)
+            .WithLegend(null)
+            .AddNode("service", "Authentication Relationship Service", 60, 50, TopologyNodeKind.Service, TopologyHealthStatus.Healthy, width: 140, height: 58, symbol: "S");
+        chart.Nodes.Single().MaximumLabelCharacters = 12;
+        var options = new TopologyRenderOptions {
+            IncludeLegend = false,
+            NodeDisplayMode = TopologyNodeDisplayMode.Tile,
+            WrapNodeLabels = true,
+            MaxNodeLabelLines = 2
+        };
+
+        var svg = chart.ToSvg(options);
+
+        Assert(svg.Contains(">Authentic...<", StringComparison.Ordinal), "Wrapped tile labels should honor node-specific character limits before line wrapping.");
+        Assert(!svg.Contains("Relationship", StringComparison.Ordinal), "Wrapped tile labels should not bypass node-specific character limits on later lines.");
+        Assert(chart.ToPng(options).Length > 64, "Character-limited wrapped tile labels should preserve PNG parity.");
+    }
+
+    private static void TopologyIconLabelsHonorNodeCharacterLimits() {
+        var chart = TopologyChart.Create()
+            .WithId("icon-label-limit")
+            .WithViewport(180, 120, 16)
+            .WithLegend(null)
+            .AddNode("dc", "NYC-DC1", 56, 36, TopologyNodeKind.Server, TopologyHealthStatus.Healthy, width: 46, height: 42, symbol: "DC");
+        chart.Nodes.Single().MaximumLabelCharacters = 6;
+        var options = new TopologyRenderOptions {
+            IncludeLegend = false,
+            IncludeIconLabels = true,
+            NodeDisplayMode = TopologyNodeDisplayMode.Icon
+        };
+
+        var svg = chart.ToSvg(options);
+
+        Assert(svg.Contains(">NYC...<", StringComparison.Ordinal), "Icon-mode labels should honor node-specific character limits.");
+        Assert(!svg.Contains(">NYC-DC1<", StringComparison.Ordinal), "Icon-mode labels should not bypass node-specific character limits.");
+        Assert(chart.ToPng(options).Length > 64, "Character-limited icon labels should preserve PNG parity.");
+    }
+
     private static void TopologyRoundedRoutesTolerateDuplicateWaypoints() {
         var chart = TopologyChart.Create()
             .WithId("duplicate-waypoint-routes")

--- a/ChartForgeX/ChartForgeX.csproj
+++ b/ChartForgeX/ChartForgeX.csproj
@@ -18,7 +18,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>ChartForgeX</PackageId>
-    <Version>1.0.2</Version>
+    <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Dependency-free SVG, HTML, PNG, GIF, JPEG, BMP, PPM, and TIFF rendering and image composition for .NET charts, visual blocks, report tables, metric cards, wallpapers, and topology diagrams.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ChartForgeX/Topology/TopologyLayoutEngine.Clone.cs
+++ b/ChartForgeX/Topology/TopologyLayoutEngine.Clone.cs
@@ -1,7 +1,7 @@
 namespace ChartForgeX.Topology;
 
 internal static partial class TopologyLayoutEngine {
-    private static TopologyChart Clone(TopologyChart chart) {
+    internal static TopologyChart Clone(TopologyChart chart) {
         var copy = new TopologyChart {
             Id = chart.Id,
             Title = chart.Title,

--- a/ChartForgeX/Topology/TopologyLayoutEngine.Clone.cs
+++ b/ChartForgeX/Topology/TopologyLayoutEngine.Clone.cs
@@ -74,6 +74,9 @@ internal static partial class TopologyLayoutEngine {
             CssClass = node.CssClass,
             Color = node.Color,
             BackgroundColor = node.BackgroundColor,
+            ShowStatusBadge = node.ShowStatusBadge,
+            PreserveDisplayModeSize = node.PreserveDisplayModeSize,
+            MaximumLabelCharacters = node.MaximumLabelCharacters,
             HasPositionOverride = node.HasPositionOverride
         };
         foreach (var item in node.Metrics) copy.Metrics[item.Key] = item.Value;

--- a/ChartForgeX/Topology/TopologyLayoutEngine.cs
+++ b/ChartForgeX/Topology/TopologyLayoutEngine.cs
@@ -53,6 +53,7 @@ internal static partial class TopologyLayoutEngine {
 
     private static void ApplyNodeDisplayMode(TopologyChart chart, TopologyNodeDisplayMode displayMode, bool preserveMindMapSizes) {
         foreach (var node in chart.Nodes) {
+            if (node.PreserveDisplayModeSize) continue;
             switch (node.DisplayMode ?? displayMode) {
                 case TopologyNodeDisplayMode.CompactCard:
                     if (!preserveMindMapSizes) {

--- a/ChartForgeX/Topology/TopologyModels.cs
+++ b/ChartForgeX/Topology/TopologyModels.cs
@@ -257,6 +257,7 @@ public sealed class TopologyNode {
     private double? _latitude;
     private double _width = 120;
     private double _height = 64;
+    private int? _maximumLabelCharacters;
 
     /// <summary>Gets or sets the stable node identifier.</summary>
     public string Id { get => _id; set => _id = value ?? throw new ArgumentNullException(nameof(value)); }
@@ -379,6 +380,21 @@ public sealed class TopologyNode {
 
     /// <summary>Gets or sets an optional node surface fill color. When unset, render options choose the card background.</summary>
     public string? BackgroundColor { get; set; }
+
+    /// <summary>Gets or sets whether renderers may draw a health-status badge for this node.</summary>
+    public bool ShowStatusBadge { get; set; } = true;
+
+    /// <summary>Gets or sets whether display-mode normalization should preserve the caller-provided node width and height.</summary>
+    public bool PreserveDisplayModeSize { get; set; }
+
+    /// <summary>Gets or sets an optional node-specific maximum label length before rendering trims the title.</summary>
+    public int? MaximumLabelCharacters {
+        get => _maximumLabelCharacters;
+        set {
+            if (value is <= 0) throw new ArgumentOutOfRangeException(nameof(value), value, "Maximum label characters must be greater than zero.");
+            _maximumLabelCharacters = value;
+        }
+    }
 
     /// <summary>Gets node metrics for host adapters.</summary>
     public Dictionary<string, string> Metrics { get; } = new();

--- a/ChartForgeX/Topology/TopologyPngRenderer.cs
+++ b/ChartForgeX/Topology/TopologyPngRenderer.cs
@@ -376,7 +376,7 @@ public sealed partial class TopologyPngRenderer {
                 DrawCentered(canvas, CenterX(node), plateY + 3, label, Color(theme.Foreground), 10.5, true);
             } else if (options.IncludeNodeLabels && displayMode != TopologyNodeDisplayMode.Icon) {
                 if (displayMode == TopologyNodeDisplayMode.Tile) {
-                    DrawCenteredLines(canvas, CenterX(node), node.Y + node.Height + 4, NodeTextLines(node.Label, Math.Max(node.Width + 34, 54), 10.5, true, options.MaxNodeLabelLines, options), Color(theme.Foreground), 10.5, true, 13);
+                    DrawCenteredLines(canvas, CenterX(node), node.Y + node.Height + 4, NodeTextLines(node.Label, Math.Max(node.Width + 34, 54), 10.5, true, options.MaxNodeLabelLines, options, NodeTitleMaxLength(node, displayMode)), Color(theme.Foreground), 10.5, true, 13);
                     if (options.IncludeTileSubtitles && !string.IsNullOrWhiteSpace(node.Subtitle)) DrawTileSubtitle(canvas, node, theme, accent, options);
                     DrawNodeBadge(canvas, node, theme, accent, displayMode);
                     continue;

--- a/ChartForgeX/Topology/TopologyPngRenderer.cs
+++ b/ChartForgeX/Topology/TopologyPngRenderer.cs
@@ -387,9 +387,10 @@ public sealed partial class TopologyPngRenderer {
                 var titleSize = displayMode == TopologyNodeDisplayMode.Pill ? 11.5 : displayMode == TopologyNodeDisplayMode.CompactCard ? 11.5 : 12.5;
                 var textRightPadding = 10;
                 var textWidth = Math.Max(24, node.Width - (textX - node.X) - textRightPadding);
-                var titleValue = TrimTo(node.Label, options.AllowMultilineNodeLabels || options.WrapNodeLabels ? NodeLabelMaxLength * Math.Max(1, options.MaxNodeLabelLines) : NodeTitleMaxLength(displayMode));
+                var titleCharacterLimit = NodeTitleMaxLength(node, displayMode);
+                var titleValue = TrimTo(node.Label, options.AllowMultilineNodeLabels || options.WrapNodeLabels ? titleCharacterLimit * Math.Max(1, options.MaxNodeLabelLines) : titleCharacterLimit);
                 titleSize = FitFontSize(NodeTextFitProbe(titleValue, textWidth, titleSize, true, options.MaxNodeLabelLines, options), textWidth, titleSize, 10, true);
-                var titleLines = NodeTextLines(titleValue, textWidth, titleSize, true, options.MaxNodeLabelLines, options);
+                var titleLines = NodeTextLines(titleValue, textWidth, titleSize, true, options.MaxNodeLabelLines, options, titleCharacterLimit);
                 DrawTextLines(canvas, textX, titleY, titleLines, Color(theme.Foreground), titleSize, true, displayMode == TopologyNodeDisplayMode.CompactCard ? 12 : 13);
                 if (displayMode != TopologyNodeDisplayMode.Pill && !string.IsNullOrWhiteSpace(node.Subtitle)) {
                     if (options.CardSubtitleMode == TopologyCardSubtitleMode.Chip) DrawCardSubtitleChip(canvas, node, theme, accent, displayMode, options);

--- a/ChartForgeX/Topology/TopologyRenderPrimitives.IconLabels.cs
+++ b/ChartForgeX/Topology/TopologyRenderPrimitives.IconLabels.cs
@@ -4,7 +4,7 @@ namespace ChartForgeX.Topology;
 
 internal static partial class TopologyRenderPrimitives {
     public static string IconLabelText(TopologyNode node) {
-        return TrimToEstimatedWidth(TrimTo(node.Label, NodeTitleMaxLength(TopologyNodeDisplayMode.Icon)), IconLabelMaxWidth(node), 10.5, true);
+        return TrimToEstimatedWidth(TrimTo(node.Label, NodeTitleMaxLength(node, TopologyNodeDisplayMode.Icon)), IconLabelMaxWidth(node), 10.5, true);
     }
 
     public static double IconLabelMaxWidth(TopologyNode node) => Math.Max(node.Width + 46, 72);

--- a/ChartForgeX/Topology/TopologyRenderPrimitives.NodeText.cs
+++ b/ChartForgeX/Topology/TopologyRenderPrimitives.NodeText.cs
@@ -5,12 +5,13 @@ using System.Text;
 namespace ChartForgeX.Topology;
 
 internal static partial class TopologyRenderPrimitives {
-    public static List<string> NodeTextLines(string value, double maxWidth, double fontSize, bool bold, int maxLines, TopologyRenderOptions options) {
+    public static List<string> NodeTextLines(string value, double maxWidth, double fontSize, bool bold, int maxLines, TopologyRenderOptions options, int maximumCharacters = NodeLabelMaxLength) {
         if (string.IsNullOrWhiteSpace(value)) return new List<string>();
         maxLines = Math.Max(1, maxLines);
         var allowMultiline = options.AllowMultilineNodeLabels;
         var wrap = options.WrapNodeLabels;
-        if (!allowMultiline && !wrap) return new List<string> { TrimToEstimatedWidth(TrimTo(value, NodeLabelMaxLength), maxWidth, fontSize, bold) };
+        maximumCharacters = Math.Max(1, maximumCharacters);
+        if (!allowMultiline && !wrap) return new List<string> { TrimToEstimatedWidth(TrimTo(value, maximumCharacters), maxWidth, fontSize, bold) };
 
         var lines = new List<string>();
         foreach (var explicitLine in SplitExplicitLines(value, allowMultiline)) {
@@ -18,14 +19,14 @@ internal static partial class TopologyRenderPrimitives {
             var trimmed = explicitLine.Trim();
             if (trimmed.Length == 0) continue;
             if (!wrap || EstimateTextWidth(trimmed, fontSize, bold) <= maxWidth) {
-                lines.Add(TrimToEstimatedWidth(TrimTo(trimmed, NodeLabelMaxLength * maxLines), maxWidth, fontSize, bold));
+                lines.Add(TrimToEstimatedWidth(TrimTo(trimmed, maximumCharacters * maxLines), maxWidth, fontSize, bold));
                 continue;
             }
 
             AddWrappedNodeTextLines(lines, trimmed, maxWidth, fontSize, bold, maxLines);
         }
 
-        if (lines.Count == 0) lines.Add(TrimToEstimatedWidth(TrimTo(value.Trim(), NodeLabelMaxLength), maxWidth, fontSize, bold));
+        if (lines.Count == 0) lines.Add(TrimToEstimatedWidth(TrimTo(value.Trim(), maximumCharacters), maxWidth, fontSize, bold));
         if (lines.Count > maxLines) lines.RemoveRange(maxLines, lines.Count - maxLines);
         return lines;
     }

--- a/ChartForgeX/Topology/TopologyRenderPrimitives.NodeText.cs
+++ b/ChartForgeX/Topology/TopologyRenderPrimitives.NodeText.cs
@@ -23,7 +23,7 @@ internal static partial class TopologyRenderPrimitives {
                 continue;
             }
 
-            AddWrappedNodeTextLines(lines, trimmed, maxWidth, fontSize, bold, maxLines);
+            AddWrappedNodeTextLines(lines, trimmed, maxWidth, fontSize, bold, maxLines, maximumCharacters);
         }
 
         if (lines.Count == 0) lines.Add(TrimToEstimatedWidth(TrimTo(value.Trim(), maximumCharacters), maxWidth, fontSize, bold));
@@ -67,7 +67,8 @@ internal static partial class TopologyRenderPrimitives {
         foreach (var line in value.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n')) yield return line;
     }
 
-    private static void AddWrappedNodeTextLines(List<string> lines, string value, double maxWidth, double fontSize, bool bold, int maxLines) {
+    private static void AddWrappedNodeTextLines(List<string> lines, string value, double maxWidth, double fontSize, bool bold, int maxLines, int maximumCharacters) {
+        value = TrimTo(value, maximumCharacters);
         var words = value.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
         var current = new StringBuilder();
         foreach (var word in words) {

--- a/ChartForgeX/Topology/TopologyRenderPrimitives.cs
+++ b/ChartForgeX/Topology/TopologyRenderPrimitives.cs
@@ -150,6 +150,7 @@ internal static partial class TopologyRenderPrimitives {
     public static string NodeGlyph(TopologyNode node) => string.IsNullOrWhiteSpace(node.Symbol) ? KindGlyph(node.Kind) : TrimTo(node.Symbol!.Trim(), 4);
 
     public static bool ShouldRenderNodeStatusBadge(TopologyNode node, TopologyRenderOptions options) {
+        if (!node.ShowStatusBadge) return false;
         var displayMode = EffectiveNodeDisplayMode(node, options);
         if (displayMode == TopologyNodeDisplayMode.Hidden) return false;
         if (displayMode == TopologyNodeDisplayMode.Dot) return false;
@@ -167,6 +168,9 @@ internal static partial class TopologyRenderPrimitives {
             _ => NodeLabelMaxLength
         };
     }
+
+    public static int NodeTitleMaxLength(TopologyNode node, TopologyNodeDisplayMode displayMode) =>
+        node.MaximumLabelCharacters is > 0 ? node.MaximumLabelCharacters.Value : NodeTitleMaxLength(displayMode);
 
     public static double EstimateTextWidth(string value, double fontSize, bool bold) {
         var weightFactor = bold ? 0.62 : 0.56;

--- a/ChartForgeX/Topology/TopologySvgRenderer.Nodes.cs
+++ b/ChartForgeX/Topology/TopologySvgRenderer.Nodes.cs
@@ -186,7 +186,7 @@ public sealed partial class TopologySvgRenderer {
         }
 
         if (displayMode == TopologyNodeDisplayMode.Tile) {
-            AddNodeTextLines(body, NodeTextLines(node.Label, Math.Max(node.Width + 34, 54), 11, true, options.MaxNodeLabelLines, options), CenterX(node), node.Y + node.Height + 15, theme.Foreground, 11, "700", "middle", 14);
+            AddNodeTextLines(body, NodeTextLines(node.Label, Math.Max(node.Width + 34, 54), 11, true, options.MaxNodeLabelLines, options, NodeTitleMaxLength(node, displayMode)), CenterX(node), node.Y + node.Height + 15, theme.Foreground, 11, "700", "middle", 14);
             if (options.IncludeTileSubtitles && !string.IsNullOrWhiteSpace(node.Subtitle)) body.AddElement(BuildTileSubtitle(node, prefix, theme, color, options));
             return body;
         }

--- a/ChartForgeX/Topology/TopologySvgRenderer.Nodes.cs
+++ b/ChartForgeX/Topology/TopologySvgRenderer.Nodes.cs
@@ -197,9 +197,10 @@ public sealed partial class TopologySvgRenderer {
         var titleSize = displayMode == TopologyNodeDisplayMode.Pill ? 11.5 : displayMode == TopologyNodeDisplayMode.CompactCard ? 11.5 : 12.5;
         var textRightPadding = 10;
         var textWidth = Math.Max(24, node.Width - (textX - node.X) - textRightPadding);
-        var titleValue = TrimTo(node.Label, options.AllowMultilineNodeLabels || options.WrapNodeLabels ? NodeLabelMaxLength * Math.Max(1, options.MaxNodeLabelLines) : NodeTitleMaxLength(displayMode));
+        var titleCharacterLimit = NodeTitleMaxLength(node, displayMode);
+        var titleValue = TrimTo(node.Label, options.AllowMultilineNodeLabels || options.WrapNodeLabels ? titleCharacterLimit * Math.Max(1, options.MaxNodeLabelLines) : titleCharacterLimit);
         titleSize = FitFontSize(NodeTextFitProbe(titleValue, textWidth, titleSize, true, options.MaxNodeLabelLines, options), textWidth, titleSize, 10, true);
-        var titleLines = NodeTextLines(titleValue, textWidth, titleSize, true, options.MaxNodeLabelLines, options);
+        var titleLines = NodeTextLines(titleValue, textWidth, titleSize, true, options.MaxNodeLabelLines, options, titleCharacterLimit);
         AddNodeTextLines(body, titleLines, textX, titleY, theme.Foreground, titleSize, "700", null, displayMode == TopologyNodeDisplayMode.CompactCard ? 13 : 14);
         if (displayMode != TopologyNodeDisplayMode.Pill && !string.IsNullOrWhiteSpace(node.Subtitle)) {
             if (options.CardSubtitleMode == TopologyCardSubtitleMode.Chip) body.AddElement(BuildCardSubtitleChip(node, prefix, theme, color, displayMode));

--- a/ChartForgeX/VisualArtifacts/VisualArtifactModels.cs
+++ b/ChartForgeX/VisualArtifacts/VisualArtifactModels.cs
@@ -106,6 +106,12 @@ public sealed class VisualArtifact {
     /// <summary>Gets or sets the artifact's natural size in pixels when known.</summary>
     public VisualArtifactSize? NaturalSize { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether exporters must preserve <see cref="NaturalSize"/>
+    /// when a renderer prepares content on a larger internal canvas.
+    /// </summary>
+    public bool PreserveNaturalSize { get; set; }
+
     /// <summary>Gets artifact metadata for host adapters and exporters.</summary>
     public Dictionary<string, string> Metadata { get; } = new(StringComparer.Ordinal);
 

--- a/ChartForgeX/VisualArtifacts/VisualArtifactRendering.cs
+++ b/ChartForgeX/VisualArtifacts/VisualArtifactRendering.cs
@@ -22,7 +22,7 @@ public static class VisualArtifactRendering {
             case Chart chart:
                 return chart.ToSvg();
             case TopologyChart topology:
-                return topology.ToSvg();
+                return TopologyModel(artifact, topology).ToSvg(TopologyOptions(artifact));
             case FlowArtifact flow:
                 return flow.ToSvg();
             case TableArtifact table:
@@ -47,7 +47,7 @@ public static class VisualArtifactRendering {
             case Chart chart:
                 return chart.ToHtmlPage();
             case TopologyChart topology:
-                return topology.ToHtmlPage();
+                return TopologyModel(artifact, topology).ToHtmlPage(TopologyOptions(artifact));
             case FlowArtifact flow:
                 return flow.ToHtmlPage();
             case TableArtifact table:
@@ -72,7 +72,7 @@ public static class VisualArtifactRendering {
             case Chart chart:
                 return chart.ToPng();
             case TopologyChart topology:
-                return topology.ToPng();
+                return TopologyModel(artifact, topology).ToPng(TopologyOptions(artifact));
             case FlowArtifact flow:
                 return flow.ToPng();
             case TableArtifact table:
@@ -110,6 +110,22 @@ public static class VisualArtifactRendering {
     internal static string WrapSvgPage(string title, string svg) {
         var safeTitle = string.IsNullOrWhiteSpace(title) ? "ChartForgeX visual artifact" : title.Trim();
         return "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>" + EscapeHtml(safeTitle) + "</title><style>html,body{margin:0;min-height:100%;background:linear-gradient(180deg,#f8fafc,#e2e8f0)}body{display:grid;place-items:center;padding:24px;box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Arial,sans-serif;-webkit-font-smoothing:antialiased;text-rendering:geometricPrecision}.chartforgex-visual-artifact{max-width:100%;height:auto}.chartforgex-visual-artifact svg{display:block;max-width:100%;height:auto;overflow:visible}@media print{html,body{background:transparent}body{padding:0}.chartforgex-visual-artifact{max-width:none}}</style></head><body><div class=\"chartforgex-visual-artifact\">" + svg + "</div></body></html>";
+    }
+
+    private static TopologyRenderOptions? TopologyOptions(VisualArtifact artifact) =>
+        artifact.PreserveNaturalSize ? new TopologyRenderOptions { FitContentToViewport = true } : null;
+
+    private static TopologyChart TopologyModel(VisualArtifact artifact, TopologyChart topology) {
+        if (!artifact.PreserveNaturalSize) return topology;
+        if (!artifact.NaturalSize.HasValue) {
+            throw new InvalidOperationException("Artifact '" + artifact.Id + "' cannot preserve its natural size because no natural size is defined.");
+        }
+
+        var naturalSize = artifact.NaturalSize.Value;
+        if (topology.Viewport.Width == naturalSize.Width && topology.Viewport.Height == naturalSize.Height) return topology;
+        var copy = TopologyLayoutEngine.Clone(topology);
+        copy.WithViewport(naturalSize.Width, naturalSize.Height, topology.Viewport.Padding);
+        return copy;
     }
 
     private static string EscapeHtml(string value) {


### PR DESCRIPTION
## Summary
- Infers deterministic Mermaid flowchart layers from edge direction, including backward-only arrows, so topology reads in the direction the diagram expresses.
- Fits default viewports and node widths to useful content, preserves complete labels through SVG and PNG rendering, and removes health badges when Mermaid carries no health semantics.
- Keeps explicitly requested SVG, PNG, and HTML artifact dimensions unchanged by carrying a typed natural-size policy through generic artifact exports.
- Preserves content-fitted Mermaid tile dimensions, literal apostrophes, and per-node label limits consistently across SVG and PNG rendering.
- Normalizes quoted Mermaid labels and keeps explicit markup dimensions compatible.
- Uses Directory.Build.props as the single package-version source instead of six repeated project versions.

## Behavior note
Flowcharts without an explicit viewport now use content fitting by default. Callers that need the former fixed canvas can set FitContent to false. Explicit width or height continues to take precedence for direct and generic artifact output while label-aware node sizing remains enabled.

No package version is bumped and this PR does not publish or release ChartForgeX.

## Validation
- Repository quality loop passed on the current implementation: 743 tests, multi-target build, Mermaid.js fixtures, NativeAOT smoke, generated examples, and package creation.
- The final review-driven artifact fix was revalidated with all 743 tests after adding differing-size, missing-size, and caller-model non-mutation coverage.
- Independent read-only review found one P2 and one P3 in the artifact follow-up; both are fixed and the targeted confirmation accepted the implementation.
- All five addressed inline review threads are resolved.