### PR TITLE
Fix ChartForgeX js-yaml security alert

### DIFF
--- a/ChartForgeX.Markup.VSCode/package-lock.json
+++ b/ChartForgeX.Markup.VSCode/package-lock.json
@@ -2592,9 +2592,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/ChartForgeX.Markup.VSCode/package.json
+++ b/ChartForgeX.Markup.VSCode/package.json
@@ -294,6 +294,6 @@
     "typescript": "^6.0.3"
   },
   "overrides": {
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.1"
   }
 }


### PR DESCRIPTION
Updates the VS Code extension override to use `js-yaml` 4.3.1, resolving Dependabot alert #41 (`GHSA-5p4m-2wfm-xmqj`).

The extension install, production audit, bundle, and VSIX package build were validated locally.