### PR TITLE
Make VSIX releases repairable

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -194,7 +194,18 @@ jobs:
               return $false
             }
 
-            $listing = $showOutput | ConvertFrom-Json
+            try {
+              $listing = $showOutput | ConvertFrom-Json -ErrorAction Stop
+            } catch {
+              Write-Host "Marketplace listing $ExtensionId did not return JSON. Publishing will create or update it." -ForegroundColor Yellow
+              return $false
+            }
+
+            if ($null -eq $listing -or $null -eq $listing.versions) {
+              Write-Host "Marketplace listing $ExtensionId has no published versions. Publishing will create it." -ForegroundColor Yellow
+              return $false
+            }
+
             return @($listing.versions | Where-Object { $_.version -eq $Version }).Count -gt 0
           }
 

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -210,13 +210,21 @@ jobs:
           }
 
           $shouldPublishMarketplace = $env:SHOULD_PUBLISH -eq 'true'
+          $isPreRelease = $env:IS_PRE_RELEASE -eq 'true'
 
           if (-not [string]::IsNullOrWhiteSpace($env:RELEASE_TAG)) {
             $publishedAt = $env:RELEASE_PUBLISHED_AT
             if ([string]::IsNullOrWhiteSpace($publishedAt)) {
-              $publishedAt = gh release view $env:RELEASE_TAG --repo $env:GITHUB_REPOSITORY --json publishedAt --jq '.publishedAt'
-              if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($publishedAt)) {
+              $releaseJson = gh release view $env:RELEASE_TAG --repo $env:GITHUB_REPOSITORY --json publishedAt,isPrerelease
+              if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($releaseJson)) {
                 throw "Could not resolve publication time for release $env:RELEASE_TAG."
+              }
+
+              $release = $releaseJson | ConvertFrom-Json -ErrorAction Stop
+              $publishedAt = $release.publishedAt
+              $isPreRelease = [bool] $release.isPrerelease
+              if ([string]::IsNullOrWhiteSpace($publishedAt)) {
+                throw "Release $env:RELEASE_TAG does not have a publication time."
               }
             }
 
@@ -239,7 +247,7 @@ jobs:
             SkipNpmCi = $true
           }
 
-          if ($env:IS_PRE_RELEASE -eq 'true') {
+          if ($isPreRelease) {
             $params.PreRelease = $true
           }
 

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -32,6 +32,10 @@ on:
         required: false
         type: boolean
         default: false
+      release_tag:
+        description: 'Existing ChartForgeX release tag to repair and attach the VSIX to'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -55,6 +59,27 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
+
+      - name: Validate release source
+        if: ${{ github.event.release.tag_name != '' || inputs.release_tag != '' }}
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+        run: |
+          if ($env:RELEASE_TAG -notmatch '^ChartForgeX-v(?:\d{14}|\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$') {
+            throw "ChartForgeX release tag is not valid: $env:RELEASE_TAG"
+          }
+
+          git fetch origin main
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to fetch origin/main for release source validation.'
+          }
+
+          git merge-base --is-ancestor HEAD origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Release publishing is only allowed from commits contained in origin/main.'
+          }
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -78,10 +103,11 @@ jobs:
         shell: pwsh
         env:
           IS_PRE_RELEASE: ${{ (github.event_name == 'release' && github.event.release.prerelease) || (github.event_name == 'workflow_dispatch' && inputs.pre_release) }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
           RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
           SHOULD_PUBLISH: ${{ github.event_name == 'release' || inputs.publish_marketplace }}
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           function Convert-ChartForgeXReleaseToExtensionVersion {
             param(
@@ -141,11 +167,11 @@ jobs:
             $package | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $packagePath -Encoding utf8
 
             if (Test-Path -LiteralPath $lockPath) {
-              $lock = Get-Content -LiteralPath $lockPath -Raw | ConvertFrom-Json
-              $lock.version = $Version
-              $rootPackage = $lock.packages.PSObject.Properties[''].Value
-              if ($null -ne $rootPackage) {
-                $rootPackage.version = $Version
+              $lock = Get-Content -LiteralPath $lockPath -Raw | ConvertFrom-Json -AsHashtable
+              $lock['version'] = $Version
+              $packages = $lock['packages']
+              if ($null -ne $packages -and $packages.ContainsKey('')) {
+                $packages['']['version'] = $Version
               }
               $lock | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $lockPath -Encoding utf8
             }
@@ -174,18 +200,16 @@ jobs:
 
           $shouldPublishMarketplace = $env:SHOULD_PUBLISH -eq 'true'
 
-          if ('${{ github.event_name }}' -eq 'release') {
-            git fetch origin main
-            if ($LASTEXITCODE -ne 0) {
-              throw 'Failed to fetch origin/main for release source validation.'
+          if (-not [string]::IsNullOrWhiteSpace($env:RELEASE_TAG)) {
+            $publishedAt = $env:RELEASE_PUBLISHED_AT
+            if ([string]::IsNullOrWhiteSpace($publishedAt)) {
+              $publishedAt = gh release view $env:RELEASE_TAG --repo $env:GITHUB_REPOSITORY --json publishedAt --jq '.publishedAt'
+              if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($publishedAt)) {
+                throw "Could not resolve publication time for release $env:RELEASE_TAG."
+              }
             }
 
-            git merge-base --is-ancestor HEAD origin/main
-            if ($LASTEXITCODE -ne 0) {
-              throw 'Release publishing is only allowed from commits contained in origin/main.'
-            }
-
-            $targetVersion = Convert-ChartForgeXReleaseToExtensionVersion -TagName $env:RELEASE_TAG -PublishedAt $env:RELEASE_PUBLISHED_AT
+            $targetVersion = Convert-ChartForgeXReleaseToExtensionVersion -TagName $env:RELEASE_TAG -PublishedAt $publishedAt
             $package = Set-ExtensionPackageVersion -Version $targetVersion
             $extensionId = "$($package.publisher).$($package.name)"
             Write-Host "Stamped ChartForgeX Markup extension version $targetVersion from release tag $env:RELEASE_TAG." -ForegroundColor Cyan
@@ -194,6 +218,9 @@ jobs:
               Write-Host "Marketplace version $extensionId@$targetVersion already exists. The VSIX will be packaged and attached to the GitHub Release, but Marketplace publishing will be skipped." -ForegroundColor Yellow
               $shouldPublishMarketplace = $false
             }
+          } else {
+            $currentVersion = (Get-Content -LiteralPath 'ChartForgeX.Markup.VSCode/package.json' -Raw | ConvertFrom-Json).version
+            $null = Set-ExtensionPackageVersion -Version $currentVersion
           }
 
           $params = @{
@@ -206,7 +233,7 @@ jobs:
           }
 
           if ($shouldPublishMarketplace) {
-            if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ github.ref_name }}' -ne 'main') {
+            if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch' -and $env:GITHUB_REF_NAME -ne 'main') {
               throw 'Marketplace publishing is only allowed from the main branch.'
             }
 
@@ -223,7 +250,7 @@ jobs:
           if-no-files-found: error
 
   attach-release-asset:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '') }}
     needs: package
     runs-on: ubuntu-latest
     permissions:
@@ -238,4 +265,5 @@ jobs:
       - name: Attach VSIX to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.event.release.tag_name }}" release-vsix/*.vsix --repo "${GITHUB_REPOSITORY}" --clobber
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+        run: gh release upload "$RELEASE_TAG" release-vsix/*.vsix --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
## What changed

- parses npm lockfiles as ordered hash tables so PowerShell 7.6 can preserve the root package entry whose key is an empty string
- exercises the real lockfile version-stamping path on ordinary push and pull-request runs, not only after a release is published
- treats an absent or non-JSON Marketplace listing as a first publication while still skipping an already-published version
- adds an explicit `release_tag` dispatch path to repair an existing ChartForgeX release, reuse its publication timestamp and stable/prerelease channel, publish the Marketplace extension, and attach the VSIX without creating a replacement tag
- validates the release-tag format and proves the selected commit is contained in `origin/main` immediately after checkout, before Node setup or `npm ci`
- keeps user-controlled refs and tags out of secret-bearing shell source

## Why it matters

The ChartForgeX 1.0.3 release exposed a PowerShell 7.6 JSON parsing incompatibility only present in release stamping. This makes normal releases reliable and gives maintainers a safe, idempotent recovery path for an existing release without silently changing its release channel.

## Validation

- reproduced the failed 1.0.3 release log from run 29831482832
- parsed, updated, serialized, and reparsed the real package lockfile with its empty root key
- resolved the existing release timestamp to SemVer-safe VSIX version `2026.721.124559`
- validated `ChartForgeX-v1.0.3` format and ancestry against `origin/main`
- reproduced `vsce show` returning `undefined` with exit code 0 for the absent listing and verified it is treated as publish-needed
- verified repair payloads inherit both stable and prerelease channel state from the selected GitHub release
- independent local review found two workflow-hardening issues; both were fixed and targeted confirmation passed