### PR TITLE
Fix js-yaml security advisory

### DIFF
--- a/ChartForgeX.Markup.VSCode/package-lock.json
+++ b/ChartForgeX.Markup.VSCode/package-lock.json
@@ -2592,9 +2592,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/ChartForgeX.Markup.VSCode/package.json
+++ b/ChartForgeX.Markup.VSCode/package.json
@@ -292,5 +292,8 @@
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.1",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
Pins js-yaml to the patched 4.3.0 release through the VS Code extension dependency override, resolving GHSA-52cp-r559-cp3m in its package lockfile.