### PR TITLE
Use canonical commands in chart benchmarks

### DIFF
--- a/Benchmarks/decimation.benchmark.ps1
+++ b/Benchmarks/decimation.benchmark.ps1
@@ -1,4 +1,4 @@
-$assemblyPath = input AssemblyPath -Required
+$assemblyPath = Get-BenchmarkInput AssemblyPath -Required
 Add-Type -Path $assemblyPath
 
 function New-ChartForgeXDenseSeries {
@@ -14,30 +14,30 @@ function New-ChartForgeXDenseSeries {
 
 $assemblyHash = (Get-FileHash -LiteralPath $assemblyPath -Algorithm SHA256).Hash
 
-benchmark 'chartforgex-decimation' {
-    policy -Warmup 1 -Iterations 7 -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
-    profile Current -Cleanup KeepOnFailure
+New-BenchmarkSuite 'chartforgex-decimation' {
+    Set-BenchmarkPolicy -Warmup 1 -Iterations 7 -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
+    Set-BenchmarkProfile Current -Cleanup KeepOnFailure
 
-    cases {
-        case LargestTriangleThreeBuckets @{ Mode = 'LargestTriangleThreeBuckets'; MaximumPoints = 1200 }
-        case MinMax @{ Mode = 'MinMax'; MaximumPoints = 1200 }
+    Add-BenchmarkCases {
+        Add-BenchmarkCase LargestTriangleThreeBuckets @{ Mode = 'LargestTriangleThreeBuckets'; MaximumPoints = 1200 }
+        Add-BenchmarkCase MinMax @{ Mode = 'MinMax'; MaximumPoints = 1200 }
     }
 
-    setup {
+    Set-BenchmarkSetup {
         param($case, $run)
         $run.Points = [ChartForgeX.Primitives.ChartPoint[]](New-ChartForgeXDenseSeries)
         $run.Mode = [ChartForgeX.Core.ChartDecimationMode]::$($case.Mode)
     }
 
-    engine ChartForgeX {
-        operation Decimate {
+    Add-BenchmarkEngine ChartForgeX {
+        Add-BenchmarkOperation Decimate {
             param($case, $run)
             $run.Result = [ChartForgeX.Core.ChartDecimator]::Decimate($run.Points, $case.MaximumPoints, $run.Mode)
             $run.IndexChecksum = ($run.Result.SourceIndices | Measure-Object -Sum).Sum
         }
     }
 
-    validate {
+    Add-BenchmarkValidation {
         param($case, $run)
         if ($run.Result.SourcePointCount -ne $run.Points.Length) { throw 'The decimator did not report the complete source count.' }
         if ($run.Result.Points.Count -gt $case.MaximumPoints) { throw 'The decimator exceeded the requested point budget.' }
@@ -45,11 +45,11 @@ benchmark 'chartforgex-decimation' {
         if ($run.IndexChecksum -le 0) { throw 'The decimator source-index result was not consumed.' }
     }
 
-    metric SourcePoints { param($case, $run) $run.Result.SourcePointCount }
-    metric RetainedPoints { param($case, $run) $run.Result.Points.Count }
-    metric RetentionPercent { param($case, $run) [Math]::Round($run.Result.Points.Count * 100.0 / $run.Result.SourcePointCount, 4) }
+    Add-BenchmarkMetric SourcePoints { param($case, $run) $run.Result.SourcePointCount }
+    Add-BenchmarkMetric RetainedPoints { param($case, $run) $run.Result.Points.Count }
+    Add-BenchmarkMetric RetentionPercent { param($case, $run) [Math]::Round($run.Result.Points.Count * 100.0 / $run.Result.SourcePointCount, 4) }
 
-    metadata AssemblySha256 $assemblyHash
-    metadata ComparisonMode 'Explicit ChartForgeX point reduction only; rendering is measured by the separate rendering suite'
-    artifacts Json, Csv, Markdown
+    Add-BenchmarkMetadata AssemblySha256 $assemblyHash
+    Add-BenchmarkMetadata ComparisonMode 'Explicit ChartForgeX point reduction only; rendering is measured by the separate rendering suite'
+    Set-BenchmarkArtifacts Json, Csv, Markdown
 }

--- a/Benchmarks/rendering.benchmark.ps1
+++ b/Benchmarks/rendering.benchmark.ps1
@@ -1,4 +1,4 @@
-$assemblyPath = input AssemblyPath -Required
+$assemblyPath = Get-BenchmarkInput AssemblyPath -Required
 Add-Type -Path $assemblyPath
 
 function New-ChartForgeXBenchmarkChart {
@@ -58,20 +58,20 @@ function New-ChartForgeXBenchmarkTopology {
 
 $assemblyHash = (Get-FileHash -LiteralPath $assemblyPath -Algorithm SHA256).Hash
 
-benchmark 'chartforgex-rendering' {
-    policy -Warmup 1 -Iterations 5 -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
-    profile Current -Cleanup KeepOnFailure
+New-BenchmarkSuite 'chartforgex-rendering' {
+    Set-BenchmarkPolicy -Warmup 1 -Iterations 5 -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
+    Set-BenchmarkProfile Current -Cleanup KeepOnFailure
 
-    cases {
-        case ChartSvg @{ Fixture = 'Chart'; Format = 'Svg' }
-        case ChartRgba @{ Fixture = 'Chart'; Format = 'Rgba' }
-        case ChartPng @{ Fixture = 'Chart'; Format = 'Png' }
-        case TopologySvg @{ Fixture = 'Topology'; Format = 'Svg' }
-        case TopologyRgba @{ Fixture = 'Topology'; Format = 'Rgba' }
-        case TopologyPng @{ Fixture = 'Topology'; Format = 'Png' }
+    Add-BenchmarkCases {
+        Add-BenchmarkCase ChartSvg @{ Fixture = 'Chart'; Format = 'Svg' }
+        Add-BenchmarkCase ChartRgba @{ Fixture = 'Chart'; Format = 'Rgba' }
+        Add-BenchmarkCase ChartPng @{ Fixture = 'Chart'; Format = 'Png' }
+        Add-BenchmarkCase TopologySvg @{ Fixture = 'Topology'; Format = 'Svg' }
+        Add-BenchmarkCase TopologyRgba @{ Fixture = 'Topology'; Format = 'Rgba' }
+        Add-BenchmarkCase TopologyPng @{ Fixture = 'Topology'; Format = 'Png' }
     }
 
-    setup {
+    Set-BenchmarkSetup {
         param($case, $run)
 
         if ($case.Fixture -eq 'Chart') {
@@ -87,8 +87,8 @@ benchmark 'chartforgex-rendering' {
         }
     }
 
-    engine ChartForgeX {
-        operation Render {
+    Add-BenchmarkEngine ChartForgeX {
+        Add-BenchmarkOperation Render {
             param($case, $run)
 
             if ($case.Fixture -eq 'Chart' -and $case.Format -eq 'Svg') {
@@ -107,7 +107,7 @@ benchmark 'chartforgex-rendering' {
         }
     }
 
-    validate {
+    Add-BenchmarkValidation {
         param($case, $run)
 
         if ($run.OutputLength -lt 1000) {
@@ -115,12 +115,12 @@ benchmark 'chartforgex-rendering' {
         }
     }
 
-    metric OutputBytes {
+    Add-BenchmarkMetric OutputBytes {
         param($case, $run)
         $run.OutputLength
     }
 
-    metadata AssemblySha256 $assemblyHash
-    metadata ComparisonMode 'ChartForgeX release rendering only; no browser-library comparison'
-    artifacts Json, Csv, Markdown
+    Add-BenchmarkMetadata AssemblySha256 $assemblyHash
+    Add-BenchmarkMetadata ComparisonMode 'ChartForgeX release rendering only; no browser-library comparison'
+    Set-BenchmarkArtifacts Json, Csv, Markdown
 }


### PR DESCRIPTION
## Summary

- migrate the rendering and decimation benchmark specifications to full PSPublishModule command names
- use explicit benchmark input switches and full parameter names
- keep the existing benchmark matrix and operations unchanged

Related shared cleanup: EvotecIT/PSPublishModule#745.