### PR TITLE
Prepare ChartForgeX 1.6.0 typed interchange release

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -3,12 +3,12 @@
   "RootPath": "..",
   "ExpectedVersion": null,
   "ExpectedVersionMap": {
-    "ChartForgeX": "1.4.X",
-    "ChartForgeX.Interactivity": "1.4.X",
-    "ChartForgeX.Interactivity.Html": "1.4.X",
-    "ChartForgeX.Markup": "1.4.X",
-    "ChartForgeX.Mermaid": "1.4.X",
-    "ChartForgeX.Markup.Mermaid": "1.4.X"
+    "ChartForgeX": "1.6.X",
+    "ChartForgeX.Interactivity": "1.6.X",
+    "ChartForgeX.Interactivity.Html": "1.6.X",
+    "ChartForgeX.Markup": "1.6.X",
+    "ChartForgeX.Mermaid": "1.6.X",
+    "ChartForgeX.Markup.Mermaid": "1.6.X"
   },
   "ExpectedVersionMapAsInclude": true,
   "ExpectedVersionMapUseWildcards": false,

--- a/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
+++ b/ChartForgeX.Interactivity.Html/ChartForgeX.Interactivity.Html.csproj
@@ -20,7 +20,7 @@
     <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Self-contained HTML, SVG, and graph explorer interaction adapter for ChartForgeX charts and graph scenes.</Description>
-    <PackageReleaseNotes>Aligns self-contained HTML interaction and package compatibility with the ChartForgeX 1.4.0 hierarchy layout runtime.</PackageReleaseNotes>
+    <PackageReleaseNotes>Aligns self-contained HTML interaction and package compatibility with the ChartForgeX 1.6.0 typed semantic interchange runtime.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ChartForgeX.png</PackageIcon>

--- a/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
+++ b/ChartForgeX.Interactivity/ChartForgeX.Interactivity.csproj
@@ -20,7 +20,7 @@
     <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Host-neutral interaction contracts for ChartForgeX chart renderers and adapters.</Description>
-    <PackageReleaseNotes>Aligns host-neutral interaction contracts and package compatibility with the ChartForgeX 1.4.0 hierarchy layout runtime.</PackageReleaseNotes>
+    <PackageReleaseNotes>Aligns host-neutral interaction contracts and package compatibility with the ChartForgeX 1.6.0 typed semantic interchange runtime.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ChartForgeX.png</PackageIcon>

--- a/ChartForgeX.Markup.Mermaid/ChartForgeX.Markup.Mermaid.csproj
+++ b/ChartForgeX.Markup.Mermaid/ChartForgeX.Markup.Mermaid.csproj
@@ -20,7 +20,7 @@
     <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Mermaid fenced-block adapter for ChartForgeX markup visual artifact pipelines.</Description>
-    <PackageReleaseNotes>Aligns Mermaid markup visual artifacts and package dependencies with the ChartForgeX 1.4.0 runtime package set.</PackageReleaseNotes>
+    <PackageReleaseNotes>Aligns Mermaid markup visual artifacts and package dependencies with the ChartForgeX 1.6.0 typed interchange runtime.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>charts;markdown;markup;mermaid;diagrams;svg;png;html;topology;reports;dashboard;aot;nativeaot;trimming</PackageTags>

--- a/ChartForgeX.Markup/ChartForgeX.Markup.csproj
+++ b/ChartForgeX.Markup/ChartForgeX.Markup.csproj
@@ -20,7 +20,7 @@
     <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Markdown-friendly ChartForgeX markup parser and code emitter for charts and topology diagrams.</Description>
-    <PackageReleaseNotes>Aligns markup rendering and package compatibility with the ChartForgeX 1.4.0 hierarchy layout runtime.</PackageReleaseNotes>
+    <PackageReleaseNotes>Aligns markup rendering and package compatibility with the ChartForgeX 1.6.0 typed semantic interchange runtime.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>charts;markdown;markup;svg;png;html;topology;reports;dashboard;zero-dependency;aot;nativeaot;trimming</PackageTags>

--- a/ChartForgeX.Mermaid/ChartForgeX.Mermaid.csproj
+++ b/ChartForgeX.Mermaid/ChartForgeX.Mermaid.csproj
@@ -20,7 +20,7 @@
     <Version>$(ChartForgeXProductVersion)</Version>
     <Authors>Evotec</Authors>
     <Description>Native Mermaid compatibility parsing foundations for ChartForgeX visual artifact pipelines.</Description>
-    <PackageReleaseNotes>Aligns Mermaid compatibility and package dependencies with the ChartForgeX 1.4.0 runtime package set.</PackageReleaseNotes>
+    <PackageReleaseNotes>Aligns Mermaid semantic artifacts and package dependencies with the ChartForgeX 1.6.0 typed interchange runtime.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ChartForgeX.png</PackageIcon>

--- a/ChartForgeX.Tests/SmokeTests/BuildQualityTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/BuildQualityTests.cs
@@ -91,6 +91,19 @@ internal static partial class SmokeTests {
         Assert(script.Contains("visual-geographic-topology-map", StringComparison.Ordinal), "Build script should verify topology-native geographic visual coverage.");
         Assert(script.Contains("data-route-curve=\"geographic\"", StringComparison.Ordinal), "Build script should verify geographic topology route-arc metadata.");
 
+        var directoryBuildPropsPath = Path.Combine(FindRepositoryRoot(), "Directory.Build.props");
+        var directoryBuildProps = File.ReadAllText(directoryBuildPropsPath);
+        var productVersionText = XDocument.Load(directoryBuildPropsPath)
+            .Descendants("ChartForgeXProductVersion")
+            .Select(static element => element.Value.Trim())
+            .FirstOrDefault();
+        Assert(
+            Version.TryParse(productVersionText, out var productVersion)
+            && productVersion.Build >= 0
+            && productVersion.Revision < 0,
+            "Directory.Build.props should own a three-part ChartForgeX product version.");
+        var expectedReleaseLane = productVersion!.Major + "." + productVersion.Minor + ".X";
+
         using var projectBuild = JsonDocument.Parse(File.ReadAllText(Path.Combine(FindRepositoryRoot(), "Build", "project.build.json")));
         var projectBuildRoot = projectBuild.RootElement;
         Assert(projectBuildRoot.GetProperty("ExpectedVersionMapAsInclude").GetBoolean(), "Build-Project manifest should treat ExpectedVersionMap as the tracked package include list.");
@@ -103,22 +116,11 @@ internal static partial class SmokeTests {
             "ChartForgeX.Mermaid",
             "ChartForgeX.Markup.Mermaid"
         }) {
-            Assert(expectedVersionMap.TryGetProperty(packageProject, out var expectedVersion) && string.Equals(expectedVersion.GetString(), "1.4.X", StringComparison.Ordinal), "Build-Project manifest should track the 1.4 package project: " + packageProject + ".");
+            Assert(expectedVersionMap.TryGetProperty(packageProject, out var expectedVersion) && string.Equals(expectedVersion.GetString(), expectedReleaseLane, StringComparison.Ordinal), "Build-Project manifest should track the current product release lane for package project: " + packageProject + ".");
             var projectFile = File.ReadAllText(Path.Combine(FindRepositoryRoot(), packageProject, packageProject + ".csproj"));
             Assert(projectFile.Contains("<Version>$(ChartForgeXProductVersion)</Version>", StringComparison.Ordinal), "Package project should consume the shared ChartForgeX product version: " + packageProject + ".");
         }
 
-        var directoryBuildPropsPath = Path.Combine(FindRepositoryRoot(), "Directory.Build.props");
-        var directoryBuildProps = File.ReadAllText(directoryBuildPropsPath);
-        var productVersionText = XDocument.Load(directoryBuildPropsPath)
-            .Descendants("ChartForgeXProductVersion")
-            .Select(static element => element.Value.Trim())
-            .FirstOrDefault();
-        Assert(
-            Version.TryParse(productVersionText, out var productVersion)
-            && productVersion.Build >= 0
-            && productVersion.Revision < 0,
-            "Directory.Build.props should own a three-part ChartForgeX product version.");
         Assert(directoryBuildProps.Contains("<AssemblyVersion>$(ChartForgeXProductVersion).0</AssemblyVersion>", StringComparison.Ordinal), "ChartForgeX assembly identity should be isolated from host build version properties.");
 
         var qualityWorkflow = File.ReadAllText(Path.Combine(FindRepositoryRoot(), ".github", "workflows", "quality.yml"));

--- a/ChartForgeX.Tests/SmokeTests/RepositoryQualityTests.cs
+++ b/ChartForgeX.Tests/SmokeTests/RepositoryQualityTests.cs
@@ -465,17 +465,19 @@ internal static partial class SmokeTests {
         Assert(HasXmlProperty(libraryProject, "IncludeSymbols", "true"), "Package should include symbol package generation.");
         Assert(HasXmlProperty(libraryProject, "SymbolPackageFormat", "snupkg"), "Package symbols should use snupkg format.");
         var releaseNotes = GetXmlValue(libraryProject, "PackageReleaseNotes");
-        Assert(ContainsMetadataConcepts(releaseNotes, "hierarchy", "per-subtree", "compact"), "Package release notes should summarize the current hierarchy-layout contract.");
-        Assert(ContainsMetadataConcepts(releaseNotes, "SVG", "HTML", "PNG"), "Package release notes should name the renderer surfaces covered by the current release.");
+        Assert(ContainsMetadataConcepts(releaseNotes, "typed", "versioned", "interchange"), "Package release notes should summarize the typed semantic interchange contract.");
+        Assert(ContainsMetadataConcepts(releaseNotes, "topology", "flow", "sequence"), "Package release notes should name the semantic families covered by the current release.");
         foreach (var dependentProject in new[] {
+            Path.Combine(FindRepositoryRoot(), "ChartForgeX.Interactivity", "ChartForgeX.Interactivity.csproj"),
+            Path.Combine(FindRepositoryRoot(), "ChartForgeX.Interactivity.Html", "ChartForgeX.Interactivity.Html.csproj"),
             Path.Combine(FindRepositoryRoot(), "ChartForgeX.Markup", "ChartForgeX.Markup.csproj"),
             Path.Combine(FindRepositoryRoot(), "ChartForgeX.Mermaid", "ChartForgeX.Mermaid.csproj"),
             Path.Combine(FindRepositoryRoot(), "ChartForgeX.Markup.Mermaid", "ChartForgeX.Markup.Mermaid.csproj")
         }) {
             var dependentReleaseNotes = GetXmlValue(dependentProject, "PackageReleaseNotes");
-            Assert(dependentReleaseNotes.Contains("1.4.0", StringComparison.Ordinal) &&
-                   !dependentReleaseNotes.Contains("1.3.0", StringComparison.Ordinal),
-                "Dependent package release notes should describe the synchronized 1.4.0 release lane: " + Path.GetRelativePath(FindRepositoryRoot(), dependentProject));
+            Assert(dependentReleaseNotes.Contains("1.6.0", StringComparison.Ordinal) &&
+                   !dependentReleaseNotes.Contains("1.5.0", StringComparison.Ordinal),
+                "Dependent package release notes should describe the synchronized 1.6.0 release lane: " + Path.GetRelativePath(FindRepositoryRoot(), dependentProject));
         }
         Assert(File.Exists(Path.Combine(FindRepositoryRoot(), "CONTRIBUTING.md")), "Repository should include contribution guidance.");
         Assert(File.Exists(Path.Combine(FindRepositoryRoot(), "TODO.md")), "Repository should include centralized follow-up guidance.");

--- a/ChartForgeX/ChartForgeX.csproj
+++ b/ChartForgeX/ChartForgeX.csproj
@@ -22,7 +22,7 @@
     <Authors>Evotec</Authors>
     <Description>Dependency-free SVG, HTML, PNG, GIF, JPEG, BMP, PPM, and TIFF rendering and image composition for .NET charts, animated terminal presentations, visual stories, visual blocks, report tables, metric cards, wallpapers, and topology diagrams.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Adds inherited per-subtree hierarchy layout policies with automatic standard-to-compact selection, explicit standard, compact, and vertical arrangements, deterministic routing metadata, and shared SVG, HTML, and PNG geometry.</PackageReleaseNotes>
+    <PackageReleaseNotes>Adds typed, versioned semantic visual-artifact interchange snapshots with deterministic JSON, validation, and topology, flow, and sequence fidelity.</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ChartForgeX.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/EvotecIT/ChartForgeX/main/assets/ChartForgeX.png</PackageIconUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <ChartForgeXProductVersion>1.5.0</ChartForgeXProductVersion>
+    <ChartForgeXProductVersion>1.6.0</ChartForgeXProductVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ChartForgeX' Or '$(MSBuildProjectName)' == 'ChartForgeX.Interactivity' Or '$(MSBuildProjectName)' == 'ChartForgeX.Interactivity.Html' Or '$(MSBuildProjectName)' == 'ChartForgeX.Markup' Or '$(MSBuildProjectName)' == 'ChartForgeX.Mermaid' Or '$(MSBuildProjectName)' == 'ChartForgeX.Markup.Mermaid'">


### PR DESCRIPTION
## Summary

- advances the shared ChartForgeX package line to 1.6.0 for the typed, versioned semantic visual-artifact interchange API already merged on `main`
- refreshes release notes across the core, interactivity, markup, and Mermaid packages
- updates the executable NuGet metadata contract to require the synchronized 1.6.0 release lane

## Why a new version is required

The immutable public ChartForgeX 1.5.0 package was built from pre-redesign commit `62fdc741`, while its tag now points at the later typed-interchange merge `889a210d`. The public payload therefore lacks `VisualArtifactInterchangeEnvelope` and related typed APIs. A new public version is required; republishing 1.5.0 is not possible.

This PR prepares source/package metadata only. It does not publish packages.

## Validation

- full `Build.ps1 -Configuration Release` quality loop passed
- 778/778 tests passed
- all 31 Mermaid fixtures passed
- NativeAOT, examples, and package generation passed
- generated 1.6.0 packages contain net472, netstandard2.0, net8.0, and net10.0 assets; the core XML surface contains the typed interchange envelope and semantic models